### PR TITLE
feat(network): implement strict boundary validation rules

### DIFF
--- a/python/combaero/network/__init__.py
+++ b/python/combaero/network/__init__.py
@@ -1,5 +1,7 @@
 from .components import (
     BoundaryNode,
+    PressureBoundary,
+    MassFlowBoundary,
     MixtureState,
     MomentumChamberNode,
     NetworkElement,
@@ -12,6 +14,8 @@ from .graph import FlowNetwork
 
 __all__: list[str] = [
     "BoundaryNode",
+    "PressureBoundary",
+    "MassFlowBoundary",
     "MixtureState",
     "MomentumChamberNode",
     "NetworkElement",

--- a/python/combaero/network/components.py
+++ b/python/combaero/network/components.py
@@ -91,7 +91,21 @@ class MomentumChamberNode(NetworkNode):
     """
     Similar to a plenum, but preserves dynamic pressure.
     Enforces P_total = P_static + 0.5 * rho * v^2 instead of P_total = P_static.
+    Supports directional flow vectors (port angles) for momentum conservation.
     """
+
+    def __init__(self, id: str, port_angles_deg: dict[str, float] | None = None):
+        super().__init__(id)
+        # Dictionary mapping connected element IDs to angle relative to chamber axis [deg]
+        self.port_angles_deg: dict[str, float] = port_angles_deg or {}
+
+    def set_port_angle(self, element_id: str, angle_deg: float) -> None:
+        """Set the angle of the flow for a specific connected element."""
+        self.port_angles_deg[element_id] = angle_deg
+
+    def get_port_angle(self, element_id: str) -> float:
+        """Get the angle of the flow for a specific connected element (defaults to 0.0)."""
+        return self.port_angles_deg.get(element_id, 0.0)
 
     def unknowns(self) -> list[str]:
         return [f"{self.id}.P", f"{self.id}.P_total"]

--- a/python/combaero/network/components.py
+++ b/python/combaero/network/components.py
@@ -124,7 +124,8 @@ class MomentumChamberNode(NetworkNode):
 
 class BoundaryNode(NetworkNode):
     """
-    Supplies fixed state values. Contributes no unknowns and no residuals.
+    Base class for nodes that supply fixed state values.
+    Contributes no unknowns and no residuals.
     """
 
     def unknowns(self) -> list[str]:
@@ -135,6 +136,24 @@ class BoundaryNode(NetworkNode):
 
     def resolve_topology(self, graph: "FlowNetwork") -> None:
         pass
+
+
+class PressureBoundary(BoundaryNode):
+    """
+    A boundary node where pressure is fixed and known.
+    Essential as a reference pressure and absolute mass sink/source for the network.
+    """
+
+    pass
+
+
+class MassFlowBoundary(BoundaryNode):
+    """
+    A boundary node where mass flow is fixed and known.
+    Cannot exclusively define a network, a pressure reference is also required.
+    """
+
+    pass
 
 
 class OrificeElement(NetworkElement):

--- a/python/combaero/network/graph.py
+++ b/python/combaero/network/graph.py
@@ -72,3 +72,20 @@ class FlowNetwork:
             node.resolve_topology(self)
         for element in self.elements.values():
             element.resolve_topology(self)
+
+    def validate(self) -> None:
+        """
+        Validates the network topology.
+        Enforces that the network contains at least one PressureBoundary to act
+        as a pressure reference and mass sink/source.
+        """
+        from .components import PressureBoundary
+
+        has_pressure_boundary = any(
+            isinstance(node, PressureBoundary) for node in self.nodes.values()
+        )
+        if not has_pressure_boundary:
+            raise ValueError(
+                "FlowNetwork validation failed: The network must contain at least "
+                "one PressureBoundary to serve as a reference."
+            )

--- a/python/tests/test_network_blocks.py
+++ b/python/tests/test_network_blocks.py
@@ -1,10 +1,10 @@
 import combaero as cb
 from combaero.network.components import (
-    BoundaryNode,
     MixtureState,
     OrificeElement,
     PipeElement,
     PlenumNode,
+    PressureBoundary,
 )
 
 
@@ -27,9 +27,9 @@ def test_atomic_network_components():
     )
 
     # 2. Instantiate nodes (Boundary, intermediate Plenum, Sink)
-    inlet = BoundaryNode("inlet")
+    inlet = PressureBoundary("inlet")
     node_1 = PlenumNode("node_1")
-    _outlet = BoundaryNode("outlet")
+    _outlet = PressureBoundary("outlet")
 
     # 3. Instantiate elements
     pipe_1 = PipeElement(
@@ -84,9 +84,9 @@ def test_flownetwork_topology():
     """
     graph = cb.network.FlowNetwork()
 
-    inlet = cb.network.BoundaryNode("inlet")
+    inlet = cb.network.PressureBoundary("inlet")
     node_1 = cb.network.PlenumNode("node_1")
-    outlet = cb.network.BoundaryNode("outlet")
+    outlet = cb.network.PressureBoundary("outlet")
 
     pipe = cb.network.PipeElement(
         id="pipe_1", from_node="inlet", to_node="node_1", length=2.0, diameter=0.15, roughness=1e-5
@@ -112,3 +112,57 @@ def test_flownetwork_topology():
 
     # 4. Verify post-resolution auto-discovery
     assert orifice.upstream_diameter == 0.15
+
+
+def test_flownetwork_validation():
+    """
+    Test 4: Validates the FlowNetwork boundary conditions checker.
+    """
+    import pytest
+
+    # Test invalid network (only MassFlowBoundary)
+    graph_invalid = cb.network.FlowNetwork()
+    inlet = cb.network.MassFlowBoundary("inlet_mf")
+    node_1 = cb.network.PlenumNode("node_1")
+    outlet = cb.network.MassFlowBoundary("outlet_mf")
+    pipe = cb.network.PipeElement(
+        id="pipe_1",
+        from_node="inlet_mf",
+        to_node="node_1",
+        length=2.0,
+        diameter=0.15,
+        roughness=1e-5,
+    )
+    orifice = cb.network.OrificeElement(
+        id="orf_1", from_node="node_1", to_node="outlet_mf", Cd=0.6, area=0.005
+    )
+
+    graph_invalid.add_node(inlet)
+    graph_invalid.add_node(node_1)
+    graph_invalid.add_node(outlet)
+    graph_invalid.add_element(pipe)
+    graph_invalid.add_element(orifice)
+
+    with pytest.raises(ValueError, match="at least one PressureBoundary"):
+        graph_invalid.validate()
+
+    # Test valid network (at least 1 PressureBoundary)
+    graph_valid = cb.network.FlowNetwork()
+    inlet_pb = cb.network.PressureBoundary("inlet_pb")
+    graph_valid.add_node(inlet_pb)
+    graph_valid.add_node(node_1)
+    graph_valid.add_node(outlet)
+
+    pipe_pb = cb.network.PipeElement(
+        id="pipe_pb",
+        from_node="inlet_pb",
+        to_node="node_1",
+        length=2.0,
+        diameter=0.15,
+        roughness=1e-5,
+    )
+    graph_valid.add_element(pipe_pb)
+    graph_valid.add_element(orifice)
+
+    # Should not raise any error
+    graph_valid.validate()

--- a/python/tests/test_network_blocks.py
+++ b/python/tests/test_network_blocks.py
@@ -65,6 +65,11 @@ def test_momentum_chamber_network():
     assert "chamber_1.P" in unknowns
     assert "chamber_1.P_total" in unknowns
 
+    # 1b. Verify directional flow vectors (angles)
+    assert node_mc.get_port_angle("pipe_in") == 0.0  # default
+    node_mc.set_port_angle("pipe_in", 45.0)
+    assert node_mc.get_port_angle("pipe_in") == 45.0
+
     # Placeholder residuals ensure conservation equations can later be injected
     state = cb.network.MixtureState(1e5, 1.1e5, 300.0, 300.0, 1.0, [0.0] * 14)
     residuals = node_mc.residuals(state)


### PR DESCRIPTION
## Description
Updates the FlowNetwork validation logic to enforce stricter rules on boundary conditions. 

- Created `PressureBoundary` and `MassFlowBoundary`
- Implemented `FlowNetwork.validate()` to ensure at least one `PressureBoundary` is present.
- Updated topology tests.

## Testing
- Pytest network topology tests updated to include these validation tests.