### PR TITLE
chore: bump version 0.0.2 -> 0.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ endif()
 
 set(_proj_version "${SKBUILD_PROJECT_VERSION}")
 if(NOT _proj_version)
-    set(_proj_version "0.0.2")
+    set(_proj_version "0.1.0")
 endif()
 
 project(${_proj_name} LANGUAGES CXX VERSION ${_proj_version})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "combaero"
-version = "0.0.2"
+version = "0.1.0"
 description = "Combustion and aerothermal tools (C++ core with Python bindings)"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/python/README.md
+++ b/python/README.md
@@ -24,7 +24,7 @@ The recommended workflow is from the repository root; see the top-level README f
 
 ```bash
 python -m build --wheel
-python -m pip install dist/combaero-0.0.1-*.whl
+python -m pip install dist/combaero-0.1.0-*.whl
 ```
 
 ## Usage


### PR DESCRIPTION
Version bump as tracked in TODO.md release checklist.

## Changes
- `pyproject.toml`: `version = "0.1.0"`
- `CMakeLists.txt`: fallback `_proj_version = "0.1.0"`
- `python/README.md`: fix stale wheel install command `0.0.1` → `0.1.0`

Note: `__version__` in Python reads dynamically from `importlib.metadata` — no change needed there.