### PR TITLE
feat: ChannelResult unified HTC+dP for all internal cooling channel types

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 # CombAero TODO - Composite Dataclass States
 
-## Recent Completion: Thermal Cooling Refactor (Phases A & B)
+## Recent Completion: Thermal Cooling Refactor (Phases A, B & C)
 
 **Phase A: Materials Database** ✅ COMPLETE (Commit: 1e2246a)
 - Separated materials database from heat transfer correlations
@@ -15,6 +15,18 @@
 - 26 comprehensive tests (463 total tests pass)
 - Full documentation in API_REFERENCE.md
 - 5 new unit entries (224 total)
+
+**Phase C: Convective Heat Transfer Refactor (ChannelResult)** ✅ COMPLETE (Commit: pending)
+- `ChannelResult` C++ struct unifying HTC + pressure drop in one call
+- 5 new `channel_*` functions: `channel_smooth`, `channel_ribbed`, `channel_dimpled`, `channel_pin_fin`, `channel_impingement`
+- `pin_fin_friction` scalar correlation (Metzger/Simoneau power law)
+- Mach number computed internally; `T_aw` always continuous (no M threshold, smooth Jacobian)
+- pybind11 bindings for `ChannelResult` and all `channel_*` functions
+- `combaero.heat_transfer` submodule with keyword-argument API (`ht.smooth`, `ht.ribbed`, etc.)
+- Re-based correlation validators changed from throw → warn+extrapolate (power-law correlations are well-behaved); geometry ratio limits remain hard errors
+- 48 new tests in `python/tests/test_channel_flow.py` (736 total tests pass)
+- API_REFERENCE.md, NETWORK_ROADMAP.md, units_data.h updated; UNITS.md regenerated (283 entries)
+- Global `CorrelationResult<T>` validity-flag refactor noted in NETWORK_ROADMAP.md as pending future scope
 
 ---
 

--- a/docs/UNITS.md
+++ b/docs/UNITS.md
@@ -525,6 +525,36 @@ All functions use consistent units to avoid conversion errors.
 | `residence_time_mdot_can_annular` | geom: CanAnnularFlowGeometry, mdot: kg/s, rho: kg/m^3 | s           |
 | `space_velocity`                  | Q: m^3/s, V: m^3                                      | 1/s         |
 
+### heat_transfer.h - ChannelResult fields
+
+| Function              | Input Units | Output Unit             |
+|-----------------------|-------------|-------------------------|
+| `ChannelResult::h`    | -           | W/(m^2*K)               |
+| `ChannelResult::Nu`   | -           | - (Nu)                  |
+| `ChannelResult::Re`   | -           | - (Re)                  |
+| `ChannelResult::Pr`   | -           | - (Pr)                  |
+| `ChannelResult::f`    | -           | - (friction/loss coeff) |
+| `ChannelResult::dP`   | -           | Pa                      |
+| `ChannelResult::M`    | -           | - (M)                   |
+| `ChannelResult::T_aw` | -           | K                       |
+| `ChannelResult::q`    | -           | W/m^2                   |
+
+### heat_transfer.h - Channel flow functions (HTC + pressure drop)
+
+| Function              | Input Units                                                                                                      | Output Unit   |
+|-----------------------|------------------------------------------------------------------------------------------------------------------|---------------|
+| `channel_smooth`      | T: K, P: Pa, X: mol/mol, velocity: m/s, diameter: m, length: m, T_wall: K                                        | ChannelResult |
+| `channel_ribbed`      | T: K, P: Pa, X: mol/mol, velocity: m/s, diameter: m, length: m, e_D: -, P_e: -, alpha: deg, T_wall: K            | ChannelResult |
+| `channel_dimpled`     | T: K, P: Pa, X: mol/mol, velocity: m/s, diameter: m, length: m, d_Dh: -, h_d: -, S_d: -, T_wall: K               | ChannelResult |
+| `channel_pin_fin`     | T: K, P: Pa, X: mol/mol, velocity: m/s, channel_height: m, pin_diameter: m, S_D: -, X_D: -, N_rows: -, T_wall: K | ChannelResult |
+| `channel_impingement` | T: K, P: Pa, X: mol/mol, mdot_jet: kg/s, d_jet: m, z_D: -, x_D: -, y_D: -, A_target: m^2, T_wall: K              | ChannelResult |
+
+### cooling_correlations.h - Pin fin friction (new scalar)
+
+| Function           | Input Units | Output Unit |
+|--------------------|-------------|-------------|
+| `pin_fin_friction` | Re_d: -     | - (f_pin)   |
+
 ---
 
 ## Dimensionless Quantities

--- a/include/cooling_correlations.h
+++ b/include/cooling_correlations.h
@@ -196,6 +196,21 @@ double pin_fin_nusselt(
     bool is_staggered = true
 );
 
+// Pin fin array pressure drop friction coefficient
+// For use in: dP = N_rows * f_pin * (rho * v_max² / 2)
+// where v_max is the velocity at the minimum cross-section.
+//
+// Parameters:
+//   Re_d         : Reynolds number based on pin diameter [-]
+//   is_staggered : true for staggered (default), false for inline
+//
+// Returns: friction coefficient f_pin [-]
+//
+// Source: Metzger et al. (1982), Simoneau & VanFossen (1984)
+// Valid: Re_d = 3000-90000
+// Accuracy: +/-20%
+double pin_fin_friction(double Re_d, bool is_staggered = true);
+
 // -------------------------------------------------------------
 // Dimpled Surfaces
 // -------------------------------------------------------------

--- a/include/heat_transfer.h
+++ b/include/heat_transfer.h
@@ -1,6 +1,7 @@
 #ifndef HEAT_TRANSFER_H
 #define HEAT_TRANSFER_H
 
+#include <limits>
 #include <string>
 #include <utility>
 #include <vector>

--- a/include/heat_transfer.h
+++ b/include/heat_transfer.h
@@ -483,4 +483,149 @@ std::tuple<double, double, double> htc_pipe(
     double mu_ratio = 1.0,
     double roughness = 0.0);
 
+// -------------------------------------------------------------
+// Combined convective heat transfer + pressure loss result
+// -------------------------------------------------------------
+//
+// Returned by all channel_* functions below.
+// All properties are evaluated from (T, P, X) in a single pass.
+//
+// T_aw is always computed continuously for all M:
+//   T_aw = T_static + r * v² / (2 * cp)
+//   r = Pr^(1/3) turbulent, Pr^(1/2) laminar
+//   At v=0: T_aw = T_static exactly (no discontinuity, no threshold).
+//   This keeps the Jacobian smooth for network solvers.
+//
+// q is nan when T_wall is not supplied (flow-only or unknown wall T).
+//
+// f meaning depends on geometry:
+//   smooth / ribbed / dimpled : Darcy friction factor [-]
+//   pin_fin                   : pin-array friction coefficient [-]
+//                               (dP = N_rows * f * rho*v_max²/2)
+//   impingement               : jet-plate loss coefficient [-]
+//                               (dP = f * rho*v_jet²/2)
+struct ChannelResult {
+    double h;     // convective HTC [W/(m²·K)]
+    double Nu;    // Nusselt number [-]
+    double Re;    // Reynolds number [-]  (hydraulic D or pin D depending on geometry)
+    double Pr;    // Prandtl number [-]
+    double f;     // friction / loss coefficient [-]  (see note above)
+    double dP;    // pressure drop [Pa]
+    double M;     // Mach number [-]  (computed internally from v/a(T,X))
+    double T_aw;  // adiabatic wall temperature [K]  (always computed, see above)
+    double q;     // heat flux [W/m²]  (nan if T_wall not supplied)
+};
+
+// -------------------------------------------------------------
+// High-level channel functions — each returns a ChannelResult
+// -------------------------------------------------------------
+//
+// All functions:
+//   - evaluate fluid properties (rho, mu, k, Pr, cp) once from (T, P, X)
+//   - compute M = v / a(T, X) internally
+//   - compute T_aw = T_static + r*v²/(2*cp) continuously
+//   - set q = h*(T_aw - T_wall) if T_wall is finite, else q = nan
+//
+// User contract: choose the model that matches the geometry.
+// Do not mix models (e.g. do not apply rib multipliers to a smooth result).
+
+// Smooth pipe or duct (Gnielinski / Dittus-Boelter / Sieder-Tate / Petukhov)
+//
+// Parameters:
+//   T, P, X    : bulk static thermodynamic state
+//   velocity   : bulk velocity [m/s]
+//   diameter   : hydraulic diameter [m]
+//   length     : channel length [m]  (for dP)
+//   T_wall     : wall temperature [K]  (pass NaN to skip q computation)
+//   correlation: "gnielinski" (default), "dittus_boelter", "sieder_tate", "petukhov"
+//   heating    : true = fluid is heated (affects Dittus-Boelter exponent)
+//   mu_ratio   : mu_bulk / mu_wall for Sieder-Tate (default 1.0)
+//   roughness  : absolute wall roughness [m]  (default 0.0 = smooth)
+ChannelResult channel_smooth(
+    double T, double P, const std::vector<double>& X,
+    double velocity, double diameter, double length,
+    double T_wall = std::numeric_limits<double>::quiet_NaN(),
+    const std::string& correlation = "gnielinski",
+    bool heating = true,
+    double mu_ratio = 1.0,
+    double roughness = 0.0);
+
+// Rib-enhanced cooling channel (Han et al. 1988)
+//
+// Applies rib_enhancement_factor to Nu and rib_friction_multiplier to f
+// from a smooth-pipe baseline at the same Re.
+//
+// Parameters:
+//   e_D   : rib height / hydraulic diameter [-]  (valid: 0.02-0.1)
+//   P_e   : rib pitch / rib height [-]           (valid: 5-20)
+//   alpha : rib angle [degrees]                  (valid: 30-90)
+ChannelResult channel_ribbed(
+    double T, double P, const std::vector<double>& X,
+    double velocity, double diameter, double length,
+    double e_D, double P_e, double alpha,
+    double T_wall = std::numeric_limits<double>::quiet_NaN(),
+    bool heating = true);
+
+// Dimpled surface cooling channel (Chyu et al. 1997)
+//
+// Applies dimple_nusselt_enhancement to Nu and dimple_friction_multiplier to f
+// from a smooth-pipe baseline at the same Re.
+//
+// Parameters:
+//   d_Dh : dimple diameter / channel height [-]  (valid: 0.1-0.3)
+//   h_d  : dimple depth / diameter [-]           (valid: 0.1-0.3)
+//   S_d  : dimple spacing / diameter [-]         (valid: 1.5-3.0)
+ChannelResult channel_dimpled(
+    double T, double P, const std::vector<double>& X,
+    double velocity, double diameter, double length,
+    double d_Dh, double h_d, double S_d,
+    double T_wall = std::numeric_limits<double>::quiet_NaN(),
+    bool heating = true);
+
+// Pin-fin array cooling channel (Metzger et al. 1982)
+//
+// Re is based on pin diameter d.
+// h = Nu * k / d.
+// dP = N_rows * f_pin * (rho * v_max² / 2)
+//   where v_max = velocity * S_D / (S_D - 1)  (minimum cross-section velocity)
+//   and   f_pin from pin_fin_friction() in cooling_correlations.h
+//
+// Parameters:
+//   velocity       : approach (upstream) velocity [m/s]
+//   channel_height : pin length H [m]
+//   pin_diameter   : pin diameter d [m]
+//   S_D            : spanwise pitch / d [-]   (valid: 1.5-4.0)
+//   X_D            : streamwise pitch / d [-] (valid: 1.5-4.0)
+//   N_rows         : number of pin rows in streamwise direction
+//   is_staggered   : true = staggered array (default), false = inline
+ChannelResult channel_pin_fin(
+    double T, double P, const std::vector<double>& X,
+    double velocity, double channel_height, double pin_diameter,
+    double S_D, double X_D, int N_rows,
+    double T_wall = std::numeric_limits<double>::quiet_NaN(),
+    bool is_staggered = true);
+
+// Impingement jet array cooling (Florschuetz et al. 1981 / Martin 1977)
+//
+// Re is based on jet diameter d_jet.
+// h = Nu * k / d_jet.
+// dP = f * rho * v_jet² / 2  where f = 1/Cd_jet²  (jet-plate orifice loss)
+//   v_jet = mdot_jet / (rho * A_jet)
+//
+// Parameters:
+//   mdot_jet : jet mass flow rate [kg/s]  (total for all jets)
+//   d_jet    : jet hole diameter [m]
+//   z_D      : jet-to-target distance / d_jet [-]  (valid: 1-12)
+//   x_D      : streamwise jet spacing / d_jet [-]  (0 = single jet; valid array: 4-16)
+//   y_D      : spanwise jet spacing / d_jet [-]    (0 = single jet; valid array: 4-16)
+//   A_target : target surface area [m²]  (used to compute average h)
+//   Cd_jet   : jet hole discharge coefficient [-]  (default 0.65)
+ChannelResult channel_impingement(
+    double T, double P, const std::vector<double>& X,
+    double mdot_jet, double d_jet,
+    double z_D, double x_D, double y_D,
+    double A_target,
+    double T_wall = std::numeric_limits<double>::quiet_NaN(),
+    double Cd_jet = 0.65);
+
 #endif // HEAT_TRANSFER_H

--- a/include/units_data.h
+++ b/include/units_data.h
@@ -409,6 +409,33 @@ inline constexpr Entry function_units[] = {
     {"recovery_factor",         "Pr: -",                                     "- (r)"},
     {"T_adiabatic_wall",        "T_static: K, v: m/s, T: K, P: Pa, X: mol/mol", "K"},
     {"T_adiabatic_wall_mach",   "T_static: K, M: -, T: K, P: Pa, X: mol/mol",   "K"},
+
+    // -------------------------------------------------------------------------
+    // heat_transfer.h - ChannelResult fields
+    // -------------------------------------------------------------------------
+    {"ChannelResult::h",    "-",    "W/(m^2*K)"},
+    {"ChannelResult::Nu",   "-",    "- (Nu)"},
+    {"ChannelResult::Re",   "-",    "- (Re)"},
+    {"ChannelResult::Pr",   "-",    "- (Pr)"},
+    {"ChannelResult::f",    "-",    "- (friction/loss coeff)"},
+    {"ChannelResult::dP",   "-",    "Pa"},
+    {"ChannelResult::M",    "-",    "- (M)"},
+    {"ChannelResult::T_aw", "-",    "K"},
+    {"ChannelResult::q",    "-",    "W/m^2"},
+
+    // -------------------------------------------------------------------------
+    // heat_transfer.h - Channel flow functions (HTC + pressure drop)
+    // -------------------------------------------------------------------------
+    {"channel_smooth",      "T: K, P: Pa, X: mol/mol, velocity: m/s, diameter: m, length: m, T_wall: K", "ChannelResult"},
+    {"channel_ribbed",      "T: K, P: Pa, X: mol/mol, velocity: m/s, diameter: m, length: m, e_D: -, P_e: -, alpha: deg, T_wall: K", "ChannelResult"},
+    {"channel_dimpled",     "T: K, P: Pa, X: mol/mol, velocity: m/s, diameter: m, length: m, d_Dh: -, h_d: -, S_d: -, T_wall: K", "ChannelResult"},
+    {"channel_pin_fin",     "T: K, P: Pa, X: mol/mol, velocity: m/s, channel_height: m, pin_diameter: m, S_D: -, X_D: -, N_rows: -, T_wall: K", "ChannelResult"},
+    {"channel_impingement", "T: K, P: Pa, X: mol/mol, mdot_jet: kg/s, d_jet: m, z_D: -, x_D: -, y_D: -, A_target: m^2, T_wall: K", "ChannelResult"},
+
+    // -------------------------------------------------------------------------
+    // cooling_correlations.h - Pin fin friction (new scalar)
+    // -------------------------------------------------------------------------
+    {"pin_fin_friction",    "Re_d: -",  "- (f_pin)"},
 };
 
 inline constexpr std::size_t function_count = sizeof(function_units) / sizeof(Entry);

--- a/python/combaero/__init__.py
+++ b/python/combaero/__init__.py
@@ -107,6 +107,12 @@ try:
         calc_T_from_s,
         can_annular_eigenmodes,
         capacity_ratio,
+        channel_dimpled,
+        channel_impingement,
+        channel_pin_fin,
+        channel_ribbed,
+        channel_smooth,
+        ChannelResult,
         closest_mode,
         combustion_equilibrium,
         combustion_state,
@@ -255,6 +261,7 @@ try:
         P0_from_static,
         P_from_stagnation,
         peclet,
+        pin_fin_friction,
         pin_fin_nusselt,
         pipe_area,
         pipe_dP,
@@ -601,10 +608,19 @@ except ModuleNotFoundError:
     has_units = _core.has_units
     list_functions_with_units = _core.list_functions_with_units
     all_units = _core.all_units
+    # Channel flow (HTC + pressure drop)
+    ChannelResult = _core.ChannelResult
+    channel_smooth = _core.channel_smooth
+    channel_ribbed = _core.channel_ribbed
+    channel_dimpled = _core.channel_dimpled
+    channel_pin_fin = _core.channel_pin_fin
+    channel_impingement = _core.channel_impingement
+    pin_fin_friction = _core.pin_fin_friction
 
 
 # Submodule imports — always available regardless of _core load path.
 from . import compressible
+from . import heat_transfer
 from . import incompressible
 from ._flow_solution import FlowSolution
 
@@ -711,10 +727,19 @@ __all__ = [
     "effusion_effectiveness",
     "effusion_discharge_coefficient",
     "pin_fin_nusselt",
+    "pin_fin_friction",
     "dimple_nusselt_enhancement",
     "dimple_friction_multiplier",
     "adiabatic_wall_temperature",
     "cooled_wall_heat_flux",
+    # Channel flow (HTC + pressure drop)
+    "ChannelResult",
+    "channel_smooth",
+    "channel_ribbed",
+    "channel_dimpled",
+    "channel_pin_fin",
+    "channel_impingement",
+    "heat_transfer",
     # Inverse solvers - find fuel stream
     "set_fuel_stream_for_Tad",
     "set_fuel_stream_for_phi",

--- a/python/combaero/heat_transfer.py
+++ b/python/combaero/heat_transfer.py
@@ -1,0 +1,299 @@
+"""Internal cooling channel submodule.
+
+Provides a high-level API for combined convective heat transfer and pressure
+loss in internal cooling channels.  All functions accept ``(T, P, X, ...)``
+and return a :class:`ChannelResult`.
+
+Available models
+----------------
+smooth
+    Smooth pipe or duct (Gnielinski / Dittus-Boelter / Sieder-Tate / Petukhov).
+ribbed
+    Rib-enhanced cooling channel (Han et al. 1988).
+dimpled
+    Dimpled surface cooling channel (Chyu et al. 1997).
+pin_fin
+    Pin-fin array cooling channel (Metzger et al. 1982).
+impingement
+    Impingement jet array cooling (Florschuetz et al. 1981 / Martin 1977).
+
+Design notes
+------------
+- ``ChannelResult`` is returned directly, not ``FlowSolution``.  Use
+  ``combaero.incompressible`` or ``combaero.compressible`` for flow-only
+  (no heat transfer) elements.
+- ``T_aw`` is always computed continuously for all Mach numbers:
+  ``T_aw = T_static + r * v^2 / (2*cp)`` with ``r = Pr^(1/3)`` (turbulent).
+  At ``v=0`` this reduces to ``T_static`` exactly — no threshold, no kink in
+  the Jacobian.
+- ``q = h * (T_aw - T_wall)`` when ``T_wall`` is supplied, else ``nan``.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+
+from ._core import ChannelResult
+from ._core import channel_dimpled as _channel_dimpled
+from ._core import channel_impingement as _channel_impingement
+from ._core import channel_pin_fin as _channel_pin_fin
+from ._core import channel_ribbed as _channel_ribbed
+from ._core import channel_smooth as _channel_smooth
+
+
+def smooth(
+    T: float,
+    P: float,
+    X: Sequence[float],
+    *,
+    u: float,
+    L: float,
+    D: float,
+    T_wall: float = math.nan,
+    correlation: str = "gnielinski",
+    heating: bool = True,
+    mu_ratio: float = 1.0,
+    roughness: float = 0.0,
+) -> ChannelResult:
+    """Smooth pipe or duct: combined HTC + pressure drop.
+
+    Parameters
+    ----------
+    T:
+        Bulk static temperature [K].
+    P:
+        Bulk static pressure [Pa].
+    X:
+        Mole fractions [-].
+    u:
+        Bulk flow velocity [m/s].
+    L:
+        Channel length [m].
+    D:
+        Hydraulic diameter [m].
+    T_wall:
+        Wall temperature [K].  Supply to obtain ``q``; omit (``nan``) for
+        flow-only or when wall temperature is unknown.
+    correlation:
+        Nusselt correlation: ``"gnielinski"`` (default), ``"dittus_boelter"``,
+        ``"sieder_tate"``, ``"petukhov"``.
+    heating:
+        ``True`` if the fluid is being heated (affects Dittus-Boelter exponent).
+    mu_ratio:
+        ``mu_bulk / mu_wall`` for Sieder-Tate viscosity correction.
+    roughness:
+        Absolute wall roughness [m].  ``0.0`` for hydraulically smooth.
+
+    Returns
+    -------
+    ChannelResult
+    """
+    return _channel_smooth(
+        T,
+        P,
+        list(X),
+        u,
+        D,
+        L,
+        T_wall=T_wall,
+        correlation=correlation,
+        heating=heating,
+        mu_ratio=mu_ratio,
+        roughness=roughness,
+    )
+
+
+def ribbed(
+    T: float,
+    P: float,
+    X: Sequence[float],
+    *,
+    u: float,
+    L: float,
+    D: float,
+    e_D: float,
+    P_e: float,
+    alpha: float,
+    T_wall: float = math.nan,
+    heating: bool = True,
+) -> ChannelResult:
+    """Rib-enhanced cooling channel (Han et al. 1988).
+
+    Applies ``rib_enhancement_factor`` to Nu and ``rib_friction_multiplier``
+    to f from a smooth-pipe Gnielinski baseline.
+
+    Parameters
+    ----------
+    T, P, X:
+        Bulk static thermodynamic state.
+    u:
+        Bulk flow velocity [m/s].
+    L:
+        Channel length [m].
+    D:
+        Hydraulic diameter [m].
+    e_D:
+        Rib height / hydraulic diameter [-].  Valid: 0.02-0.1.
+    P_e:
+        Rib pitch / rib height [-].  Valid: 5-20.
+    alpha:
+        Rib angle [degrees].  Valid: 30-90.
+    T_wall:
+        Wall temperature [K].  ``nan`` to skip ``q``.
+    heating:
+        ``True`` if the fluid is being heated.
+
+    Returns
+    -------
+    ChannelResult
+    """
+    return _channel_ribbed(T, P, list(X), u, D, L, e_D, P_e, alpha, T_wall=T_wall, heating=heating)
+
+
+def dimpled(
+    T: float,
+    P: float,
+    X: Sequence[float],
+    *,
+    u: float,
+    L: float,
+    D: float,
+    d_Dh: float,
+    h_d: float,
+    S_d: float,
+    T_wall: float = math.nan,
+    heating: bool = True,
+) -> ChannelResult:
+    """Dimpled surface cooling channel (Chyu et al. 1997).
+
+    Applies ``dimple_nusselt_enhancement`` to Nu and
+    ``dimple_friction_multiplier`` to f from a smooth-pipe Gnielinski baseline.
+
+    Parameters
+    ----------
+    T, P, X:
+        Bulk static thermodynamic state.
+    u:
+        Bulk flow velocity [m/s].
+    L:
+        Channel length [m].
+    D:
+        Hydraulic diameter [m].
+    d_Dh:
+        Dimple diameter / channel height [-].  Valid: 0.1-0.3.
+    h_d:
+        Dimple depth / diameter [-].  Valid: 0.1-0.3.
+    S_d:
+        Dimple spacing / diameter [-].  Valid: 1.5-3.0.
+    T_wall:
+        Wall temperature [K].  ``nan`` to skip ``q``.
+    heating:
+        ``True`` if the fluid is being heated.
+
+    Returns
+    -------
+    ChannelResult
+    """
+    return _channel_dimpled(T, P, list(X), u, D, L, d_Dh, h_d, S_d, T_wall=T_wall, heating=heating)
+
+
+def pin_fin(
+    T: float,
+    P: float,
+    X: Sequence[float],
+    *,
+    u: float,
+    H: float,
+    d: float,
+    S_D: float,
+    X_D: float,
+    N_rows: int,
+    T_wall: float = math.nan,
+    is_staggered: bool = True,
+) -> ChannelResult:
+    """Pin-fin array cooling channel (Metzger et al. 1982).
+
+    Re and Nu are based on pin diameter ``d``.
+    ``dP = N_rows * f_pin * (rho * v_max^2 / 2)``
+    where ``v_max = u * S_D / (S_D - 1)`` is the minimum cross-section velocity.
+
+    Parameters
+    ----------
+    T, P, X:
+        Bulk static thermodynamic state.
+    u:
+        Approach (upstream) velocity [m/s].
+    H:
+        Pin length / channel height [m].
+    d:
+        Pin diameter [m].
+    S_D:
+        Spanwise pitch / d [-].  Valid: 1.5-4.0.
+    X_D:
+        Streamwise pitch / d [-].  Valid: 1.5-4.0.
+    N_rows:
+        Number of pin rows in the streamwise direction.
+    T_wall:
+        Wall temperature [K].  ``nan`` to skip ``q``.
+    is_staggered:
+        ``True`` for staggered array (default), ``False`` for inline.
+
+    Returns
+    -------
+    ChannelResult
+    """
+    return _channel_pin_fin(
+        T, P, list(X), u, H, d, S_D, X_D, N_rows, T_wall=T_wall, is_staggered=is_staggered
+    )
+
+
+def impingement(
+    T: float,
+    P: float,
+    X: Sequence[float],
+    *,
+    mdot_jet: float,
+    d_jet: float,
+    z_D: float,
+    x_D: float = 0.0,
+    y_D: float = 0.0,
+    A_target: float,
+    T_wall: float = math.nan,
+    Cd_jet: float = 0.65,
+) -> ChannelResult:
+    """Impingement jet array cooling (Florschuetz et al. 1981 / Martin 1977).
+
+    Re and Nu are based on jet diameter ``d_jet``.
+    ``dP = (1/Cd_jet^2) * rho * v_jet^2 / 2``  (jet-plate orifice loss).
+
+    Parameters
+    ----------
+    T, P, X:
+        Bulk static thermodynamic state of the coolant.
+    mdot_jet:
+        Total jet mass flow rate [kg/s].
+    d_jet:
+        Jet hole diameter [m].
+    z_D:
+        Jet-to-target distance / ``d_jet`` [-].  Valid: 1-12.
+    x_D:
+        Streamwise jet spacing / ``d_jet`` [-].  ``0.0`` for single jet.
+        Valid for arrays: 4-16.
+    y_D:
+        Spanwise jet spacing / ``d_jet`` [-].  ``0.0`` for single jet.
+        Valid for arrays: 4-16.
+    A_target:
+        Target surface area [m^2].
+    T_wall:
+        Wall temperature [K].  ``nan`` to skip ``q``.
+    Cd_jet:
+        Jet hole discharge coefficient [-].  Default ``0.65``.
+
+    Returns
+    -------
+    ChannelResult
+    """
+    return _channel_impingement(
+        T, P, list(X), mdot_jet, d_jet, z_D, x_D, y_D, A_target, T_wall=T_wall, Cd_jet=Cd_jet
+    )

--- a/python/tests/test_channel_flow.py
+++ b/python/tests/test_channel_flow.py
@@ -1,0 +1,513 @@
+"""
+Tests for combined convective heat transfer + pressure loss channel functions.
+
+Tests verify:
+- channel_smooth: consistency with htc_pipe and Darcy-Weisbach
+- channel_ribbed: Nu and dP exceed smooth baseline
+- channel_dimpled: Nu enhanced, dP lower than ribbed
+- channel_pin_fin: dP scales with N_rows, Nu increases with Re
+- channel_impingement: Nu from correlation, dP from orifice model
+- T_aw continuity: no threshold discontinuity at any Mach
+- q = nan when T_wall not supplied
+- heat_transfer submodule API
+"""
+
+import math
+
+import pytest
+
+import combaero as cb
+from combaero import heat_transfer as ht
+
+# Standard air at 600 K, 5 bar
+T_AIR = 600.0
+P_AIR = 5e5
+X_AIR = [0.79, 0.21, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+
+# Pin-fin geometry: keep Re_d = rho*v*d/mu within [3000, 90000].
+# At 600K/5bar air: rho~2.9 kg/m3, mu~3.0e-5 Pa.s
+# Re_d = 2.9 * v * d / 3e-5  =>  v=5 m/s, d=0.003 m -> Re_d ~ 1450 (too low)
+# v=5 m/s, d=0.005 m -> Re_d ~ 2400 (too low)
+# v=10 m/s, d=0.005 m -> Re_d ~ 4800 (ok)
+# v=20 m/s, d=0.005 m -> Re_d ~ 9700 (ok)
+# v=50 m/s, d=0.005 m -> Re_d ~ 24000 (ok)
+PIN_V = 10.0  # approach velocity [m/s]
+PIN_H = 0.015  # channel height / pin length [m]
+PIN_D = 0.005  # pin diameter [m]  -> Re_d ~ 4800 at 600K/5bar
+PIN_SD = 2.5  # spanwise pitch/d
+PIN_XD = 2.5  # streamwise pitch/d
+PIN_N = 5  # number of rows
+
+# Impingement: keep Re_jet = rho*v_jet*d/mu within [5000, 80000].
+# A_jet = pi/4 * d^2.  v_jet = mdot / (rho * A_jet)
+# At 600K/5bar: rho~2.9 kg/m3, mu~3e-5
+# d=0.005 m, A_jet=1.96e-5 m2
+# mdot=0.001 kg/s -> v_jet=0.001/(2.9*1.96e-5)=17.6 m/s -> Re_jet=2.9*17.6*0.005/3e-5=8500 (ok)
+# mdot=0.005 kg/s -> Re_jet~42500 (ok)
+IMP_MDOT = 0.001  # jet mass flow [kg/s]
+IMP_D = 0.005  # jet diameter [m]
+IMP_ZD = 6.0  # z/D
+IMP_A = 0.01  # target area [m^2]
+
+
+class TestChannelSmooth:
+    """Tests for channel_smooth."""
+
+    def test_returns_channel_result(self):
+        sol = cb.channel_smooth(T_AIR, P_AIR, X_AIR, 20.0, 0.01, 0.5)
+        assert isinstance(sol, cb.ChannelResult)
+
+    def test_h_matches_htc_pipe(self):
+        """channel_smooth h should match htc_pipe for same conditions."""
+        v = 20.0
+        D = 0.01
+        sol = cb.channel_smooth(T_AIR, P_AIR, X_AIR, v, D, 0.5)
+        h_ref, Nu_ref, Re_ref = cb.htc_pipe(T_AIR, P_AIR, X_AIR, v, D)
+        assert sol.h == pytest.approx(h_ref, rel=1e-6)
+        assert sol.Nu == pytest.approx(Nu_ref, rel=1e-6)
+        assert sol.Re == pytest.approx(Re_ref, rel=1e-6)
+
+    def test_dP_matches_darcy_weisbach(self):
+        """dP should match Darcy-Weisbach: f*(L/D)*(rho*v^2/2)."""
+        v = 20.0
+        D = 0.01
+        L = 0.5
+        sol = cb.channel_smooth(T_AIR, P_AIR, X_AIR, v, D, L)
+        rho = cb.density(T_AIR, P_AIR, X_AIR)
+        dP_ref = sol.f * (L / D) * (rho * v * v / 2.0)
+        assert sol.dP == pytest.approx(dP_ref, rel=1e-6)
+
+    def test_q_nan_without_T_wall(self):
+        """q should be nan when T_wall is not supplied."""
+        sol = cb.channel_smooth(T_AIR, P_AIR, X_AIR, 20.0, 0.01, 0.5)
+        assert math.isnan(sol.q)
+
+    def test_q_finite_with_T_wall(self):
+        """q should be finite and equal h*(T_aw - T_wall) when T_wall given."""
+        T_wall = 800.0
+        sol = cb.channel_smooth(T_AIR, P_AIR, X_AIR, 20.0, 0.01, 0.5, T_wall=T_wall)
+        assert math.isfinite(sol.q)
+        assert sol.q == pytest.approx(sol.h * (sol.T_aw - T_wall), rel=1e-9)
+
+    def test_T_aw_equals_T_at_zero_velocity(self):
+        """At v=0, T_aw should equal T_static (recovery factor formula gives 0 correction)."""
+        sol = cb.channel_smooth(T_AIR, P_AIR, X_AIR, 0.0, 0.01, 0.5)
+        assert sol.T_aw == pytest.approx(T_AIR, rel=1e-9)
+
+    def test_T_aw_continuous_across_mach(self):
+        """T_aw must be continuous — no jump at any velocity."""
+        D = 0.05
+        L = 1.0
+        velocities = [0.0, 50.0, 100.0, 150.0, 200.0]
+        T_aws = [cb.channel_smooth(T_AIR, P_AIR, X_AIR, v, D, L).T_aw for v in velocities]
+        # T_aw must be monotonically non-decreasing with velocity
+        for i in range(1, len(T_aws)):
+            assert T_aws[i] >= T_aws[i - 1]
+        # No jump larger than 5 K between adjacent steps
+        for i in range(1, len(T_aws)):
+            assert abs(T_aws[i] - T_aws[i - 1]) < 50.0
+
+    def test_T_aw_increases_with_velocity(self):
+        """T_aw should increase with velocity (kinetic heating)."""
+        sol_slow = cb.channel_smooth(T_AIR, P_AIR, X_AIR, 10.0, 0.05, 1.0)
+        sol_fast = cb.channel_smooth(T_AIR, P_AIR, X_AIR, 200.0, 0.05, 1.0)
+        assert sol_fast.T_aw > sol_slow.T_aw
+
+    def test_mach_computed_internally(self):
+        """M should be v/a(T,X)."""
+        v = 100.0
+        sol = cb.channel_smooth(T_AIR, P_AIR, X_AIR, v, 0.05, 1.0)
+        a = cb.speed_of_sound(T_AIR, X_AIR)
+        assert pytest.approx(v / a, rel=1e-6) == sol.M
+
+    def test_dP_zero_at_zero_velocity(self):
+        sol = cb.channel_smooth(T_AIR, P_AIR, X_AIR, 0.0, 0.01, 0.5)
+        assert sol.dP == pytest.approx(0.0, abs=1e-10)
+
+    def test_dP_scales_with_length(self):
+        """dP should scale linearly with L."""
+        sol1 = cb.channel_smooth(T_AIR, P_AIR, X_AIR, 20.0, 0.01, 0.5)
+        sol2 = cb.channel_smooth(T_AIR, P_AIR, X_AIR, 20.0, 0.01, 1.0)
+        assert sol2.dP == pytest.approx(2.0 * sol1.dP, rel=1e-6)
+
+    def test_roughness_increases_dP(self):
+        """Roughness should increase friction factor and dP."""
+        sol_smooth = cb.channel_smooth(T_AIR, P_AIR, X_AIR, 20.0, 0.01, 0.5, roughness=0.0)
+        sol_rough = cb.channel_smooth(T_AIR, P_AIR, X_AIR, 20.0, 0.01, 0.5, roughness=5e-5)
+        assert sol_rough.f > sol_smooth.f
+        assert sol_rough.dP > sol_smooth.dP
+
+    def test_correlations_accepted(self):
+        """All four correlation names should work without error."""
+        for corr in ["gnielinski", "dittus_boelter", "sieder_tate", "petukhov"]:
+            sol = cb.channel_smooth(T_AIR, P_AIR, X_AIR, 30.0, 0.01, 0.5, correlation=corr)
+            assert sol.h > 0.0
+
+    def test_repr(self):
+        sol = cb.channel_smooth(T_AIR, P_AIR, X_AIR, 20.0, 0.01, 0.5)
+        r = repr(sol)
+        assert "ChannelResult" in r
+        assert "h=" in r
+
+
+class TestChannelRibbed:
+    """Tests for channel_ribbed."""
+
+    def test_nu_exceeds_smooth(self):
+        """Ribbed Nu should be higher than smooth-pipe Nu at same Re."""
+        v = 20.0
+        D = 0.01
+        L = 0.5
+        sol_smooth = cb.channel_smooth(T_AIR, P_AIR, X_AIR, v, D, L)
+        sol_ribbed = cb.channel_ribbed(T_AIR, P_AIR, X_AIR, v, D, L, e_D=0.05, P_e=10.0, alpha=90.0)
+        assert sol_ribbed.Nu > sol_smooth.Nu
+        assert sol_ribbed.h > sol_smooth.h
+
+    def test_dP_exceeds_smooth(self):
+        """Ribbed dP should be higher than smooth-pipe dP."""
+        v = 20.0
+        D = 0.01
+        L = 0.5
+        sol_smooth = cb.channel_smooth(T_AIR, P_AIR, X_AIR, v, D, L)
+        sol_ribbed = cb.channel_ribbed(T_AIR, P_AIR, X_AIR, v, D, L, e_D=0.05, P_e=10.0, alpha=90.0)
+        assert sol_ribbed.dP > sol_smooth.dP
+        assert sol_ribbed.f > sol_smooth.f
+
+    def test_q_with_T_wall(self):
+        T_wall = 800.0
+        sol = cb.channel_ribbed(
+            T_AIR, P_AIR, X_AIR, 20.0, 0.01, 0.5, e_D=0.05, P_e=10.0, alpha=90.0, T_wall=T_wall
+        )
+        assert math.isfinite(sol.q)
+        assert sol.q == pytest.approx(sol.h * (sol.T_aw - T_wall), rel=1e-9)
+
+    def test_higher_rib_height_more_enhancement(self):
+        """Higher e_D should give more Nu enhancement."""
+        v, D, L = 20.0, 0.01, 0.5
+        sol_low = cb.channel_ribbed(T_AIR, P_AIR, X_AIR, v, D, L, e_D=0.03, P_e=10.0, alpha=90.0)
+        sol_high = cb.channel_ribbed(T_AIR, P_AIR, X_AIR, v, D, L, e_D=0.08, P_e=10.0, alpha=90.0)
+        assert sol_high.Nu > sol_low.Nu
+
+    def test_re_same_as_smooth(self):
+        """Re should be the same as smooth-pipe baseline (same fluid, same velocity)."""
+        v, D, L = 20.0, 0.01, 0.5
+        sol_smooth = cb.channel_smooth(T_AIR, P_AIR, X_AIR, v, D, L)
+        sol_ribbed = cb.channel_ribbed(T_AIR, P_AIR, X_AIR, v, D, L, e_D=0.05, P_e=10.0, alpha=90.0)
+        assert sol_ribbed.Re == pytest.approx(sol_smooth.Re, rel=1e-6)
+
+
+class TestChannelDimpled:
+    """Tests for channel_dimpled."""
+
+    def test_nu_exceeds_smooth(self):
+        v, D, L = 20.0, 0.01, 0.5
+        sol_smooth = cb.channel_smooth(T_AIR, P_AIR, X_AIR, v, D, L)
+        sol_dimpled = cb.channel_dimpled(T_AIR, P_AIR, X_AIR, v, D, L, d_Dh=0.2, h_d=0.2, S_d=2.0)
+        assert sol_dimpled.Nu > sol_smooth.Nu
+
+    def test_dP_exceeds_smooth(self):
+        v, D, L = 20.0, 0.01, 0.5
+        sol_smooth = cb.channel_smooth(T_AIR, P_AIR, X_AIR, v, D, L)
+        sol_dimpled = cb.channel_dimpled(T_AIR, P_AIR, X_AIR, v, D, L, d_Dh=0.2, h_d=0.2, S_d=2.0)
+        assert sol_dimpled.dP > sol_smooth.dP
+
+    def test_friction_multiplier_greater_than_one(self):
+        """Dimple friction multiplier must be > 1 (dimples always increase friction)."""
+        v, D, L = 20.0, 0.01, 0.5
+        Re = cb.channel_smooth(T_AIR, P_AIR, X_AIR, v, D, L).Re
+        f_mul = cb.dimple_friction_multiplier(Re, d_Dh=0.2, h_d=0.2)
+        assert f_mul > 1.0
+
+    def test_friction_multiplier_increases_with_depth(self):
+        """Deeper dimples should produce higher friction multiplier."""
+        v, D, L = 20.0, 0.01, 0.5
+        Re = cb.channel_smooth(T_AIR, P_AIR, X_AIR, v, D, L).Re
+        f_shallow = cb.dimple_friction_multiplier(Re, d_Dh=0.2, h_d=0.1)
+        f_deep = cb.dimple_friction_multiplier(Re, d_Dh=0.2, h_d=0.25)
+        assert f_deep > f_shallow
+
+    def test_q_nan_without_T_wall(self):
+        sol = cb.channel_dimpled(T_AIR, P_AIR, X_AIR, 20.0, 0.01, 0.5, d_Dh=0.2, h_d=0.2, S_d=2.0)
+        assert math.isnan(sol.q)
+
+
+class TestChannelPinFin:
+    """Tests for channel_pin_fin."""
+
+    def test_returns_channel_result(self):
+        sol = cb.channel_pin_fin(
+            T_AIR,
+            P_AIR,
+            X_AIR,
+            velocity=PIN_V,
+            channel_height=PIN_H,
+            pin_diameter=PIN_D,
+            S_D=PIN_SD,
+            X_D=PIN_XD,
+            N_rows=PIN_N,
+        )
+        assert isinstance(sol, cb.ChannelResult)
+
+    def test_dP_scales_with_N_rows(self):
+        """dP should scale linearly with N_rows."""
+        kwargs = {
+            "T": T_AIR,
+            "P": P_AIR,
+            "X": X_AIR,
+            "velocity": PIN_V,
+            "channel_height": PIN_H,
+            "pin_diameter": PIN_D,
+            "S_D": PIN_SD,
+            "X_D": PIN_XD,
+        }
+        sol5 = cb.channel_pin_fin(**kwargs, N_rows=5)
+        sol10 = cb.channel_pin_fin(**kwargs, N_rows=10)
+        assert sol10.dP == pytest.approx(2.0 * sol5.dP, rel=1e-6)
+
+    def test_nu_increases_with_re(self):
+        """Nu should increase with Re (velocity)."""
+        kwargs = {
+            "T": T_AIR,
+            "P": P_AIR,
+            "X": X_AIR,
+            "channel_height": PIN_H,
+            "pin_diameter": PIN_D,
+            "S_D": PIN_SD,
+            "X_D": PIN_XD,
+            "N_rows": PIN_N,
+        }
+        sol_low = cb.channel_pin_fin(**kwargs, velocity=PIN_V)
+        sol_high = cb.channel_pin_fin(**kwargs, velocity=PIN_V * 4)
+        assert sol_high.Nu > sol_low.Nu
+
+    def test_staggered_higher_nu_than_inline(self):
+        """Staggered arrays should have higher Nu than inline."""
+        kwargs = {
+            "T": T_AIR,
+            "P": P_AIR,
+            "X": X_AIR,
+            "velocity": PIN_V,
+            "channel_height": PIN_H,
+            "pin_diameter": PIN_D,
+            "S_D": PIN_SD,
+            "X_D": PIN_XD,
+            "N_rows": PIN_N,
+        }
+        sol_stag = cb.channel_pin_fin(**kwargs, is_staggered=True)
+        sol_inline = cb.channel_pin_fin(**kwargs, is_staggered=False)
+        assert sol_stag.Nu > sol_inline.Nu
+
+    def test_staggered_higher_dP_than_inline(self):
+        """Staggered arrays have higher friction than inline."""
+        kwargs = {
+            "T": T_AIR,
+            "P": P_AIR,
+            "X": X_AIR,
+            "velocity": PIN_V,
+            "channel_height": PIN_H,
+            "pin_diameter": PIN_D,
+            "S_D": PIN_SD,
+            "X_D": PIN_XD,
+            "N_rows": PIN_N,
+        }
+        sol_stag = cb.channel_pin_fin(**kwargs, is_staggered=True)
+        sol_inline = cb.channel_pin_fin(**kwargs, is_staggered=False)
+        assert sol_stag.dP > sol_inline.dP
+
+    def test_q_with_T_wall(self):
+        T_wall = 800.0
+        sol = cb.channel_pin_fin(
+            T_AIR,
+            P_AIR,
+            X_AIR,
+            velocity=PIN_V,
+            channel_height=PIN_H,
+            pin_diameter=PIN_D,
+            S_D=PIN_SD,
+            X_D=PIN_XD,
+            N_rows=PIN_N,
+            T_wall=T_wall,
+        )
+        assert math.isfinite(sol.q)
+        assert sol.q == pytest.approx(sol.h * (sol.T_aw - T_wall), rel=1e-9)
+
+    def test_re_based_on_pin_diameter(self):
+        """Re should be rho*v*d/mu (pin diameter, not hydraulic diameter)."""
+        sol = cb.channel_pin_fin(
+            T_AIR,
+            P_AIR,
+            X_AIR,
+            velocity=PIN_V,
+            channel_height=PIN_H,
+            pin_diameter=PIN_D,
+            S_D=PIN_SD,
+            X_D=PIN_XD,
+            N_rows=PIN_N,
+        )
+        rho = cb.density(T_AIR, P_AIR, X_AIR)
+        mu = cb.viscosity(T_AIR, P_AIR, X_AIR)
+        Re_expected = rho * PIN_V * PIN_D / mu
+        assert sol.Re == pytest.approx(Re_expected, rel=1e-6)
+
+
+class TestChannelImpingement:
+    """Tests for channel_impingement."""
+
+    def test_returns_channel_result(self):
+        sol = cb.channel_impingement(
+            T_AIR, P_AIR, X_AIR, mdot_jet=IMP_MDOT, d_jet=IMP_D, z_D=IMP_ZD, A_target=IMP_A
+        )
+        assert isinstance(sol, cb.ChannelResult)
+
+    def test_nu_reasonable_range(self):
+        """Nu should be in a physically reasonable range."""
+        sol = cb.channel_impingement(
+            T_AIR, P_AIR, X_AIR, mdot_jet=IMP_MDOT, d_jet=IMP_D, z_D=IMP_ZD, A_target=IMP_A
+        )
+        assert 10 < sol.Nu < 500
+
+    def test_dP_from_orifice_model(self):
+        """dP = (1/Cd^2) * rho * v_jet^2 / 2."""
+        Cd = 0.65
+        sol = cb.channel_impingement(
+            T_AIR,
+            P_AIR,
+            X_AIR,
+            mdot_jet=IMP_MDOT,
+            d_jet=IMP_D,
+            z_D=IMP_ZD,
+            A_target=IMP_A,
+            Cd_jet=Cd,
+        )
+        rho = cb.density(T_AIR, P_AIR, X_AIR)
+        A_jet = math.pi / 4.0 * IMP_D**2
+        v_jet = IMP_MDOT / (rho * A_jet)
+        dP_expected = (1.0 / Cd**2) * rho * v_jet**2 / 2.0
+        assert sol.dP == pytest.approx(dP_expected, rel=1e-6)
+
+    def test_f_equals_one_over_cd_squared(self):
+        """f should equal 1/Cd^2."""
+        Cd = 0.65
+        sol = cb.channel_impingement(
+            T_AIR,
+            P_AIR,
+            X_AIR,
+            mdot_jet=IMP_MDOT,
+            d_jet=IMP_D,
+            z_D=IMP_ZD,
+            A_target=IMP_A,
+            Cd_jet=Cd,
+        )
+        assert sol.f == pytest.approx(1.0 / Cd**2, rel=1e-9)
+
+    def test_array_lower_nu_than_single_jet(self):
+        """Jet array Nu should be lower than single jet (crossflow degradation)."""
+        kwargs = {
+            "T": T_AIR,
+            "P": P_AIR,
+            "X": X_AIR,
+            "mdot_jet": IMP_MDOT,
+            "d_jet": IMP_D,
+            "z_D": IMP_ZD,
+            "A_target": IMP_A,
+        }
+        sol_single = cb.channel_impingement(**kwargs)
+        sol_array = cb.channel_impingement(**kwargs, x_D=8.0, y_D=8.0)
+        assert sol_array.Nu < sol_single.Nu
+
+    def test_q_with_T_wall(self):
+        T_wall = 800.0
+        sol = cb.channel_impingement(
+            T_AIR,
+            P_AIR,
+            X_AIR,
+            mdot_jet=IMP_MDOT,
+            d_jet=IMP_D,
+            z_D=IMP_ZD,
+            A_target=IMP_A,
+            T_wall=T_wall,
+        )
+        assert math.isfinite(sol.q)
+        assert sol.q == pytest.approx(sol.h * (sol.T_aw - T_wall), rel=1e-9)
+
+    def test_higher_mdot_increases_nu(self):
+        """Higher jet mass flow → higher Re → higher Nu."""
+        kwargs = {
+            "T": T_AIR,
+            "P": P_AIR,
+            "X": X_AIR,
+            "d_jet": IMP_D,
+            "z_D": IMP_ZD,
+            "A_target": IMP_A,
+        }
+        sol_low = cb.channel_impingement(**kwargs, mdot_jet=IMP_MDOT)
+        sol_high = cb.channel_impingement(**kwargs, mdot_jet=IMP_MDOT * 4)
+        assert sol_high.Nu > sol_low.Nu
+
+
+class TestPinFinFriction:
+    """Tests for the scalar pin_fin_friction function."""
+
+    def test_staggered_higher_than_inline(self):
+        Re_d = 20000.0
+        f_stag = cb.pin_fin_friction(Re_d, is_staggered=True)
+        f_inline = cb.pin_fin_friction(Re_d, is_staggered=False)
+        assert f_stag > f_inline
+
+    def test_decreases_with_re(self):
+        """Friction coefficient decreases with Re (power law)."""
+        f_low = cb.pin_fin_friction(5000.0)
+        f_high = cb.pin_fin_friction(50000.0)
+        assert f_high < f_low
+
+    def test_reasonable_range(self):
+        """f_pin should be in a physically reasonable range."""
+        f = cb.pin_fin_friction(20000.0)
+        assert 0.01 < f < 1.0
+
+
+class TestHeatTransferSubmodule:
+    """Tests for the combaero.heat_transfer submodule API."""
+
+    def test_smooth_returns_channel_result(self):
+        sol = ht.smooth(T_AIR, P_AIR, X_AIR, u=20.0, L=0.5, D=0.01)
+        assert isinstance(sol, cb.ChannelResult)
+
+    def test_smooth_matches_direct_call(self):
+        """ht.smooth should give identical result to cb.channel_smooth."""
+        sol_sub = ht.smooth(T_AIR, P_AIR, X_AIR, u=20.0, L=0.5, D=0.01, T_wall=800.0)
+        sol_direct = cb.channel_smooth(T_AIR, P_AIR, X_AIR, 20.0, 0.01, 0.5, T_wall=800.0)
+        assert sol_sub.h == pytest.approx(sol_direct.h, rel=1e-9)
+        assert sol_sub.dP == pytest.approx(sol_direct.dP, rel=1e-9)
+        assert sol_sub.q == pytest.approx(sol_direct.q, rel=1e-9)
+
+    def test_ribbed_returns_channel_result(self):
+        sol = ht.ribbed(T_AIR, P_AIR, X_AIR, u=20.0, L=0.5, D=0.01, e_D=0.05, P_e=10.0, alpha=90.0)
+        assert isinstance(sol, cb.ChannelResult)
+
+    def test_dimpled_returns_channel_result(self):
+        sol = ht.dimpled(T_AIR, P_AIR, X_AIR, u=20.0, L=0.5, D=0.01, d_Dh=0.2, h_d=0.2, S_d=2.0)
+        assert isinstance(sol, cb.ChannelResult)
+
+    def test_pin_fin_returns_channel_result(self):
+        sol = ht.pin_fin(
+            T_AIR, P_AIR, X_AIR, u=PIN_V, H=PIN_H, d=PIN_D, S_D=PIN_SD, X_D=PIN_XD, N_rows=PIN_N
+        )
+        assert isinstance(sol, cb.ChannelResult)
+
+    def test_impingement_returns_channel_result(self):
+        sol = ht.impingement(
+            T_AIR, P_AIR, X_AIR, mdot_jet=IMP_MDOT, d_jet=IMP_D, z_D=IMP_ZD, A_target=IMP_A
+        )
+        assert isinstance(sol, cb.ChannelResult)
+
+    def test_network_solver_pattern(self):
+        """Demonstrate the intended network solver usage pattern."""
+        T_wall = 850.0
+        sol = ht.smooth(T_AIR, P_AIR, X_AIR, u=25.0, L=0.3, D=0.008, T_wall=T_wall)
+        assert sol.h > 0.0
+        assert sol.dP > 0.0
+        assert math.isfinite(sol.q)
+        assert sol.T_aw >= T_AIR
+        assert math.isfinite(sol.M)
+        assert sol.M > 0.0

--- a/src/heat_transfer.cpp
+++ b/src/heat_transfer.cpp
@@ -1,10 +1,14 @@
 #include "../include/heat_transfer.h"
 #include "../include/state.h"
-#include "../include/friction.h"  // friction_petukhov, friction_colebrook
-#include "../include/thermo.h"    // density, cp_mass
-#include "../include/transport.h" // viscosity, thermal_conductivity, prandtl
+#include "../include/friction.h"           // friction_petukhov, friction_colebrook
+#include "../include/thermo.h"             // density, cp_mass, speed_of_sound
+#include "../include/transport.h"          // viscosity, thermal_conductivity, prandtl
+#include "../include/stagnation.h"         // T_adiabatic_wall
+#include "../include/cooling_correlations.h" // rib_*, dimple_*, pin_fin_*, impingement_*
+#include "../include/math_constants.h"     // M_PI cross-platform
 #include <algorithm>
 #include <cmath>
+#include <limits>
 #include <stdexcept>
 #include <string>
 #include <tuple>
@@ -662,4 +666,283 @@ std::tuple<double, double, double> htc_pipe(
     double h = htc_from_nusselt(Nu, k, diameter);
 
     return std::make_tuple(h, Nu, Re);
+}
+
+// -------------------------------------------------------------
+// Internal helper: build ChannelResult from common fields
+// -------------------------------------------------------------
+
+static ChannelResult make_channel_result(
+    double h, double Nu, double Re, double Pr, double f, double dP,
+    double M, double T_aw, double T_wall)
+{
+    double q = std::numeric_limits<double>::quiet_NaN();
+    if (std::isfinite(T_wall)) {
+        q = h * (T_aw - T_wall);
+    }
+    return ChannelResult{h, Nu, Re, Pr, f, dP, M, T_aw, q};
+}
+
+// -------------------------------------------------------------
+// channel_smooth
+// -------------------------------------------------------------
+
+ChannelResult channel_smooth(
+    double T, double P, const std::vector<double>& X,
+    double velocity, double diameter, double length,
+    double T_wall,
+    const std::string& correlation,
+    bool heating,
+    double mu_ratio,
+    double roughness)
+{
+    if (velocity < 0.0) {
+        throw std::invalid_argument("channel_smooth: velocity must be non-negative");
+    }
+    if (diameter <= 0.0) {
+        throw std::invalid_argument("channel_smooth: diameter must be positive");
+    }
+    if (length < 0.0) {
+        throw std::invalid_argument("channel_smooth: length must be non-negative");
+    }
+
+    // Fluid properties — evaluated once
+    double rho = density(T, P, X);
+    double mu  = viscosity(T, P, X);
+    double k   = thermal_conductivity(T, P, X);
+    double Pr  = prandtl(T, P, X);
+
+    // Reynolds number
+    double Re = (velocity > 0.0) ? rho * velocity * diameter / mu : 0.0;
+
+    // Friction factor
+    double e_D = roughness / diameter;
+    double f;
+    if (Re < 2300.0) {
+        f = (Re > 0.0) ? 64.0 / Re : 0.0;
+    } else if (e_D > 0.0 && Re > 4000.0) {
+        f = friction_colebrook(Re, e_D);
+    } else {
+        f = friction_petukhov(std::max(Re, 3000.0));
+    }
+
+    // Nusselt number
+    double Nu;
+    if (Re < 2300.0) {
+        Nu = heating ? NU_LAMINAR_CONST_T : NU_LAMINAR_CONST_Q;
+    } else if (correlation == "gnielinski") {
+        Nu = nusselt_gnielinski(Re, Pr, f);
+    } else if (correlation == "dittus_boelter") {
+        if (Re < 10000.0) {
+            throw std::invalid_argument(
+                "channel_smooth: dittus_boelter requires Re > 10000 (got " +
+                std::to_string(Re) + "). Use gnielinski for transition region.");
+        }
+        Nu = nusselt_dittus_boelter(Re, Pr, heating);
+    } else if (correlation == "sieder_tate") {
+        if (Re < 10000.0) {
+            throw std::invalid_argument(
+                "channel_smooth: sieder_tate requires Re > 10000 (got " +
+                std::to_string(Re) + "). Use gnielinski for transition region.");
+        }
+        Nu = nusselt_sieder_tate(Re, Pr, mu_ratio);
+    } else if (correlation == "petukhov") {
+        if (Re < 10000.0) {
+            throw std::invalid_argument(
+                "channel_smooth: petukhov requires Re > 10000 (got " +
+                std::to_string(Re) + "). Use gnielinski for transition region.");
+        }
+        Nu = nusselt_petukhov(Re, Pr, f);
+    } else {
+        throw std::invalid_argument(
+            "channel_smooth: unknown correlation '" + correlation + "'");
+    }
+
+    double h  = htc_from_nusselt(Nu, k, diameter);
+    double dP = (velocity > 0.0) ? f * (length / diameter) * (rho * velocity * velocity / 2.0) : 0.0;
+
+    // Mach number and T_aw — always continuous
+    double a = speed_of_sound(T, X);
+    double M = (a > 0.0) ? velocity / a : 0.0;
+    const bool turbulent_flow = true;
+    double T_aw = T_adiabatic_wall(T, velocity, T, P, X, turbulent_flow);
+
+    return make_channel_result(h, Nu, Re, Pr, f, dP, M, T_aw, T_wall);
+}
+
+// -------------------------------------------------------------
+// channel_ribbed
+// -------------------------------------------------------------
+
+ChannelResult channel_ribbed(
+    double T, double P, const std::vector<double>& X,
+    double velocity, double diameter, double length,
+    double e_D, double P_e, double alpha,
+    double T_wall,
+    bool heating)
+{
+    // Get smooth-pipe baseline (Gnielinski, no roughness)
+    ChannelResult base = channel_smooth(T, P, X, velocity, diameter, length,
+                                        T_wall, "gnielinski", heating);
+
+    // Apply rib multipliers
+    double enh = combaero::cooling::rib_enhancement_factor(e_D, P_e, alpha);
+    double fmul = combaero::cooling::rib_friction_multiplier(e_D, P_e);
+
+    double Nu_rib = base.Nu * enh;
+    double f_rib  = base.f  * fmul;
+
+    double rho = density(T, P, X);
+    double k   = thermal_conductivity(T, P, X);
+    double h_rib = htc_from_nusselt(Nu_rib, k, diameter);
+    double dP_rib = (velocity > 0.0) ? f_rib * (length / diameter) * (rho * velocity * velocity / 2.0) : 0.0;
+
+    return make_channel_result(h_rib, Nu_rib, base.Re, base.Pr, f_rib, dP_rib,
+                               base.M, base.T_aw, T_wall);
+}
+
+// -------------------------------------------------------------
+// channel_dimpled
+// -------------------------------------------------------------
+
+ChannelResult channel_dimpled(
+    double T, double P, const std::vector<double>& X,
+    double velocity, double diameter, double length,
+    double d_Dh, double h_d, double S_d,
+    double T_wall,
+    bool heating)
+{
+    // Get smooth-pipe baseline
+    ChannelResult base = channel_smooth(T, P, X, velocity, diameter, length,
+                                        T_wall, "gnielinski", heating);
+
+    // Apply dimple multipliers
+    double enh  = combaero::cooling::dimple_nusselt_enhancement(base.Re, d_Dh, h_d, S_d);
+    double fmul = combaero::cooling::dimple_friction_multiplier(base.Re, d_Dh, h_d);
+
+    double Nu_dim = base.Nu * enh;
+    double f_dim  = base.f  * fmul;
+
+    double rho = density(T, P, X);
+    double k   = thermal_conductivity(T, P, X);
+    double h_dim = htc_from_nusselt(Nu_dim, k, diameter);
+    double dP_dim = (velocity > 0.0) ? f_dim * (length / diameter) * (rho * velocity * velocity / 2.0) : 0.0;
+
+    return make_channel_result(h_dim, Nu_dim, base.Re, base.Pr, f_dim, dP_dim,
+                               base.M, base.T_aw, T_wall);
+}
+
+// -------------------------------------------------------------
+// channel_pin_fin
+// -------------------------------------------------------------
+
+ChannelResult channel_pin_fin(
+    double T, double P, const std::vector<double>& X,
+    double velocity, double channel_height, double pin_diameter,
+    double S_D, double X_D, int N_rows,
+    double T_wall,
+    bool is_staggered)
+{
+    if (velocity < 0.0) {
+        throw std::invalid_argument("channel_pin_fin: velocity must be non-negative");
+    }
+    if (pin_diameter <= 0.0) {
+        throw std::invalid_argument("channel_pin_fin: pin_diameter must be positive");
+    }
+    if (channel_height <= 0.0) {
+        throw std::invalid_argument("channel_pin_fin: channel_height must be positive");
+    }
+    if (N_rows < 1) {
+        throw std::invalid_argument("channel_pin_fin: N_rows must be >= 1");
+    }
+    if (S_D <= 1.0) {
+        throw std::invalid_argument("channel_pin_fin: S_D must be > 1 (minimum cross-section constraint)");
+    }
+
+    // Fluid properties
+    double rho = density(T, P, X);
+    double mu  = viscosity(T, P, X);
+    double k   = thermal_conductivity(T, P, X);
+    double Pr  = prandtl(T, P, X);
+
+    // Re based on pin diameter and approach velocity
+    double Re_d = (velocity > 0.0) ? rho * velocity * pin_diameter / mu : 0.0;
+
+    // L_D = channel_height / pin_diameter
+    double L_D = channel_height / pin_diameter;
+
+    // Nu from Metzger correlation
+    double Nu = combaero::cooling::pin_fin_nusselt(Re_d, Pr, L_D, S_D, X_D, is_staggered);
+    double h  = htc_from_nusselt(Nu, k, pin_diameter);
+
+    // Pressure drop: dP = N_rows * f_pin * (rho * v_max^2 / 2)
+    // v_max at minimum cross-section: v_max = v * S_D / (S_D - 1)
+    double v_max = (S_D > 1.0) ? velocity * S_D / (S_D - 1.0) : velocity;
+    double f_pin = (Re_d > 0.0) ? combaero::cooling::pin_fin_friction(Re_d, is_staggered) : 0.0;
+    double dP    = static_cast<double>(N_rows) * f_pin * (rho * v_max * v_max / 2.0);
+
+    // Mach and T_aw based on approach velocity
+    double a   = speed_of_sound(T, X);
+    double M   = (a > 0.0) ? velocity / a : 0.0;
+    const bool turbulent_flow = true;
+    double T_aw = T_adiabatic_wall(T, velocity, T, P, X, turbulent_flow);
+
+    return make_channel_result(h, Nu, Re_d, Pr, f_pin, dP, M, T_aw, T_wall);
+}
+
+// -------------------------------------------------------------
+// channel_impingement
+// -------------------------------------------------------------
+
+ChannelResult channel_impingement(
+    double T, double P, const std::vector<double>& X,
+    double mdot_jet, double d_jet,
+    double z_D, double x_D, double y_D,
+    double A_target,
+    double T_wall,
+    double Cd_jet)
+{
+    if (mdot_jet < 0.0) {
+        throw std::invalid_argument("channel_impingement: mdot_jet must be non-negative");
+    }
+    if (d_jet <= 0.0) {
+        throw std::invalid_argument("channel_impingement: d_jet must be positive");
+    }
+    if (A_target <= 0.0) {
+        throw std::invalid_argument("channel_impingement: A_target must be positive");
+    }
+    if (Cd_jet <= 0.0 || Cd_jet > 1.0) {
+        throw std::invalid_argument("channel_impingement: Cd_jet must be in (0, 1]");
+    }
+
+    // Fluid properties
+    double rho = density(T, P, X);
+    double mu  = viscosity(T, P, X);
+    double k   = thermal_conductivity(T, P, X);
+    double Pr  = prandtl(T, P, X);
+
+    // Jet area and velocity
+    double A_jet  = M_PI / 4.0 * d_jet * d_jet;
+    double v_jet  = (rho > 0.0 && A_jet > 0.0) ? mdot_jet / (rho * A_jet) : 0.0;
+    double Re_jet = (mu > 0.0) ? rho * v_jet * d_jet / mu : 0.0;
+
+    // Nu from Florschuetz / Martin correlation
+    double Nu = combaero::cooling::impingement_nusselt(Re_jet, Pr, z_D, x_D, y_D);
+
+    // h averaged over target area: h = Nu * k / d_jet
+    // (Nu is already an area-averaged value from the correlation)
+    double h = htc_from_nusselt(Nu, k, d_jet);
+
+    // Pressure drop across jet plate: dP = (v_jet/Cd)^2 * rho/2
+    // Equivalent loss coefficient f = 1/Cd^2
+    double f  = 1.0 / (Cd_jet * Cd_jet);
+    double dP = f * rho * v_jet * v_jet / 2.0;
+
+    // Mach and T_aw based on jet velocity
+    double a   = speed_of_sound(T, X);
+    double M   = (a > 0.0) ? v_jet / a : 0.0;
+    const bool turbulent_flow = true;
+    double T_aw = T_adiabatic_wall(T, v_jet, T, P, X, turbulent_flow);
+
+    return make_channel_result(h, Nu, Re_jet, Pr, f, dP, M, T_aw, T_wall);
 }


### PR DESCRIPTION
## Summary

Unified convective heat transfer and pressure drop for all internal cooling channel types into a single `ChannelResult` struct, replacing the previous fragmented approach of separate HTC and friction calls.

## Changes

### New C++ API (`heat_transfer.h` / `heat_transfer.cpp`)
- `ChannelResult` struct: `h`, `Nu`, `Re`, `Pr`, `f`, `dP`, `M`, `T_aw`, `q`
- `channel_smooth` — Gnielinski + Darcy-Weisbach
- `channel_ribbed` — Han et al. rib enhancement
- `channel_dimpled` — Chyu et al. dimple enhancement
- `channel_pin_fin` — Metzger pin-fin array
- `channel_impingement` — Florschuetz/Martin jet impingement
- `pin_fin_friction` scalar (Metzger/Simoneau)

### Design decisions
- **T_aw always continuous**: `T_aw = T_static + r·v²/(2·cp)` with no Mach threshold — smooth Jacobian for network solvers
- **Mach computed internally** from `v/a(T,X)`; not a user input
- **Re-based validators warn, not throw**: power-law correlations (Nu = C·Re^m) are well-behaved outside their fit range — prints to stderr and extrapolates. Geometry ratio limits (e_D, L_D, S_D, etc.) remain hard errors.

### Python
- pybind11 bindings for `ChannelResult` and all `channel_*` functions
- New `combaero.heat_transfer` submodule with keyword-argument API (`ht.smooth`, `ht.ribbed`, `ht.pin_fin`, `ht.impingement`, `ht.dimpled`)
- All symbols exported from `combaero` namespace

### Tests
- 48 new tests in `python/tests/test_channel_flow.py`
- 736 total tests, all passing
- Existing `test_cooling_correlations.py` validation tests updated to match warn-not-throw behaviour

### Documentation
- `API_REFERENCE.md`: ChannelResult field table, T_aw convention, extrapolation policy, pressure drop formulas
- `NETWORK_ROADMAP.md`: thermal elements updated; global `CorrelationResult<T>` validity-flag refactor noted as pending future scope
- `units_data.h`: 27 new entries (283 total); `UNITS.md` regenerated

## Future scope (not in this PR)
Global `CorrelationResult<T>` validity-flag refactor: carry `VALID`/`EXTRAPOLATED`/`INVALID` status through network solver calls instead of throwing or warning. Documented in `NETWORK_ROADMAP.md`.