### PR TITLE
feat: extrapolation validity framework

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ set(SOURCES
     src/materials.cpp
     src/cooling_correlations.cpp
     src/stagnation.cpp
+    src/correlation_status.cpp
 )
 
 # Core library

--- a/docs/UNITS.md
+++ b/docs/UNITS.md
@@ -555,6 +555,15 @@ All functions use consistent units to avoid conversion errors.
 |--------------------|-------------|-------------|
 | `pin_fin_friction` | Re_d: -     | - (f_pin)   |
 
+### correlation_status.h - Extrapolation validity utilities
+
+| Function              | Input Units              | Output Unit     |
+|-----------------------|--------------------------|-----------------|
+| `is_well_behaved`     | v: any, lo: any, hi: any | bool            |
+| `set_warning_handler` | handler: callable(str)   | -               |
+| `get_warning_handler` | -                        | callable(str)   |
+| `suppress_warnings`   | -                        | context manager |
+
 ---
 
 ## Dimensionless Quantities

--- a/include/correlation_status.h
+++ b/include/correlation_status.h
@@ -1,0 +1,43 @@
+#ifndef CORRELATION_STATUS_H
+#define CORRELATION_STATUS_H
+
+#include <cmath>
+#include <functional>
+#include <string>
+
+namespace combaero {
+
+// Status returned by correlations when called outside their validated range.
+// Valid        : input within the correlation's fit range.
+// Extrapolated : input outside fit range; result is a smooth power-law
+//                extrapolation and is still usable in Newton/CasADi solvers.
+enum class CorrelationStatus : uint8_t {
+    Valid        = 0,
+    Extrapolated = 1,
+};
+
+// Warning handler type.  Default implementation writes to std::cerr.
+using WarningHandler = std::function<void(const std::string&)>;
+
+// Replace the global warning handler.  Pass an empty function to suppress all
+// warnings.  Not thread-safe — call once at program startup or use
+// suppress_warnings() in Python for batch runs.
+void set_warning_handler(WarningHandler fn);
+
+// Retrieve the current handler (useful for save/restore patterns).
+WarningHandler get_warning_handler();
+
+// Emit a warning through the current handler.
+void warn(const std::string& msg);
+
+// Returns true when a correlation result is safe to use in a Jacobian-based
+// solver: finite, strictly positive (> lo), and below the overflow guard (< hi).
+// lo defaults to 1e-12 (covers Nu, h, f — all must be positive).
+// hi defaults to 1e15 (well below double overflow).
+inline bool is_well_behaved(double v, double lo = 1e-12, double hi = 1e15) {
+    return std::isfinite(v) && v > lo && v < hi;
+}
+
+}  // namespace combaero
+
+#endif  // CORRELATION_STATUS_H

--- a/include/correlation_status.h
+++ b/include/correlation_status.h
@@ -2,6 +2,7 @@
 #define CORRELATION_STATUS_H
 
 #include <cmath>
+#include <cstdint>
 #include <functional>
 #include <string>
 

--- a/include/heat_transfer.h
+++ b/include/heat_transfer.h
@@ -6,6 +6,8 @@
 #include <utility>
 #include <vector>
 
+#include "correlation_status.h"
+
 // -------------------------------------------------------------
 // Heat Transfer Correlations for Forced Convection
 // -------------------------------------------------------------
@@ -41,7 +43,10 @@
 //   Re      : Reynolds number [-]
 //   Pr      : Prandtl number [-]
 //   heating : true if fluid is being heated, false if cooled
-double nusselt_dittus_boelter(double Re, double Pr, bool heating = true);
+//   status  : if non-null, set to Extrapolated when Re or Pr is outside the
+//             validated range; no warning is emitted in that case
+double nusselt_dittus_boelter(double Re, double Pr, bool heating = true,
+                              combaero::CorrelationStatus* status = nullptr);
 
 // Gnielinski correlation (1976)
 // Nu = (f/8) * (Re - 1000) * Pr / (1 + 12.7 * sqrt(f/8) * (Pr^(2/3) - 1))
@@ -52,14 +57,20 @@ double nusselt_dittus_boelter(double Re, double Pr, bool heating = true);
 //   - 0.5 < Pr < 2000
 //
 // Parameters:
-//   Re  : Reynolds number [-]
-//   Pr  : Prandtl number [-]
-//   f   : Darcy friction factor [-] (use friction_colebrook or similar)
-double nusselt_gnielinski(double Re, double Pr, double f);
+//   Re     : Reynolds number [-]
+//   Pr     : Prandtl number [-]
+//   f      : Darcy friction factor [-] (use friction_colebrook or similar)
+//   status : if non-null, set to Extrapolated when Re or Pr is outside the
+//            validated range; no warning is emitted in that case.
+//            Below Re=2300 a C1-smooth Hermite blend to laminar Nu is used
+//            (the raw formula goes negative at Re<1000).
+double nusselt_gnielinski(double Re, double Pr, double f,
+                          combaero::CorrelationStatus* status = nullptr);
 
 // Gnielinski with automatic friction factor (smooth pipe)
 // Uses Petukhov friction correlation: f = (0.790*ln(Re) - 1.64)^(-2)
-double nusselt_gnielinski(double Re, double Pr);
+double nusselt_gnielinski(double Re, double Pr,
+                          combaero::CorrelationStatus* status = nullptr);
 
 // Sieder-Tate correlation (1936)
 // Nu = 0.027 * Re^0.8 * Pr^(1/3) * (μ_bulk / μ_wall)^0.14
@@ -74,7 +85,10 @@ double nusselt_gnielinski(double Re, double Pr);
 //   Re       : Reynolds number at bulk temperature [-]
 //   Pr       : Prandtl number at bulk temperature [-]
 //   mu_ratio : μ_bulk / μ_wall [-] (typically 0.5-2.0)
-double nusselt_sieder_tate(double Re, double Pr, double mu_ratio = 1.0);
+//   status   : if non-null, set to Extrapolated when Re or Pr is outside the
+//              validated range; no warning is emitted in that case
+double nusselt_sieder_tate(double Re, double Pr, double mu_ratio = 1.0,
+                           combaero::CorrelationStatus* status = nullptr);
 
 // Petukhov correlation (1970)
 // Nu = (f/8) * Re * Pr / (1.07 + 12.7 * sqrt(f/8) * (Pr^(2/3) - 1))
@@ -85,13 +99,17 @@ double nusselt_sieder_tate(double Re, double Pr, double mu_ratio = 1.0);
 //   - 0.5 < Pr < 2000
 //
 // Parameters:
-//   Re  : Reynolds number [-]
-//   Pr  : Prandtl number [-]
-//   f   : Darcy friction factor [-]
-double nusselt_petukhov(double Re, double Pr, double f);
+//   Re     : Reynolds number [-]
+//   Pr     : Prandtl number [-]
+//   f      : Darcy friction factor [-]
+//   status : if non-null, set to Extrapolated when Re or Pr is outside the
+//            validated range; no warning is emitted in that case
+double nusselt_petukhov(double Re, double Pr, double f,
+                        combaero::CorrelationStatus* status = nullptr);
 
 // Petukhov with automatic friction factor (smooth pipe)
-double nusselt_petukhov(double Re, double Pr);
+double nusselt_petukhov(double Re, double Pr,
+                        combaero::CorrelationStatus* status = nullptr);
 
 // -------------------------------------------------------------
 // Laminar Flow (for completeness)

--- a/include/units_data.h
+++ b/include/units_data.h
@@ -436,6 +436,14 @@ inline constexpr Entry function_units[] = {
     // cooling_correlations.h - Pin fin friction (new scalar)
     // -------------------------------------------------------------------------
     {"pin_fin_friction",    "Re_d: -",  "- (f_pin)"},
+
+    // -------------------------------------------------------------------------
+    // correlation_status.h - Extrapolation validity utilities
+    // -------------------------------------------------------------------------
+    {"is_well_behaved",       "v: any, lo: any, hi: any",  "bool"},
+    {"set_warning_handler",   "handler: callable(str)",    "-"},
+    {"get_warning_handler",   "-",                         "callable(str)"},
+    {"suppress_warnings",     "-",                         "context manager"},
 };
 
 inline constexpr std::size_t function_count = sizeof(function_units) / sizeof(Entry);

--- a/python/combaero/__init__.py
+++ b/python/combaero/__init__.py
@@ -293,7 +293,10 @@ try:
         s,
         s_mass,
         saturation_vapor_pressure,
+        get_warning_handler,
+        is_well_behaved,
         set_equivalence_ratio_mass,
+        set_warning_handler,
         set_equivalence_ratio_mole,
         set_fuel_stream_for_CO2,
         set_fuel_stream_for_CO2_dry,
@@ -623,6 +626,39 @@ from . import compressible
 from . import heat_transfer
 from . import incompressible
 from ._flow_solution import FlowSolution
+
+# ---------------------------------------------------------------------------
+# suppress_warnings context manager
+# ---------------------------------------------------------------------------
+from collections.abc import Generator
+from contextlib import contextmanager
+
+
+@contextmanager
+def suppress_warnings() -> Generator[None, None, None]:
+    """Context manager that silences all combaero correlation warnings.
+
+    Useful for batch solver runs where out-of-range extrapolation warnings
+    would flood the output.  The original handler is restored on exit.
+
+    Example::
+
+        with combaero.suppress_warnings():
+            result = solver.run()
+    """
+    try:
+        original = get_warning_handler()
+    except Exception:
+        original = None
+    try:
+        set_warning_handler(lambda msg: None)
+        yield
+    finally:
+        if original is not None:
+            set_warning_handler(original)
+        else:
+            set_warning_handler(None)
+
 
 __all__ = [
     "FlowSolution",

--- a/src/correlation_status.cpp
+++ b/src/correlation_status.cpp
@@ -1,0 +1,31 @@
+#include "correlation_status.h"
+#include <iostream>
+
+namespace combaero {
+
+namespace {
+
+void default_warning_handler(const std::string& msg) {
+    std::cerr << "[combaero] " << msg << "\n";
+}
+
+WarningHandler& global_handler() {
+    static WarningHandler handler = default_warning_handler;
+    return handler;
+}
+
+}  // namespace
+
+void set_warning_handler(WarningHandler fn) {
+    global_handler() = fn ? std::move(fn) : default_warning_handler;
+}
+
+WarningHandler get_warning_handler() {
+    return global_handler();
+}
+
+void warn(const std::string& msg) {
+    global_handler()(msg);
+}
+
+}  // namespace combaero

--- a/tests/test_thermo_transport.cpp
+++ b/tests/test_thermo_transport.cpp
@@ -3170,10 +3170,11 @@ TEST(HeatTransferTest, GnielinskiHermiteBlend) {
     }
 
     // At Re=2300 the Hermite blend must match the Gnielinski formula exactly
-    // (C0 continuity).
-    double f2300 = friction_petukhov(2300.0);
+    // (C0 continuity).  The no-friction overload clamps Re to 3000 for the
+    // Petukhov friction call, so we must use the same f here.
+    double f_used = friction_petukhov(3000.0);
     double Nu_hermite = nusselt_gnielinski(2300.0, 0.7);
-    double f8 = f2300 / 8.0;
+    double f8 = f_used / 8.0;
     double denom = 1.0 + 12.7 * std::sqrt(f8) * (std::pow(0.7, 2.0/3.0) - 1.0);
     double Nu_formula = f8 * (2300.0 - 1000.0) * 0.7 / denom;
     EXPECT_NEAR(Nu_hermite, Nu_formula, Nu_formula * 0.001);  // 0.1% tolerance

--- a/tests/test_thermo_transport.cpp
+++ b/tests/test_thermo_transport.cpp
@@ -10,6 +10,9 @@
 #include "../include/acoustics.h"
 #include "../include/state.h"
 #include "../include/math_constants.h"  // MSVC compatibility for M_PI
+#include "../include/heat_transfer.h"
+#include "../include/correlation_status.h"
+#include <cmath>
 #include <vector>
 
 using namespace combaero;
@@ -3088,12 +3091,25 @@ TEST(HeatTransferTest, DittusBoelterBasic) {
 }
 
 TEST(HeatTransferTest, DittusBoelterValidRange) {
-    // Should throw for Re < 10000
-    EXPECT_THROW(nusselt_dittus_boelter(5000, 0.7), std::invalid_argument);
+    // Re < 10000: warns and extrapolates (power law — no divergence)
+    double Nu_low_Re;
+    EXPECT_NO_THROW(Nu_low_Re = nusselt_dittus_boelter(5000, 0.7));
+    EXPECT_GT(Nu_low_Re, 0.0);
+    EXPECT_TRUE(std::isfinite(Nu_low_Re));
 
-    // Should throw for Pr outside [0.6, 160]
-    EXPECT_THROW(nusselt_dittus_boelter(50000, 0.5), std::invalid_argument);
-    EXPECT_THROW(nusselt_dittus_boelter(50000, 200), std::invalid_argument);
+    // Pr outside [0.6, 160]: warns and extrapolates
+    double Nu_low_Pr, Nu_high_Pr;
+    EXPECT_NO_THROW(Nu_low_Pr = nusselt_dittus_boelter(50000, 0.5));
+    EXPECT_GT(Nu_low_Pr, 0.0);
+    EXPECT_NO_THROW(Nu_high_Pr = nusselt_dittus_boelter(50000, 200));
+    EXPECT_GT(Nu_high_Pr, 0.0);
+
+    // CorrelationStatus out-param: Extrapolated when outside range
+    combaero::CorrelationStatus st;
+    nusselt_dittus_boelter(5000, 0.7, true, &st);
+    EXPECT_EQ(st, combaero::CorrelationStatus::Extrapolated);
+    nusselt_dittus_boelter(50000, 0.7, true, &st);
+    EXPECT_EQ(st, combaero::CorrelationStatus::Valid);
 }
 
 TEST(HeatTransferTest, GnielinskiBasic) {
@@ -3120,13 +3136,56 @@ TEST(HeatTransferTest, GnielinskiWithFriction) {
 }
 
 TEST(HeatTransferTest, GnielinskiValidRange) {
-    // Should throw for Re outside [2300, 5e6]
-    EXPECT_THROW(nusselt_gnielinski(2000, 0.7), std::invalid_argument);
-    EXPECT_THROW(nusselt_gnielinski(6e6, 0.7), std::invalid_argument);
+    // Re outside [2300, 5e6]: warns and extrapolates (or uses Hermite blend)
+    double Nu_low_Re, Nu_high_Re;
+    EXPECT_NO_THROW(Nu_low_Re = nusselt_gnielinski(2000, 0.7));
+    EXPECT_GT(Nu_low_Re, 0.0);
+    EXPECT_TRUE(std::isfinite(Nu_low_Re));
+    EXPECT_NO_THROW(Nu_high_Re = nusselt_gnielinski(6e6, 0.7));
+    EXPECT_GT(Nu_high_Re, 0.0);
+    EXPECT_TRUE(std::isfinite(Nu_high_Re));
 
-    // Should throw for Pr outside [0.5, 2000]
-    EXPECT_THROW(nusselt_gnielinski(50000, 0.4), std::invalid_argument);
-    EXPECT_THROW(nusselt_gnielinski(50000, 3000), std::invalid_argument);
+    // Pr outside [0.5, 2000]: warns and extrapolates
+    double Nu_low_Pr, Nu_high_Pr;
+    EXPECT_NO_THROW(Nu_low_Pr = nusselt_gnielinski(50000, 0.4));
+    EXPECT_GT(Nu_low_Pr, 0.0);
+    EXPECT_NO_THROW(Nu_high_Pr = nusselt_gnielinski(50000, 3000));
+    EXPECT_GT(Nu_high_Pr, 0.0);
+
+    // CorrelationStatus out-param
+    combaero::CorrelationStatus st;
+    nusselt_gnielinski(2000, 0.7, &st);
+    EXPECT_EQ(st, combaero::CorrelationStatus::Extrapolated);
+    nusselt_gnielinski(50000, 0.7, &st);
+    EXPECT_EQ(st, combaero::CorrelationStatus::Valid);
+}
+
+TEST(HeatTransferTest, GnielinskiHermiteBlend) {
+    // Below Re=2300 the raw formula goes negative; Hermite blend must give
+    // positive, finite Nu for all Re in [0, 2300].
+    for (double Re : {100.0, 500.0, 1000.0, 1500.0, 2000.0, 2299.0}) {
+        double Nu = nusselt_gnielinski(Re, 0.7);
+        EXPECT_GT(Nu, 0.0) << "Nu must be positive at Re=" << Re;
+        EXPECT_TRUE(std::isfinite(Nu)) << "Nu must be finite at Re=" << Re;
+    }
+
+    // At Re=2300 the Hermite blend must match the Gnielinski formula exactly
+    // (C0 continuity).
+    double f2300 = friction_petukhov(2300.0);
+    double Nu_hermite = nusselt_gnielinski(2300.0, 0.7);
+    double f8 = f2300 / 8.0;
+    double denom = 1.0 + 12.7 * std::sqrt(f8) * (std::pow(0.7, 2.0/3.0) - 1.0);
+    double Nu_formula = f8 * (2300.0 - 1000.0) * 0.7 / denom;
+    EXPECT_NEAR(Nu_hermite, Nu_formula, Nu_formula * 0.001);  // 0.1% tolerance
+
+    // C1 continuity at Re=2300: numerical derivative from both sides must match
+    // within 1% (finite-difference step h=1).
+    double h_step = 1.0;
+    double dNu_below = (nusselt_gnielinski(2300.0, 0.7) -
+                        nusselt_gnielinski(2300.0 - h_step, 0.7)) / h_step;
+    double dNu_above = (nusselt_gnielinski(2300.0 + h_step, 0.7) -
+                        nusselt_gnielinski(2300.0, 0.7)) / h_step;
+    EXPECT_NEAR(dNu_below, dNu_above, std::abs(dNu_above) * 0.01);
 }
 
 TEST(HeatTransferTest, SiederTateBasic) {


### PR DESCRIPTION
## Summary

Implements the project-wide extrapolation and validity framework for correlation functions, prioritising Jacobian stability for Newton/CasADi network solvers.

## Changes

### New files
- `include/correlation_status.h`: `CorrelationStatus` enum (`Valid`/`Extrapolated`), `WarningHandler` typedef, `set_warning_handler()`, `get_warning_handler()`, `warn()`, `is_well_behaved()` inline utility
- `src/correlation_status.cpp`: global handler storage, default stderr output

### Core refactor: 4 Nusselt scalar functions
Re and Pr out-of-range now **warn + extrapolate** instead of throw:
- `nusselt_dittus_boelter` — Re < 10000, Pr outside [0.6, 160]
- `nusselt_gnielinski` — Re outside [2300, 5e6], Pr outside [0.5, 2000]
- `nusselt_sieder_tate` — Re < 10000, Pr outside [0.7, 16700]
- `nusselt_petukhov` — Re outside [1e4, 5e6], Pr outside [0.5, 2000]

All four get an optional `CorrelationStatus* status = nullptr` out-param (zero cost when unused). Physical impossibilities (`f <= 0`, `mu_ratio <= 0`) still throw.

### Gnielinski C1-smooth Hermite blend (Re < 2300)
The raw Gnielinski formula goes negative at Re < 1000. A **cubic Hermite blend** from laminar Nu (3.66) to Gnielinski at Re=2300 matches value and first derivative at the boundary. Gradient is continuous — safe for Newton Jacobians.

### Python API
- `combaero.set_warning_handler(callable | None)` — replace global handler
- `combaero.get_warning_handler()` — retrieve current handler
- `combaero.is_well_behaved(v, lo=1e-12, hi=1e15)` — Jacobian-safety check
- `combaero.suppress_warnings()` — context manager for batch solver runs

### Tests
- C++ (`tests/test_thermo_transport.cpp`): `EXPECT_THROW` replaced with `EXPECT_NO_THROW` + finite+positive for all Re/Pr limits; new `GnielinskiHermiteBlend` test and C1 continuity check (numerical derivative match within 1% at Re=2300)
- Python (`python/tests/test_heat_transfer.py`): 17 new tests covering extrapolation, `is_well_behaved`, `suppress_warnings`, `set_warning_handler`

### Docs
- `docs/API_REFERENCE.md`: Extrapolation Policy section with usage examples
- `include/units_data.h` + `docs/UNITS.md` regenerated (287 entries)

## What is NOT changing

| Item | Reason |
|---|---|
| Geometry ratio throws (`e_D`, `L_D`, `S_D`, `z_D`, `alpha`) | Correlation form changes — not smooth extrapolation |
| Physical impossibility throws (`f <= 0`, zero diameter) | Modelling error |
| Material k(T) throws | Polynomial fits diverge badly |
| Film/effusion throws | Not in network solver path |

## Test results

**753 Python tests pass** (736 existing + 17 new)
