### PR TITLE
refactor: move pipe_roughness to friction.h/cpp

### DIFF
--- a/include/friction.h
+++ b/include/friction.h
@@ -1,6 +1,9 @@
 #ifndef FRICTION_H
 #define FRICTION_H
 
+#include <string>
+#include <unordered_map>
+
 // -------------------------------------------------------------
 // Darcy friction factor correlations for turbulent pipe flow
 // -------------------------------------------------------------
@@ -40,5 +43,27 @@ double friction_colebrook(double Re, double e_D, double tol = 1e-10, int max_ite
 // Often used with Gnielinski/Petukhov heat transfer correlations.
 // Reference: Petukhov (1970), Advances in Heat Transfer, 6, 503
 double friction_petukhov(double Re);
+
+// -------------------------------------------------------------
+// Pipe Roughness Database
+// -------------------------------------------------------------
+// Absolute roughness ε [m] for common pipe materials.
+// Used as e_D = ε/D in friction factor correlations.
+//
+// References:
+// - Moody (1944): Transactions of the ASME, 66(8)
+// - White (2011): Fluid Mechanics (7th ed.), Table 6.1
+// - Munson et al. (2013): Fundamentals of Fluid Mechanics (7th ed.), Table 8.1
+// - Crane Co. (2009): Technical Paper No. 410, Table A-24
+
+// Get absolute roughness for a standard pipe material [m].
+// Material names are case-insensitive.
+// Throws std::invalid_argument if material not found.
+// Use standard_pipe_roughness() to list available materials.
+double pipe_roughness(const std::string& material);
+
+// Get all standard pipe roughness values.
+// Returns: map of material name -> roughness [m]
+std::unordered_map<std::string, double> standard_pipe_roughness();
 
 #endif // FRICTION_H

--- a/include/utils.h
+++ b/include/utils.h
@@ -1,24 +1,10 @@
 #ifndef UTILS_H
 #define UTILS_H
 
-#include <string>
-#include <unordered_map>
 #include <vector>
 
 // Print all properties of a mixture at given temperature and pressure
 void print_mixture_properties(double T, double P, const std::vector<double>& X);
 
-// -------------------------------------------------------------
-// Pipe Roughness Database
-// -------------------------------------------------------------
-
-// Get absolute roughness for a standard pipe material [m]
-// Returns roughness value or throws std::invalid_argument if material not found
-// Material names are case-insensitive
-double pipe_roughness(const std::string& material);
-
-// Get all standard pipe roughness values as a map
-// Returns: map of material name -> roughness [m]
-std::unordered_map<std::string, double> standard_pipe_roughness();
 
 #endif // UTILS_H

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,83 +1,8 @@
 #include "../include/utils.h"
 #include "../include/thermo.h"
-#include <algorithm>
 #include <cmath>
 #include <iostream>
 #include <numeric>
-#include <stdexcept>
-#include <unordered_map>
-
-// -------------------------------------------------------------
-// Pipe Roughness Database
-// -------------------------------------------------------------
-
-// Absolute roughness values for common pipe materials [m]
-//
-// References:
-// - Moody, L.F. (1944). "Friction factors for pipe flow".
-//   Transactions of the ASME, 66(8), 671-684.
-// - Colebrook, C.F. (1939). "Turbulent flow in pipes, with particular
-//   reference to the transition region between smooth and rough pipe laws".
-//   Journal of the Institution of Civil Engineers, 11(4), 133-156.
-// - White, F.M. (2011). "Fluid Mechanics" (7th ed.). McGraw-Hill.
-//   Table 6.1, p. 357.
-// - Munson, B.R., et al. (2013). "Fundamentals of Fluid Mechanics" (7th ed.).
-//   Wiley. Table 8.1, p. 428.
-// - Crane Co. (2009). "Flow of Fluids Through Valves, Fittings, and Pipe".
-//   Technical Paper No. 410, Table A-24.
-//
-// Note: Values represent typical absolute roughness (ε) for new, clean pipes.
-// Actual roughness may vary with age, corrosion, and service conditions.
-//
-static const std::unordered_map<std::string, double> ROUGHNESS_DATA = {
-    // Smooth surfaces
-    {"smooth",              0.0},           // Ideally smooth (theoretical)
-    {"drawn_tubing",        1.5e-6},        // Drawn brass, copper, glass, plastic (White 2011)
-    {"pvc",                 1.5e-6},        // PVC, polyethylene (White 2011)
-    {"plastic",             1.5e-6},        // Generic plastic pipe
-
-    // Steel pipes
-    {"commercial_steel",    4.5e-5},        // New commercial steel (Moody 1944, White 2011)
-    {"new_steel",           4.5e-5},        // Alias for commercial_steel
-    {"wrought_iron",        4.5e-5},        // Wrought iron (White 2011)
-    {"galvanized_iron",     1.5e-4},        // Galvanized iron/steel (Moody 1944, Crane 2009)
-    {"galvanized_steel",    1.5e-4},        // Alias for galvanized_iron
-    {"rusted_steel",        2.5e-4},        // Moderately rusted steel (Munson 2013)
-
-    // Cast iron
-    {"cast_iron",           2.6e-4},        // Uncoated cast iron (Moody 1944, White 2011)
-    {"asphalted_cast_iron", 1.2e-4},        // Asphalted cast iron (White 2011)
-
-    // Concrete
-    {"concrete",            3.0e-4},        // Concrete, well-finished (Moody 1944, Munson 2013)
-    {"rough_concrete",      3.0e-3},        // Rough concrete (White 2011)
-
-    // Other materials
-    {"riveted_steel",       9.0e-4},        // Riveted steel (Moody 1944, Crane 2009)
-    {"wood_stave",          1.8e-4},        // Wood stave pipe (White 2011)
-    {"corrugated_metal",    4.5e-2},        // Corrugated metal pipe (Munson 2013)
-};
-
-std::unordered_map<std::string, double> standard_pipe_roughness() {
-    return ROUGHNESS_DATA;
-}
-
-double pipe_roughness(const std::string& material) {
-    // Convert to lowercase for case-insensitive lookup
-    std::string material_lower = material;
-    std::transform(material_lower.begin(), material_lower.end(),
-                   material_lower.begin(), ::tolower);
-
-    auto it = ROUGHNESS_DATA.find(material_lower);
-    if (it != ROUGHNESS_DATA.end()) {
-        return it->second;
-    }
-
-    // Material not found - provide helpful error message
-    throw std::invalid_argument(
-        "pipe_roughness: unknown material '" + material + "'. "
-        "Use standard_pipe_roughness() to see available materials.");
-}
 
 // -------------------------------------------------------------
 // Utility Functions


### PR DESCRIPTION
pipe_roughness and standard_pipe_roughness belong alongside the friction factor correlations — users call pipe_roughness() to get e_D for friction_haaland/serghides/colebrook. References are identical (Moody, Colebrook, White).

- friction.h: add pipe_roughness + standard_pipe_roughness declarations
- friction.cpp: move implementation from utils.cpp
- utils.h: remove roughness declarations + unused includes
- utils.cpp: remove roughness implementation + unused includes