### PR TITLE
feat: harden network validation and fix solver bugs

### DIFF
--- a/python/combaero/network/components.py
+++ b/python/combaero/network/components.py
@@ -142,6 +142,18 @@ class PressureBoundary(NetworkNode):
     Essential as a reference pressure and absolute mass sink/source for the network.
     """
 
+    def __init__(
+        self,
+        id: str,
+        P_total: float = 101325.0,
+        T_total: float = 300.0,
+        X: list[float] | None = None,
+    ) -> None:
+        super().__init__(id)
+        self.P_total = P_total
+        self.T_total = T_total
+        self.X = X
+
     def unknowns(self) -> list[str]:
         return []
 
@@ -154,15 +166,29 @@ class PressureBoundary(NetworkNode):
 
 class MassFlowBoundary(NetworkNode):
     """
-    Supplies fixed mass flow and stagnation temperature. Contributes no unknowns and no residuals.
+    Supplies fixed mass flow and stagnation temperature. Its pressure floats to satisfy the flow equations.
     Cannot exclusively define a network, a pressure reference is also required.
     """
 
+    def __init__(
+        self,
+        id: str,
+        m_dot: float = 0.1,
+        T_total: float = 300.0,
+        X: list[float] | None = None,
+    ) -> None:
+        super().__init__(id)
+        self.m_dot = m_dot
+        self.T_total = T_total
+        self.X = X
+
     def unknowns(self) -> list[str]:
-        return []
+        # Pressure floats to whatever is required to push the defined mass flow
+        return [f"{self.id}.P", f"{self.id}.P_total"]
 
     def residuals(self, state: MixtureState) -> list[float]:
-        return []
+        # Stagnation assumptions
+        return [state.P_total - state.P]
 
     def resolve_topology(self, graph: "FlowNetwork") -> None:
         pass

--- a/python/combaero/network/solver.py
+++ b/python/combaero/network/solver.py
@@ -33,14 +33,16 @@ class NetworkSolver:
 
         # Iterate through interior nodes and gather unknowns
         for node_id, node in self.network.nodes.items():
-            if not isinstance(node, (PressureBoundary, MassFlowBoundary)):
+            if not isinstance(node, PressureBoundary):
                 unknowns = node.unknowns()
                 if unknowns:
                     start_idx = len(x0_list)
                     for unk in unknowns:
                         self.unknown_names.append(unk)
-                        # Very simple initial guess logic based on variable name
-                        if unk.endswith(".P") or unk.endswith(".P_total"):
+                        guess_dict = getattr(node, "initial_guess", {})
+                        if unk in guess_dict:
+                            x0_list.append(guess_dict[unk])
+                        elif unk.endswith(".P") or unk.endswith(".P_total"):
                             x0_list.append(101325.0)  # Default 1 atm
                         elif unk.endswith(".T") or unk.endswith(".T_total"):
                             x0_list.append(300.0)
@@ -81,7 +83,7 @@ class NetworkSolver:
             P_stat = guess.get(f"{node.id}.P", P_tot)
             T_tot = guess.get(f"{node.id}.T_total", getattr(node, "T_total", 300.0))
             T_stat = guess.get(f"{node.id}.T", T_tot)
-            X = getattr(node, "X", X_air)
+            X = getattr(node, "X", None) or X_air
             return MixtureState(P=P_stat, P_total=P_tot, T=T_stat, T_total=T_tot, m_dot=0.0, X=X)
 
         if isinstance(node, MassFlowBoundary):
@@ -89,8 +91,20 @@ class NetworkSolver:
             m = getattr(node, "m_dot", 0.1)
             T_tot = guess.get(f"{node.id}.T_total", getattr(node, "T_total", 300.0))
             T_stat = guess.get(f"{node.id}.T", T_tot)
-            X = getattr(node, "X", X_air)
-            return MixtureState(P=101325.0, P_total=101325.0, T=T_stat, T_total=T_tot, m_dot=m, X=X)
+            X = getattr(node, "X", None) or X_air
+
+            p_val = guess.get(f"{node.id}.P", 101325.0)
+            ptot_val = guess.get(f"{node.id}.P_total", 101325.0)
+
+            indices = self._unknown_indices.get(node.id, [])
+            unknowns = node.unknowns()
+            for i, unk in zip(indices, unknowns, strict=False):
+                if unk.endswith(".P"):
+                    p_val = x[i]
+                elif unk.endswith(".P_total"):
+                    ptot_val = x[i]
+
+            return MixtureState(P=p_val, P_total=ptot_val, T=T_stat, T_total=T_tot, m_dot=m, X=X)
 
         # For interior nodes, unpack from x
         indices = self._unknown_indices.get(node.id, [])
@@ -121,7 +135,7 @@ class NetworkSolver:
 
         # 1. Node Residuals (P_total constraint + Mass Conservation)
         for node_id, node in self.network.nodes.items():
-            if isinstance(node, (PressureBoundary, MassFlowBoundary)):
+            if isinstance(node, PressureBoundary):
                 continue
 
             # Node thermodynamic constraints
@@ -136,6 +150,9 @@ class NetworkSolver:
 
             m_dot_in = 0.0
             m_dot_out = 0.0
+
+            if isinstance(node, MassFlowBoundary):
+                m_dot_in += getattr(node, "m_dot", 0.0)
 
             for elem in upstream_elems:
                 indices = self._unknown_indices.get(elem.id)
@@ -175,11 +192,15 @@ class NetworkSolver:
 
         return np.array(res, dtype=float)
 
-    def solve(self, method="hybr") -> dict[str, float]:
+    def solve(self, method="hybr", options=None) -> dict[str, float]:
         """
         Executes the root finding algorithm to solve the network.
         Returns a dictionary mapping unknown names to their solved values.
         """
+        if options is None:
+            # Provide sensible defaults to avoid infinite loops on unphysical bounds
+            options = {"maxiter": 500}
+
         # Ensure topology is resolved before solving
         self.network.resolve_all_topology()
         self.network.validate()
@@ -192,7 +213,7 @@ class NetworkSolver:
             raise ValueError(f"System not square: {len(x0)} unknowns vs {len(res0)} equations.")
 
         # Solve
-        sol = root(self._residuals, x0, method=method)
+        sol = root(self._residuals, x0, method=method, options=options)
 
         if not sol.success:
             import warnings

--- a/python/tests/test_network_scenarios.py
+++ b/python/tests/test_network_scenarios.py
@@ -1,0 +1,240 @@
+import pytest
+
+from combaero.network import (
+    FlowNetwork,
+    MomentumChamberNode,
+    NetworkSolver,
+    OrificeElement,
+    PipeElement,
+    PlenumNode,
+    PressureBoundary,
+)
+
+
+def _get_air_X():
+    """Helper to create standard air composition."""
+    X = [0.0] * 14
+    X[0] = 0.79  # N2
+    X[1] = 0.21  # O2
+    return X
+
+
+def build_pressure_bounds():
+    """Create standard pressure boundaries."""
+    inlet = PressureBoundary("inlet", P_total=150000.0, T_total=300.0, X=_get_air_X())
+    outlet = PressureBoundary("outlet", P_total=100000.0, T_total=300.0, X=_get_air_X())
+    return inlet, outlet
+
+
+def test_step_1_simple_series():
+    """Test: PB -> Pipe -> Plenum -> Pipe -> PB"""
+    graph = FlowNetwork()
+    inlet, outlet = build_pressure_bounds()
+
+    n1 = PlenumNode("n1")
+    p1 = PipeElement("p1", "inlet", "n1", length=2.0, diameter=0.1, roughness=1e-4)
+    p2 = PipeElement("p2", "n1", "outlet", length=2.0, diameter=0.1, roughness=1e-4)
+
+    for n in [inlet, outlet, n1]:
+        graph.add_node(n)
+    for e in [p1, p2]:
+        graph.add_element(e)
+
+    solver = NetworkSolver(graph)
+    sol = solver.solve(method="lm")
+
+    # Verify solution exists and mass is conserved
+    assert "p1.m_dot" in sol
+    assert "p2.m_dot" in sol
+    assert abs(sol["p1.m_dot"] - sol["p2.m_dot"]) < 1e-6
+    assert sol["p1.m_dot"] > 0  # Positive flow from high to low pressure
+
+
+def test_step_2_add_orifices():
+    """Test: PB -> Pipe -> n1 -> Orifice -> mc1 -> Pipe -> PB"""
+    graph = FlowNetwork()
+    inlet, outlet = build_pressure_bounds()
+
+    n1 = PlenumNode("n1")
+    mc1 = MomentumChamberNode("mc1")
+
+    p1 = PipeElement("p1", "inlet", "n1", length=2.0, diameter=0.1, roughness=1e-4)
+    o1 = OrificeElement("o1", "n1", "mc1", Cd=0.6, area=0.005)
+    p2 = PipeElement("p2", "mc1", "outlet", length=2.0, diameter=0.1, roughness=1e-4)
+
+    for n in [inlet, outlet, n1, mc1]:
+        graph.add_node(n)
+    for e in [p1, o1, p2]:
+        graph.add_element(e)
+
+    solver = NetworkSolver(graph)
+    sol = solver.solve(method="lm")
+
+    # Verify mass conservation across all elements
+    assert abs(sol["p1.m_dot"] - sol["o1.m_dot"]) < 1e-6
+    assert abs(sol["o1.m_dot"] - sol["p2.m_dot"]) < 1e-6
+    assert sol["p1.m_dot"] > 0
+
+
+def test_step_3_full_series_no_bypass():
+    """Test: Full user series without bypass"""
+    graph = FlowNetwork()
+    inlet, outlet = build_pressure_bounds()
+
+    n1 = PlenumNode("n1")
+    mc1 = MomentumChamberNode("mc1")
+    n2 = PlenumNode("n2")
+    plen = PlenumNode("plenum")
+    mc2 = MomentumChamberNode("mc2")
+
+    p1 = PipeElement("p1", "inlet", "n1", length=2.0, diameter=0.1, roughness=1e-4)
+    o1 = OrificeElement("o1", "n1", "mc1", Cd=0.6, area=0.008)
+    p2 = PipeElement("p2", "mc1", "n2", length=2.0, diameter=0.1, roughness=1e-4)
+    o2 = OrificeElement("o2", "n2", "plenum", Cd=0.6, area=0.008)
+    p3 = PipeElement("p3", "plenum", "mc2", length=2.0, diameter=0.1, roughness=1e-4)
+    p4 = PipeElement("p4", "mc2", "outlet", length=2.0, diameter=0.1, roughness=1e-4)
+
+    for n in [inlet, outlet, n1, mc1, n2, plen, mc2]:
+        graph.add_node(n)
+    for e in [p1, o1, p2, o2, p3, p4]:
+        graph.add_element(e)
+
+    # Set initial guesses for better convergence
+    n1.initial_guess = {"n1.P": 140000.0, "n1.P_total": 140000.0}
+    mc1.initial_guess = {"mc1.P": 135000.0, "mc1.P_total": 135000.0}
+    n2.initial_guess = {"n2.P": 130000.0, "n2.P_total": 130000.0}
+    plen.initial_guess = {"plenum.P": 120000.0, "plenum.P_total": 120000.0}
+    mc2.initial_guess = {"mc2.P": 110000.0, "mc2.P_total": 110000.0}
+
+    solver = NetworkSolver(graph)
+    sol = solver.solve(method="lm")
+
+    # Verify mass conservation across entire series
+    mass_flows = [sol[f"{e}.m_dot"] for e in ["p1", "o1", "p2", "o2", "p3", "p4"]]
+    for i in range(len(mass_flows) - 1):
+        assert abs(mass_flows[i] - mass_flows[i + 1]) < 1e-6, (
+            f"Mass not conserved between elements {i} and {i + 1}"
+        )
+
+    assert all(mf > 0 for mf in mass_flows), "All mass flows should be positive"
+
+
+def test_step_4_adding_bypass():
+    """Test: Adding bypass branch (mc1 -> orifice -> mc2)"""
+    graph = FlowNetwork()
+    inlet, outlet = build_pressure_bounds()
+
+    n1 = PlenumNode("n1")
+    mc1 = MomentumChamberNode("mc1")
+    n2 = PlenumNode("n2")
+    plen = PlenumNode("plenum")
+    mc2 = MomentumChamberNode("mc2")
+
+    # Main series elements
+    p1 = PipeElement("p1", "inlet", "n1", length=2.0, diameter=0.1, roughness=1e-4)
+    o1 = OrificeElement("o1", "n1", "mc1", Cd=0.6, area=0.008)
+    p2 = PipeElement("p2", "mc1", "n2", length=2.0, diameter=0.1, roughness=1e-4)
+    o2 = OrificeElement("o2", "n2", "plenum", Cd=0.6, area=0.008)
+    p3 = PipeElement("p3", "plenum", "mc2", length=2.0, diameter=0.1, roughness=1e-4)
+    p4 = PipeElement("p4", "mc2", "outlet", length=2.0, diameter=0.1, roughness=1e-4)
+
+    # Bypass branch
+    n_bypass = PlenumNode("n_bypass")
+    p_bypass = PipeElement("p_bypass", "mc1", "n_bypass", length=5.0, diameter=0.08, roughness=1e-4)
+    o_bypass = OrificeElement("o_bypass", "n_bypass", "mc2", Cd=0.6, area=0.005)
+
+    # Add all nodes and elements
+    for n in [inlet, outlet, n1, mc1, n2, plen, mc2, n_bypass]:
+        graph.add_node(n)
+    for e in [p1, o1, p2, o2, p3, p4, p_bypass, o_bypass]:
+        graph.add_element(e)
+
+    # Set initial guesses
+    n1.initial_guess = {"n1.P": 145000.0, "n1.P_total": 145000.0}
+    mc1.initial_guess = {"mc1.P": 140000.0, "mc1.P_total": 140000.0}
+    n_bypass.initial_guess = {"n_bypass.P": 130000.0, "n_bypass.P_total": 130000.0}
+    n2.initial_guess = {"n2.P": 135000.0, "n2.P_total": 135000.0}
+    plen.initial_guess = {"plenum.P": 125000.0, "plenum.P_total": 125000.0}
+    mc2.initial_guess = {"mc2.P": 115000.0, "mc2.P_total": 115000.0}
+
+    solver = NetworkSolver(graph)
+    sol = solver.solve(method="lm")
+
+    # Verify mass conservation at junctions
+    # At mc1: p1.m_dot = p2.m_dot + p_bypass.m_dot
+    assert abs(sol["p1.m_dot"] - (sol["p2.m_dot"] + sol["p_bypass.m_dot"])) < 1e-6
+
+    # At mc2: p3.m_dot + bypass.m_dot = p4.m_dot (bypass joins here)
+    assert abs((sol["p3.m_dot"] + sol["p_bypass.m_dot"]) - sol["p4.m_dot"]) < 1e-6
+
+    # All flows should be positive
+    assert all(sol[f"{e}.m_dot"] > 0 for e in ["p1", "p2", "p3", "p4", "p_bypass"])
+
+    # Bypass should carry less flow than main branch (smaller diameter)
+    assert sol["p_bypass.m_dot"] < sol["p2.m_dot"]
+
+
+def test_network_validation_edge_cases():
+    """Test additional edge cases for network validation"""
+
+    # Test self-loop rejection
+    graph = FlowNetwork()
+    inlet = PressureBoundary("inlet", P_total=150000.0, T_total=300.0, X=_get_air_X())
+    outlet = PressureBoundary("outlet", P_total=100000.0, T_total=300.0, X=_get_air_X())
+
+    graph.add_node(inlet)
+    graph.add_node(outlet)
+
+    # Should raise ValueError for self-loop
+    with pytest.raises(ValueError, match="Self-loops are not permitted"):
+        graph.add_element(OrificeElement("self_loop", "inlet", "inlet", Cd=0.6, area=0.005))
+
+    # Test isolated node detection
+    graph2 = FlowNetwork()
+    inlet2 = PressureBoundary("inlet2", P_total=150000.0, T_total=300.0, X=_get_air_X())
+    outlet2 = PressureBoundary("outlet2", P_total=100000.0, T_total=300.0, X=_get_air_X())
+    isolated = PlenumNode("isolated")
+
+    graph2.add_node(inlet2)
+    graph2.add_node(outlet2)
+    graph2.add_node(isolated)
+    graph2.add_element(OrificeElement("conn", "inlet2", "outlet2", Cd=0.6, area=0.005))
+
+    # Should raise ValueError for isolated node
+    with pytest.raises(ValueError, match="isolated node"):
+        graph2.validate()
+
+
+def test_parallel_elements():
+    """Test parallel elements between same nodes"""
+    graph = FlowNetwork()
+    inlet = PressureBoundary("inlet", P_total=150000.0, T_total=300.0, X=_get_air_X())
+    outlet = PressureBoundary("outlet", P_total=100000.0, T_total=300.0, X=_get_air_X())
+
+    graph.add_node(inlet)
+    graph.add_node(outlet)
+
+    # Two parallel orifices with different areas
+    orf1 = OrificeElement("orf_1", "inlet", "outlet", Cd=0.6, area=0.005)
+    orf2 = OrificeElement("orf_2", "inlet", "outlet", Cd=0.6, area=0.002)
+
+    graph.add_element(orf1)
+    graph.add_element(orf2)
+
+    solver = NetworkSolver(graph)
+    sol = solver.solve(method="lm")
+
+    # Both should have positive flow
+    assert sol["orf_1.m_dot"] > 0
+    assert sol["orf_2.m_dot"] > 0
+
+    # Larger orifice should carry more flow
+    assert sol["orf_1.m_dot"] > sol["orf_2.m_dot"]
+
+    # Total flow should be reasonable
+    total_flow = sol["orf_1.m_dot"] + sol["orf_2.m_dot"]
+    assert total_flow > 0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/python/tests/test_network_solver.py
+++ b/python/tests/test_network_solver.py
@@ -1,6 +1,12 @@
+import math
+
+import pytest
+
 import combaero as cb
 from combaero.network import (
     FlowNetwork,
+    LosslessConnectionElement,
+    MassFlowBoundary,
     NetworkSolver,
     OrificeElement,
     PipeElement,
@@ -9,9 +15,16 @@ from combaero.network import (
 )
 
 
+def _get_air_X():
+    X = [0.0] * 14
+    X[0] = 0.79  # N2
+    X[1] = 0.21  # O2
+    return X
+
+
 def test_network_solver_simple_orifice():
     """
-    Test 1: Simple PressureBoundary -> Orifice -> PressureBoundary.
+    Scenario A (part 1): Simple PressureBoundary -> Orifice -> PressureBoundary.
     Verifies that the solver successfully finds the exact m_dot analytical value.
     """
     graph = FlowNetwork()
@@ -19,9 +32,7 @@ def test_network_solver_simple_orifice():
     inlet = PressureBoundary("inlet")
     inlet.P_total = 500000.0
     inlet.T_total = 300.0
-    inlet.X = [0.0] * 14
-    inlet.X[0] = 0.79  # N2
-    inlet.X[1] = 0.21  # O2
+    inlet.X = _get_air_X()
 
     outlet = PressureBoundary("outlet")
     outlet.P_total = 101325.0
@@ -42,55 +53,215 @@ def test_network_solver_simple_orifice():
     # Analytical check
     rho_in = cb.density(inlet.T_total, inlet.P_total, inlet.X)
     dP = inlet.P_total - outlet.P_total
-    expected_m_dot_incompressible = 0.6 * 0.005 * (2.0 * rho_in * dP) ** 0.5
+    # Orifice m_dot = Cd * A * sqrt(2 * rho * dP)
+    m_dot_analytical, _ = cb.orifice_mdot_and_jacobian(dP, rho_in, 0.6, 0.005)
 
-    # Should be close
-    assert abs(solution["orf_1.m_dot"] - expected_m_dot_incompressible) < 1e-4
+    assert solution["orf_1.m_dot"] == pytest.approx(m_dot_analytical, rel=1e-4)
 
 
-def test_network_solver_pipe_plenum_orifice():
+def test_network_solver_simple_pipe():
     """
-    Test 2: Multi-node network
-    Boundary -> Pipe -> Plenum -> Orifice -> Boundary
-    Verifies mass conservation holds across junctions.
+    Scenario A (part 2): Simple PressureBoundary -> Pipe -> PressureBoundary.
+    Verifies exact Darcy-Weisbach flow scaling.
     """
     graph = FlowNetwork()
 
     inlet = PressureBoundary("inlet")
-    inlet.P_total = 200000.0
+    inlet.P_total = 150000.0
     inlet.T_total = 300.0
-
-    X_air = [0.0] * 14
-    X_air[0] = 0.79
-    X_air[1] = 0.21
-    inlet.X = X_air
-
-    plenum = PlenumNode("plenum")
+    inlet.X = _get_air_X()
 
     outlet = PressureBoundary("outlet")
-    outlet.P_total = 101325.0
+    outlet.P_total = 100000.0
     outlet.T_total = 300.0
-    outlet.X = X_air
+    outlet.X = inlet.X
 
-    pipe = PipeElement("pipe_1", "inlet", "plenum", length=5.0, diameter=0.1, roughness=1e-5)
-    orf = OrificeElement("orf_1", "plenum", "outlet", Cd=0.6, area=0.002)
+    pipe = PipeElement(
+        "pipe_1",
+        "inlet",
+        "outlet",
+        length=10.0,
+        diameter=0.05,
+        roughness=1e-5,
+        friction_model="haaland",
+    )
 
     graph.add_node(inlet)
-    graph.add_node(plenum)
     graph.add_node(outlet)
-
     graph.add_element(pipe)
-    graph.add_element(orf)
 
     solver = NetworkSolver(graph)
-    solution = solver.solve(method="hybr")
+    solution = solver.solve()
 
-    m_dot_pipe = solution["pipe_1.m_dot"]
-    m_dot_orf = solution["orf_1.m_dot"]
+    m_dot_solved = solution["pipe_1.m_dot"]
 
-    assert abs(m_dot_pipe - m_dot_orf) < 1e-6, "Mass not conserved across plenum"
-    assert "plenum.P" in solution
-    assert "plenum.P_total" in solution
+    # Analytical verification
+    rho = cb.density(inlet.T_total, inlet.P_total, inlet.X)
+    mu = cb.viscosity(inlet.T_total, inlet.P_total, inlet.X)
+    A = math.pi * (0.05 / 2) ** 2
+    v = m_dot_solved / (rho * A)
+    Re = max(4.0 * m_dot_solved / (math.pi * 0.05 * mu), 1.0)
+
+    f, _ = cb.friction_and_jacobian("haaland", Re, 1e-5 / 0.05)
+
+    dP_analytical = f * (10.0 / 0.05) * 0.5 * rho * v**2
+    dP_actual = inlet.P_total - outlet.P_total
+
+    assert dP_analytical == pytest.approx(dP_actual, rel=1e-4)
 
 
-#
+def test_network_bc_swapping():
+    """
+    Scenario B: Boundary Condition Swapping (Reverse Lookup).
+    1. MassFlowBoundary -> Pipe -> PressureBoundary. Solve for P at inlet.
+    2. PressureBoundary(P=P_solved) -> Pipe -> PressureBoundary. Solve for m_dot.
+    m_dot should precisely equal the original MassFlowBoundary input.
+    """
+
+    # --- SETUP 1: Prescribe Mass, Solve for Pressure ---
+    graph1 = FlowNetwork()
+    target_m_dot = 0.5  # kg/s
+
+    inlet_m = MassFlowBoundary("inlet")
+    inlet_m.m_dot = target_m_dot
+    inlet_m.T_total = 300.0
+    inlet_m.X = _get_air_X()
+
+    outlet_p = PressureBoundary("outlet")
+    outlet_p.P_total = 100000.0
+    outlet_p.T_total = 300.0
+    outlet_p.X = _get_air_X()
+
+    # Direct connection: MassFlowBoundary natively supports floating its pressure to push flow!
+    pipe1 = PipeElement("pipe_1", "inlet", "outlet", length=5.0, diameter=0.1, roughness=1e-4)
+
+    graph1.add_node(inlet_m)
+    graph1.add_node(outlet_p)
+    graph1.add_element(pipe1)
+
+    solver1 = NetworkSolver(graph1)
+    # Hint the inlet pressure for a faster Newton step
+    inlet_m.initial_guess = {"inlet.P": 110000.0, "inlet.P_total": 110000.0}
+
+    sol1 = solver1.solve()
+
+    # Assert mass flow is conserved
+    assert sol1["pipe_1.m_dot"] == pytest.approx(target_m_dot, rel=1e-6)
+
+    # Store the solved pressure that the MFB had to rise to
+    p_solved = sol1["inlet.P_total"]
+
+    # --- SETUP 2: Prescribe Solved Pressure, Solve for Mass ---
+    graph2 = FlowNetwork()
+    inlet_p = PressureBoundary("inlet")
+    inlet_p.P_total = p_solved
+    inlet_p.T_total = 300.0
+    inlet_p.X = _get_air_X()
+
+    outlet2 = PressureBoundary("outlet")
+    outlet2.P_total = 100000.0
+    outlet2.T_total = 300.0
+    outlet2.X = _get_air_X()
+
+    pipe2 = PipeElement("pipe_1", "inlet", "outlet", length=5.0, diameter=0.1, roughness=1e-4)
+
+    graph2.add_node(inlet_p)
+    graph2.add_node(outlet2)
+    graph2.add_element(pipe2)
+
+    solver2 = NetworkSolver(graph2)
+    sol2 = solver2.solve()
+
+    # Verify the mass flows match mapping the reverse lookup
+    assert sol2["pipe_1.m_dot"] == pytest.approx(target_m_dot, rel=1e-6)
+
+
+def test_network_element_series():
+    """
+    Scenario C: Simple Element Series and Junction Mass Conservation.
+    Boundary -> Pipe1 -> Junction -> Pipe2 -> Boundary
+    """
+    graph = FlowNetwork()
+
+    inlet = PressureBoundary("inlet")
+    inlet.P_total = 110000.0
+    inlet.T_total = 300.0
+    inlet.X = _get_air_X()
+
+    junc = PlenumNode("junc_1")
+
+    outlet = PressureBoundary("outlet")
+    outlet.P_total = 100000.0
+    outlet.T_total = 300.0
+    outlet.X = _get_air_X()
+
+    # Pipe 1 is larger, Pipe 2 is smaller
+    pipe1 = PipeElement("p1", "inlet", "junc_1", length=5.0, diameter=0.1, roughness=0.0)
+    pipe2 = PipeElement("p2", "junc_1", "outlet", length=5.0, diameter=0.05, roughness=0.0)
+
+    graph.add_node(inlet)
+    graph.add_node(junc)
+    graph.add_node(outlet)
+    graph.add_element(pipe1)
+    graph.add_element(pipe2)
+
+    solver = NetworkSolver(graph)
+    # The initial guesses for default boundary variables starts at 101325
+    sol = solver.solve()
+
+    m_p1 = sol["p1.m_dot"]
+    m_p2 = sol["p2.m_dot"]
+
+    # Conservation of mass
+    assert m_p1 == pytest.approx(m_p2, abs=1e-6)
+
+    # Ensure continuity of pressure (P_total across junction is essentially static pressure P)
+    # The pressure drops should equal the total pressure drop (with a small margin for density changes)
+    dP1 = inlet.P_total - sol["junc_1.P"]
+    dP2 = sol["junc_1.P"] - outlet.P_total
+
+    assert (dP1 + dP2) == pytest.approx(inlet.P_total - outlet.P_total, abs=1e-4)
+    # Pipe 2 (smaller) should drop much more pressure than Pipe 1
+    assert dP2 > dP1 * 10
+
+
+def test_network_lossless_connectors():
+    """
+    Scenario D: Lossless Connectors and Plenums.
+    Boundary -> Lossless -> Plenum -> Lossless -> Boundary
+    Mass flow should be essentially unconstrained / infinity if 0 dP, so we set a tiny dP
+    Wait, Lossless connection between two different pressures will diverge.
+    Instead: We put an Orifice AND a lossless in series.
+    Boundary -> Lossless -> Plenum -> Orifice -> Boundary
+    """
+    graph = FlowNetwork()
+
+    inlet = PressureBoundary("inlet")
+    inlet.P_total = 105000.0
+    inlet.T_total = 300.0
+    inlet.X = _get_air_X()
+
+    plen = PlenumNode("plenum_idx")
+
+    outlet = PressureBoundary("outlet")
+    outlet.P_total = 100000.0
+    outlet.T_total = 300.0
+    outlet.X = _get_air_X()
+
+    conn1 = LosslessConnectionElement("l1", "inlet", "plenum_idx")
+    orf1 = OrificeElement("o1", "plenum_idx", "outlet", Cd=0.65, area=0.01)
+
+    graph.add_node(inlet)
+    graph.add_node(plen)
+    graph.add_node(outlet)
+    graph.add_element(conn1)
+    graph.add_element(orf1)
+
+    solver = NetworkSolver(graph)
+    sol = solver.solve()
+
+    # The total pressure in the plenum should perfectly equal the inlet pressure
+    # because the lossless connection drops 0 pressure regardless of flow rate
+    assert sol["plenum_idx.P_total"] == pytest.approx(inlet.P_total, abs=1e-6)
+    # And mass should be conserved
+    assert sol["l1.m_dot"] == pytest.approx(sol["o1.m_dot"], abs=1e-6)


### PR DESCRIPTION
## Changes

### Network Validation Improvements
- Add self-loop rejection in FlowNetwork.add_element()
- Add isolated node detection via BFS reachability check
- Add empty network checks (no nodes/elements)
- Add node connectivity validation

### NetworkSolver Bug Fixes
- Fix X_air species indices (N2=0, O2=1 instead of 11/12)
- Include MassFlowBoundary contributions in node mass conservation
- Guard zero-DOF element KeyError with .get() fallback
- Emit warning on solver convergence failure (sol.success=False)
- Ensure MixtureState.X is never None for boundaries

### Test Coverage
- Add test_network_scenarios.py with comprehensive tests:
  - Tests all scratch.py scenarios (simple series, orifices, full series, bypass)
  - Tests parallel elements between same nodes
  - Tests validation edge cases (self-loops, isolated nodes)
  - Verifies mass conservation across complex junctions
- Update test_network_validation_edge_cases.py to work with hardened validation

### Impact
- Prevents malformed network topologies from reaching the solver
- Fixes incorrect species composition leading to wrong thermodynamic properties
- Ensures mass conservation includes boundary mass flows
- Provides better error messages and warnings for debugging
