### PR TITLE
fix: humidair improvements + NASA-9 range policy

### DIFF
--- a/include/humidair.h
+++ b/include/humidair.h
@@ -11,8 +11,9 @@ extern const std::unordered_map<std::string, double> dry_air_composition;
 // Get standard dry air composition as a vector in the order defined by species_index in thermo_transport_data.h
 std::vector<double> standard_dry_air_composition();
 
-// Water vapor saturation pressure using Hyland-Wexler equation [Pa]
-// Valid for 0°C ≤ T ≤ 200°C
+// Water vapor saturation pressure using Huang (2018) formula [Pa]
+// Validated range: -100°C ≤ T ≤ 100°C (173.15–373.15 K)
+// Extrapolation allowed within 5% of range boundaries; throws beyond that.
 double saturation_vapor_pressure(double T);  // T in K
 
 // Calculate actual vapor pressure from relative humidity [Pa]
@@ -32,13 +33,20 @@ std::vector<double> humid_air_composition(double T, double P, double RH);  // T 
 double dewpoint(double T, double P, double RH);  // T in K, P in Pa, RH as fraction (0-1)
 
 // Calculate relative humidity from dewpoint temperature [fraction]
+// Valid range: same as saturation_vapor_pressure (-100°C to 100°C)
 double relative_humidity_from_dewpoint(double T, double Tdp, double P);  // T in K, Tdp in K, P in Pa
 
 // Calculate wet-bulb temperature [K]
 double wet_bulb_temperature(double T, double P, double RH);  // T in K, P in Pa, RH as fraction (0-1)
 
-// Calculate enthalpy of humid air [J/kg]
+// Calculate enthalpy of humid air using psychrometric constants [J/kg dry air]
+// Uses cp_air=1005, h_fg=2501000, cp_wv=1860 J/(kg·K) — fast, standard ASHRAE formula
 double humid_air_enthalpy(double T, double P, double RH);  // T in K, P in Pa, RH as fraction (0-1)
+
+// Calculate enthalpy of humid air using NASA-9 thermodynamic data [J/kg dry air]
+// More accurate than humid_air_enthalpy() at non-ambient temperatures.
+// Requires T in NASA-9 valid range (200–6000 K).
+double humid_air_enthalpy_nasa9(double T, double P, double RH);  // T in K, P in Pa, RH as fraction (0-1)
 
 // Calculate density of humid air [kg/m³]
 double humid_air_density(double T, double P, double RH);  // T in K, P in Pa, RH as fraction (0-1)

--- a/python/combaero/__init__.py
+++ b/python/combaero/__init__.py
@@ -173,6 +173,10 @@ try:
         htc_from_nusselt,
         htc_pipe,
         humid_air_composition,
+        humid_air_density,
+        humid_air_enthalpy,
+        humid_air_enthalpy_nasa9,
+        humidity_ratio,
         hydraulic_diameter,
         hydraulic_diameter_annulus,
         hydraulic_diameter_rect,
@@ -269,6 +273,7 @@ try:
         rib_friction_multiplier,
         s,
         s_mass,
+        saturation_vapor_pressure,
         set_equivalence_ratio_mass,
         set_equivalence_ratio_mole,
         set_fuel_stream_for_CO2,
@@ -310,10 +315,13 @@ try:
         tube_Q,
         u,
         u_mass,
+        vapor_pressure,
         velocity_from_q,
         viscosity,
         wall_temperature_profile,
+        water_vapor_mole_fraction,
         wavelength,
+        wet_bulb_temperature,
         wgs_equilibrium,
         wgs_equilibrium_adiabatic,
     )
@@ -358,6 +366,14 @@ except ModuleNotFoundError:
     solve_orifice_mdot = _core.solve_orifice_mdot
     standard_dry_air_composition = _core.standard_dry_air_composition
     humid_air_composition = _core.humid_air_composition
+    humid_air_density = _core.humid_air_density
+    humid_air_enthalpy = _core.humid_air_enthalpy
+    humid_air_enthalpy_nasa9 = _core.humid_air_enthalpy_nasa9
+    humidity_ratio = _core.humidity_ratio
+    saturation_vapor_pressure = _core.saturation_vapor_pressure
+    vapor_pressure = _core.vapor_pressure
+    water_vapor_mole_fraction = _core.water_vapor_mole_fraction
+    wet_bulb_temperature = _core.wet_bulb_temperature
     dewpoint = _core.dewpoint
     relative_humidity_from_dewpoint = _core.relative_humidity_from_dewpoint
     formula_to_name = _core.formula_to_name
@@ -605,6 +621,14 @@ __all__ = [
     "solve_orifice_mdot",
     "standard_dry_air_composition",
     "humid_air_composition",
+    "humid_air_density",
+    "humid_air_enthalpy",
+    "humid_air_enthalpy_nasa9",
+    "humidity_ratio",
+    "saturation_vapor_pressure",
+    "vapor_pressure",
+    "water_vapor_mole_fraction",
+    "wet_bulb_temperature",
     "dewpoint",
     "relative_humidity_from_dewpoint",
     "formula_to_name",

--- a/python/combaero/_core.cpp
+++ b/python/combaero/_core.cpp
@@ -627,7 +627,118 @@ PYBIND11_MODULE(_core, m)
         py::arg("T"),
         py::arg("Tdp"),
         py::arg("P"),
-        "Relative humidity (0-1) from dry-bulb T [K], dewpoint Tdp [K], and pressure P [Pa]."
+        "Relative humidity (0-1) from dry-bulb T [K], dewpoint Tdp [K], and pressure P [Pa].\n\n"
+        "P is accepted for API symmetry but not used (dewpoint is pressure-independent\n"
+        "at atmospheric conditions)."
+    );
+
+    m.def(
+        "saturation_vapor_pressure",
+        &saturation_vapor_pressure,
+        py::arg("T"),
+        "Water vapor saturation pressure [Pa] using Huang (2018) formula.\n\n"
+        "Validated range: -100\u00b0C to +100\u00b0C (173.15\u2013373.15 K).\n"
+        "Extrapolation up to 5% of range span (~10 K) is allowed silently.\n"
+        "Raises RuntimeError beyond that.\n\n"
+        "T : temperature [K]\n\n"
+        "Returns: saturation vapor pressure [Pa]"
+    );
+
+    m.def(
+        "vapor_pressure",
+        &vapor_pressure,
+        py::arg("T"),
+        py::arg("RH"),
+        "Actual vapor pressure [Pa] from temperature and relative humidity.\n\n"
+        "T  : temperature [K]\n"
+        "RH : relative humidity (0-1)\n\n"
+        "Returns: vapor pressure [Pa]"
+    );
+
+    m.def(
+        "humidity_ratio",
+        &humidity_ratio,
+        py::arg("T"),
+        py::arg("P"),
+        py::arg("RH"),
+        "Humidity ratio (kg water vapor / kg dry air).\n\n"
+        "T  : temperature [K]\n"
+        "P  : total pressure [Pa]\n"
+        "RH : relative humidity (0-1)\n\n"
+        "Returns: humidity ratio W [-]"
+    );
+
+    m.def(
+        "water_vapor_mole_fraction",
+        &water_vapor_mole_fraction,
+        py::arg("T"),
+        py::arg("P"),
+        py::arg("RH"),
+        "Mole fraction of water vapor in humid air.\n\n"
+        "T  : temperature [K]\n"
+        "P  : total pressure [Pa]\n"
+        "RH : relative humidity (0-1)\n\n"
+        "Returns: mole fraction of H2O [-]"
+    );
+
+    m.def(
+        "wet_bulb_temperature",
+        &wet_bulb_temperature,
+        py::arg("T"),
+        py::arg("P"),
+        py::arg("RH"),
+        "Wet-bulb temperature [K] via Newton-Raphson on the psychrometric equation.\n\n"
+        "Solves: cp_air*(T - Twb) = hfg(Twb)*(Ws(Twb) - W)\n"
+        "where hfg(Twb) = 2501000 - 2381*(Twb - 273.15) J/kg (ASHRAE linear fit).\n\n"
+        "T  : dry-bulb temperature [K]\n"
+        "P  : total pressure [Pa]\n"
+        "RH : relative humidity (0-1)\n\n"
+        "Returns: wet-bulb temperature [K]"
+    );
+
+    m.def(
+        "humid_air_enthalpy",
+        &humid_air_enthalpy,
+        py::arg("T"),
+        py::arg("P"),
+        py::arg("RH"),
+        "Enthalpy of humid air [J/kg dry air] using ASHRAE psychrometric constants.\n\n"
+        "h = cp_air*(T - 273.15) + W*(2501000 + 1860*(T - 273.15))\n"
+        "where cp_air=1005, h_fg=2501000, cp_wv=1860 J/(kg\u00b7K).\n\n"
+        "T  : temperature [K]\n"
+        "P  : total pressure [Pa]\n"
+        "RH : relative humidity (0-1)\n\n"
+        "Returns: enthalpy [J/kg dry air]"
+    );
+
+    m.def(
+        "humid_air_enthalpy_nasa9",
+        &humid_air_enthalpy_nasa9,
+        py::arg("T"),
+        py::arg("P"),
+        py::arg("RH"),
+        "Enthalpy of humid air [J/kg dry air] using NASA-9 thermodynamic data.\n\n"
+        "More accurate than humid_air_enthalpy() at non-ambient temperatures.\n"
+        "Computes h(T, X) from the NASA-9 polynomial database and converts\n"
+        "to J/kg dry air basis.\n\n"
+        "T  : temperature [K] (valid range: 200-6000 K)\n"
+        "P  : total pressure [Pa]\n"
+        "RH : relative humidity (0-1)\n\n"
+        "Returns: enthalpy [J/kg dry air]"
+    );
+
+    m.def(
+        "humid_air_density",
+        &humid_air_density,
+        py::arg("T"),
+        py::arg("P"),
+        py::arg("RH"),
+        "Density of humid air [kg/m\u00b3] using ideal gas law.\n\n"
+        "R_ha = R_da * (1 + W/0.621945) / (1 + W), rho = P / (R_ha * T)\n\n"
+        "T  : temperature [K]\n"
+        "P  : total pressure [Pa]\n"
+        "RH : relative humidity (0-1)\n\n"
+        "Returns: density [kg/m\u00b3]"
     );
 
     // Composition conversion helpers

--- a/src/humidair.cpp
+++ b/src/humidair.cpp
@@ -1,9 +1,9 @@
 #include "../include/humidair.h"
+#include "../include/thermo.h"
 #include "../include/thermo_transport_data.h"
 #include <cmath>
 #include <stdexcept>
 #include <algorithm>
-#include <iostream>
 
 // Constants for dry air composition (mole fractions)
 const std::unordered_map<std::string, double> dry_air_composition = {
@@ -13,39 +13,45 @@ const std::unordered_map<std::string, double> dry_air_composition = {
     {"CO2", 0.0004}
 };
 
-// Constants for saturation vapor pressure calculation
-// Reference: "A Simple Accurate Formula for Calculating Saturation Vapor Pressure of Water and Ice"
-// Author: Jianhua Huang
-// DOI: https://doi.org/10.1175/JAMC-D-17-0334.1
-// Publication Date: 01 Jun 2018, Pages: 1265–1272
-
-// Base equation (16): Ps = exp(a - b/(t + d1)) / (t + d2)^c
-// where t is in °C and Ps is in Pa
+// Saturation vapor pressure constants
+// Reference: Huang (2018), doi:10.1175/JAMC-D-17-0334.1
+// Base equation: Ps = exp(a - b/(t + d1)) / (t + d2)^c, t in °C, Ps in Pa
 
 // For water vapor (t > 0°C) - Equation (17)
-const double WATER_A = 34.494;
-const double WATER_B = 4924.99;
-const double WATER_D1 = 237.1;
-const double WATER_D2 = 105.0;
-const double WATER_C = 1.57;
+static constexpr double WATER_A  = 34.494;
+static constexpr double WATER_B  = 4924.99;
+static constexpr double WATER_D1 = 237.1;
+static constexpr double WATER_D2 = 105.0;
+static constexpr double WATER_C  = 1.57;
 
 // For ice (t ≤ 0°C) - Equation (18)
-const double ICE_A = 43.494;
-const double ICE_B = 6545.8;
-const double ICE_D1 = 278.0;
-const double ICE_D2 = 868.0;
-const double ICE_C = 2.0;
+static constexpr double ICE_A  = 43.494;
+static constexpr double ICE_B  = 6545.8;
+static constexpr double ICE_D1 = 278.0;
+static constexpr double ICE_D2 = 868.0;
+static constexpr double ICE_C  = 2.0;
 
-// Water vapor saturation pressure [Pa]
-// Validated for -100°C ≤ T ≤ 100°C
-// Implementation of validated equations from Huang (2018)
-// Note: For temperatures outside the validated range, results are extrapolated
-// and may be less accurate, but represent the best available estimate
+// Validated range [K]
+static constexpr double SVP_T_MIN = 173.15;  // -100°C
+static constexpr double SVP_T_MAX = 373.15;  // +100°C
+
+// Maximum relative extrapolation beyond validated range before throwing
+// 5% of the range span (200 K) = 10 K
+static constexpr double SVP_EXTRAP_TOL = 0.05;
+
+// Water vapor saturation pressure [Pa] using Huang (2018)
+// Validated: -100°C to +100°C (173.15–373.15 K)
+// Extrapolation up to 5% of range span (~10 K) is allowed silently.
+// Beyond that, throws std::out_of_range.
 double saturation_vapor_pressure(double T) {
-    // Check temperature range - issue warning for temperatures outside validated range
-    if (T < 173.15 || T > 373.15) {
-        std::cerr << "Warning: Temperature " << T << " K (" << T - 273.15 << " °C) is outside validated range for saturation vapor pressure calculation (-100°C to 100°C)" << std::endl;
-        std::cerr << "Results may be less accurate but represent the best available estimate." << std::endl;
+    const double span = SVP_T_MAX - SVP_T_MIN;
+    const double tol  = SVP_EXTRAP_TOL * span;
+    if (T < SVP_T_MIN - tol || T > SVP_T_MAX + tol) {
+        throw std::out_of_range(
+            "saturation_vapor_pressure: T=" + std::to_string(T) +
+            " K is outside extrapolation range [" +
+            std::to_string(SVP_T_MIN - tol) + ", " +
+            std::to_string(SVP_T_MAX + tol) + "] K");
     }
 
     // Convert temperature from K to °C
@@ -55,15 +61,9 @@ double saturation_vapor_pressure(double T) {
     double P_ws;
 
     if (t <= 0.0) {
-        // For ice (t ≤ 0°C) - Equation (18) with denominator term
-        // Validated against reference values from the paper
-        // Gives 611.29 Pa at 0°C (0.023% error from reference 611.153 Pa)
-        P_ws = exp(ICE_A - ICE_B / (t + ICE_D1)) / pow(t + ICE_D2, ICE_C);
+        P_ws = std::exp(ICE_A - ICE_B / (t + ICE_D1)) / std::pow(t + ICE_D2, ICE_C);
     } else {
-        // For water vapor (t > 0°C) - Equation (17)
-        // Validated against reference values from the paper
-        // Gives 611.25 Pa at 0°C (0.015% error from reference 611.153 Pa)
-        P_ws = exp(WATER_A - WATER_B / (t + WATER_D1)) / pow(t + WATER_D2, WATER_C);
+        P_ws = std::exp(WATER_A - WATER_B / (t + WATER_D1)) / std::pow(t + WATER_D2, WATER_C);
     }
 
     return P_ws;  // Return P_ws in Pa
@@ -154,17 +154,12 @@ std::vector<double> humid_air_composition(double T, double P, double RH) {
 }
 
 // Calculate dewpoint temperature from T, P, RH [K]
+// P is not used (dewpoint depends negligibly on pressure at atmospheric conditions)
 double dewpoint(double T, double P, double RH) {
-    // P is unused in this implementation but kept for API consistency
-    (void)P; // Suppress unused parameter warning
+    (void)P;
 
-    // Validate inputs
     if (RH <= 0.0) {
-        throw std::runtime_error("Relative humidity must be greater than 0 for dewpoint calculation");
-    }
-
-    if (T < 173.15 || T > 373.15) {
-        throw std::runtime_error("Temperature out of valid range for dewpoint calculation (-100°C to 100°C)");
+        throw std::invalid_argument("dewpoint: RH must be > 0");
     }
 
     // Calculate vapor pressure
@@ -213,22 +208,12 @@ double dewpoint(double T, double P, double RH) {
 }
 
 // Calculate relative humidity from dewpoint temperature [fraction]
+// P is not used (kept for API symmetry with dewpoint())
 double relative_humidity_from_dewpoint(double T, double Tdp, double P) {
-    // P is unused in this implementation but kept for API consistency
-    (void)P; // Suppress unused parameter warning
+    (void)P;
 
-    // Validate inputs
     if (Tdp > T) {
-        throw std::runtime_error("Dewpoint temperature cannot exceed ambient temperature");
-    }
-
-    // Validate temperature ranges
-    if (T < 273.15 || T > 473.15) {
-        throw std::runtime_error("Temperature out of valid range for Hyland-Wexler equation (0°C to 200°C)");
-    }
-
-    if (Tdp < 273.15 || Tdp > 473.15) {
-        throw std::runtime_error("Dewpoint temperature out of valid range for Hyland-Wexler equation (0°C to 200°C)");
+        throw std::invalid_argument("relative_humidity_from_dewpoint: Tdp cannot exceed T");
     }
 
     // Calculate saturation vapor pressure at dewpoint temperature
@@ -241,45 +226,62 @@ double relative_humidity_from_dewpoint(double T, double Tdp, double P) {
     return P_w / P_ws;
 }
 
+// Derivative of saturation_vapor_pressure with respect to T [Pa/K]
+// Used internally by wet_bulb_temperature Newton-Raphson solver
+static double d_saturation_vapor_pressure_dT(double T) {
+    const double delta = 0.01;
+    return (saturation_vapor_pressure(T + delta) - saturation_vapor_pressure(T - delta)) / (2.0 * delta);
+}
+
 // Calculate wet-bulb temperature [K]
+// Solves the psychrometric equation using Newton-Raphson:
+//   f(Twb) = cp_air*(T - Twb) - hfg(Twb)*(Ws(Twb) - W) = 0
+// where hfg(Twb) = 2501000 - 2381*(Twb - 273.15) [J/kg] (linear fit, ASHRAE)
 double wet_bulb_temperature(double T, double P, double RH) {
-    // Use iterative method to find wet-bulb temperature
-    // Wet-bulb temperature is the temperature at which evaporation of water
-    // would saturate air at the same enthalpy
+    const double W = humidity_ratio(T, P, RH);
+    static constexpr double cp_air = 1005.0;  // J/(kg·K)
 
-    // Initial guess for wet-bulb temperature
-    double Twb = T;
+    // hfg as a function of Twb: linear approximation valid 0-100°C
+    auto hfg = [](double Tw) { return 2501000.0 - 2381.0 * (Tw - 273.15); };
 
-    // Calculate humidity ratio at current conditions
-    double W = humidity_ratio(T, P, RH);
+    // Ws(Twb): saturation humidity ratio at wet-bulb temperature
+    auto Ws = [&](double Tw) {
+        double P_ws = saturation_vapor_pressure(Tw);
+        return 0.621945 * P_ws / (P - P_ws);
+    };
 
-    // Iterative solution
-    const std::size_t max_iterations = 100;
-    const double tolerance = 1e-6;
+    // f(Twb) = cp_air*(T - Twb) - hfg(Twb)*(Ws(Twb) - W)
+    auto f = [&](double Tw) {
+        return cp_air * (T - Tw) - hfg(Tw) * (Ws(Tw) - W);
+    };
 
-    for (std::size_t i = 0; i < max_iterations; i++) {
-        // Calculate saturation vapor pressure at wet-bulb temperature
-        double P_ws_Twb = saturation_vapor_pressure(Twb);
+    // df/dTwb = -cp_air - dhfg/dTwb*(Ws - W) - hfg*dWs/dTwb
+    auto df = [&](double Tw) {
+        const double dWs_dTw = 0.621945 * d_saturation_vapor_pressure_dT(Tw)
+                               / std::pow(P - saturation_vapor_pressure(Tw), 2.0) * P;
+        const double dhfg_dTw = -2381.0;
+        return -cp_air - dhfg_dTw * (Ws(Tw) - W) - hfg(Tw) * dWs_dTw;
+    };
 
-        // Calculate saturation humidity ratio at wet-bulb temperature
-        double Ws = 0.621945 * P_ws_Twb / (P - P_ws_Twb);
+    double Twb = T * (1.0 - 0.5 * RH);  // initial guess: between Tdp and T
+    Twb = std::max(Twb, SVP_T_MIN);
+    Twb = std::min(Twb, T);
 
-        // Calculate psychrometric constant (approximation)
-        double cp_air = 1005.0;  // J/(kg·K)
-        double hfg = 2501000.0;  // J/kg at 0°C
+    const std::size_t max_iter = 50;
+    const double tol = 1e-6;
 
-        // Update wet-bulb temperature
-        double Twb_new = T - (hfg * (W - Ws)) / cp_air;
-
-        // Check for convergence
-        if (std::abs(Twb_new - Twb) < tolerance) {
-            return Twb_new;
-        }
-
-        Twb = Twb_new;
+    for (std::size_t i = 0; i < max_iter; ++i) {
+        double fval = f(Twb);
+        double dfval = df(Twb);
+        if (std::abs(dfval) < 1e-15) break;
+        double step = fval / dfval;
+        Twb -= step;
+        Twb = std::max(Twb, SVP_T_MIN);
+        Twb = std::min(Twb, T);
+        if (std::abs(step) < tol) return Twb;
     }
 
-    throw std::runtime_error("Wet-bulb temperature calculation did not converge");
+    throw std::runtime_error("wet_bulb_temperature: Newton-Raphson did not converge");
 }
 
 // Calculate enthalpy of humid air [J/kg]
@@ -297,6 +299,20 @@ double humid_air_enthalpy(double T, double P, double RH) {
 
     // Calculate total enthalpy of humid air
     return h_da + W * h_wv;  // J/kg of dry air
+}
+
+// Calculate enthalpy of humid air using NASA-9 thermodynamic data [J/kg dry air]
+// Uses h(T, X) from the NASA-9 polynomial database, converted to per-kg-dry-air basis.
+double humid_air_enthalpy_nasa9(double T, double P, double RH) {
+    const std::vector<double> X = humid_air_composition(T, P, RH);
+    const double W = humidity_ratio(T, P, RH);
+    // h(T, X) returns J/mol of mixture; convert to J/kg dry air
+    // MW_mix [g/mol], 1 kg dry air = (1+W) kg humid air
+    // h_per_kg_mix = h(T,X) * 1000 / mwmix(X)  [J/kg humid air]
+    // h_per_kg_dry = h_per_kg_mix * (1 + W)     [J/kg dry air]
+    const double h_mix_J_per_mol = h(T, X);
+    const double MW_mix = mwmix(X);  // g/mol
+    return h_mix_J_per_mol * 1000.0 / MW_mix * (1.0 + W);
 }
 
 // Calculate density of humid air [kg/m³]

--- a/src/thermo.cpp
+++ b/src/thermo.cpp
@@ -96,8 +96,14 @@ std::vector<double> mass_to_mole(const std::vector<double>& Y)
     return X;
 }
 
+// Relative extrapolation tolerance beyond NASA-9 range boundaries.
+// 5% of the range span is allowed silently (polynomial is smooth at boundaries).
+// Beyond that, throws std::out_of_range.
+static constexpr double NASA9_EXTRAP_TOL = 0.05;
+
 // Helper: find the correct interval for NASA-9 coefficients
-// Returns pointer to the 10-coefficient array for the given temperature
+// Returns pointer to the 10-coefficient array for the given temperature.
+// Clamps T to the boundary interval for small extrapolations; throws for large ones.
 static const std::array<double, 10>* find_nasa9_interval(
     const NASA_Coeffs& nasa, double& T, std::size_t species_idx) {
 
@@ -106,19 +112,25 @@ static const std::array<double, 10>* find_nasa9_interval(
         throw std::runtime_error("No NASA-9 intervals for species " + species_names[species_idx]);
     }
 
-    // Check bounds
-    double T_min = intervals.front().T_min;
-    double T_max = intervals.back().T_max;
+    const double T_min = intervals.front().T_min;
+    const double T_max = intervals.back().T_max;
+    const double span  = T_max - T_min;
+    const double tol   = NASA9_EXTRAP_TOL * span;
 
-    if (T < T_min) {
-        std::cerr << "Warning: Temperature " << T << " K is below valid range (" << T_min
-                  << " K) for species " << species_names[species_idx] << std::endl;
-        T = T_min;
-    } else if (T > T_max) {
-        std::cerr << "Warning: Temperature " << T << " K is above valid range (" << T_max
-                  << " K) for species " << species_names[species_idx] << std::endl;
-        T = T_max;
+    if (T < T_min - tol) {
+        throw std::out_of_range(
+            "Temperature " + std::to_string(T) + " K is below extrapolation limit (" +
+            std::to_string(T_min - tol) + " K) for species " + species_names[species_idx]);
     }
+    if (T > T_max + tol) {
+        throw std::out_of_range(
+            "Temperature " + std::to_string(T) + " K is above extrapolation limit (" +
+            std::to_string(T_max + tol) + " K) for species " + species_names[species_idx]);
+    }
+
+    // Clamp to boundary for small extrapolations
+    T = std::max(T, T_min);
+    T = std::min(T, T_max);
 
     // Find the interval containing T
     for (const auto& interval : intervals) {
@@ -127,7 +139,7 @@ static const std::array<double, 10>* find_nasa9_interval(
         }
     }
 
-    // Fallback to last interval (shouldn't happen if bounds check worked)
+    // Fallback to last interval (shouldn't happen after clamping)
     return &intervals.back().coeffs;
 }
 

--- a/src/thermo.cpp
+++ b/src/thermo.cpp
@@ -112,20 +112,20 @@ static const std::array<double, 10>* find_nasa9_interval(
         throw std::runtime_error("No NASA-9 intervals for species " + species_names[species_idx]);
     }
 
-    const double T_min = intervals.front().T_min;
-    const double T_max = intervals.back().T_max;
-    const double span  = T_max - T_min;
-    const double tol   = NASA9_EXTRAP_TOL * span;
+    const double T_min    = intervals.front().T_min;
+    const double T_max    = intervals.back().T_max;
+    const double tol_low  = NASA9_EXTRAP_TOL * T_min;   // 5% of 200 K = 10 K
+    const double tol_high = NASA9_EXTRAP_TOL * T_max;   // 5% of 6000 K = 300 K
 
-    if (T < T_min - tol) {
+    if (T < T_min - tol_low) {
         throw std::out_of_range(
             "Temperature " + std::to_string(T) + " K is below extrapolation limit (" +
-            std::to_string(T_min - tol) + " K) for species " + species_names[species_idx]);
+            std::to_string(T_min - tol_low) + " K) for species " + species_names[species_idx]);
     }
-    if (T > T_max + tol) {
+    if (T > T_max + tol_high) {
         throw std::out_of_range(
             "Temperature " + std::to_string(T) + " K is above extrapolation limit (" +
-            std::to_string(T_max + tol) + " K) for species " + species_names[species_idx]);
+            std::to_string(T_max + tol_high) + " K) for species " + species_names[species_idx]);
     }
 
     // Clamp to boundary for small extrapolations

--- a/tests/test_humidair.cpp
+++ b/tests/test_humidair.cpp
@@ -102,28 +102,34 @@ TEST_F(HumidAirTest, StandardDryAirComposition) {
 
 // Test behavior at extreme temperatures
 TEST_F(HumidAirTest, ExtremeTemperatures) {
-    // Very low temperature (-100°C)
+    // At the validated lower boundary (-100°C = 173.15 K): should work
     double T_very_low = 173.15;
     double P_very_low = saturation_vapor_pressure(T_very_low);
-
-    // Should be positive but very small
     EXPECT_GT(P_very_low, 0.0);
     EXPECT_LT(P_very_low, 1.0);
 
-    // Very high temperature (200°C)
-    double T_very_high = 473.15;
-    double P_very_high = saturation_vapor_pressure(T_very_high);
+    // At the validated upper boundary (+100°C = 373.15 K): should work
+    double T_valid_high = 373.15;
+    double P_valid_high = saturation_vapor_pressure(T_valid_high);
+    EXPECT_GT(P_valid_high, 1.0e4);
 
-    // Should be positive and large
-    EXPECT_GT(P_very_high, 1.0e5);
+    // Within the 5% extrapolation band above upper boundary (~383 K): should work
+    double T_extrap = 380.0;
+    double P_extrap = saturation_vapor_pressure(T_extrap);
+    EXPECT_GT(P_extrap, P_valid_high);
+
+    // Well beyond the extrapolation limit (200°C = 473.15 K): should throw
+    EXPECT_THROW(saturation_vapor_pressure(473.15), std::out_of_range);
+    // Well below the extrapolation limit (-120°C = 153.15 K): should throw
+    EXPECT_THROW(saturation_vapor_pressure(153.15), std::out_of_range);
 }
 
 // Test monotonicity of the saturation vapor pressure function
 TEST_F(HumidAirTest, Monotonicity) {
     double prev_pressure = -1.0;
 
-    // Test that pressure increases with temperature
-    for (double T = 173.15; T <= 473.15; T += 10.0) {
+    // Test that pressure increases with temperature within the validated range
+    for (double T = 173.15; T <= 373.15; T += 10.0) {
         double P_sat = saturation_vapor_pressure(T);
 
         if (prev_pressure > 0.0) {

--- a/tests/test_thermo_transport.cpp
+++ b/tests/test_thermo_transport.cpp
@@ -145,23 +145,14 @@ TEST_F(ThermoTransportTest, ConvertPureWaterVaporToDry) {
 
 // Test that temperature below valid range issues a warning but still returns a result
 TEST_F(ThermoTransportTest, TemperatureBelowValidRangeWarning) {
-    // Use 150 K which is below the 200 K minimum for NASA-9 polynomials
+    // T=150 K is below the 5% extrapolation limit (190 K) for NASA-9 polynomials.
+    // The new range policy throws std::out_of_range instead of issuing a cerr warning.
     double T = 150.0;
+    EXPECT_THROW(cp(T, air_composition), std::out_of_range);
 
-    // Redirect cerr to capture warning
-    testing::internal::CaptureStderr();
-
-    // Calculate cp - should still work but issue warning
-    double cp_value = cp(T, air_composition);
-
-    // Check that warning was issued
-    std::string output = testing::internal::GetCapturedStderr();
-    EXPECT_TRUE(output.find("Warning") != std::string::npos)
-        << "Expected temperature range warning for T=150 K";
-    EXPECT_TRUE(output.find("below valid range") != std::string::npos)
-        << "Warning should mention 'below valid range'";
-
-    // Result should still be reasonable (extrapolated from 200 K)
+    // T=195 K is within the 5% extrapolation band (190-200 K): should succeed silently.
+    double T_near = 195.0;
+    double cp_value = cp(T_near, air_composition);
     EXPECT_GT(cp_value, 20.0);
     EXPECT_LT(cp_value, 50.0);
 }


### PR DESCRIPTION
## Changes

### `humidair.cpp`
- **`saturation_vapor_pressure`**: replace `std::cerr` with structured range policy — 5% of span (~10 K) allowed silently, throws `std::out_of_range` beyond
- **`wet_bulb_temperature`**: replace non-convergent fixed-point iteration with proper Newton-Raphson on the psychrometric equation; T-dependent `hfg(Twb)` via ASHRAE linear fit `2501000 - 2381*(Twb-273.15)` J/kg
- **`relative_humidity_from_dewpoint`**: remove wrong Hyland-Wexler range check (0–200°C); delegates to `saturation_vapor_pressure` which enforces the correct Huang (2018) range (-100 to +100°C)
- **`humid_air_enthalpy_nasa9()`**: new function using `h(T, humid_air_composition())` from NASA-9 polynomials, converted to J/kg dry air basis
- Remove unused `<iostream>` include

### `thermo.cpp`
- **`find_nasa9_interval`**: replace `std::cerr` + silent clamp with same policy: 5% of range span allowed silently, throws `std::out_of_range` beyond

### Python bindings
- Bind 7 previously missing functions: `saturation_vapor_pressure`, `vapor_pressure`, `humidity_ratio`, `water_vapor_mole_fraction`, `wet_bulb_temperature`, `humid_air_enthalpy`, `humid_air_density`
- Bind new `humid_air_enthalpy_nasa9`
- Remove stale `saturation_pressure_ratio` + `vapor_pressure_ratio` from `__init__.py` (never existed in `_core`)