### PR TITLE
feat: optimize CI/CD for docs-only changes with gatekeeper status-check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,43 @@ on:
     branches: [ main, master ]
 
 jobs:
+  changes:
+    name: Detect Changed Paths
+    runs-on: ubuntu-latest
+    outputs:
+      source: ${{ steps.filter.outputs.source }}
+      documentation: ${{ steps.filter.outputs.documentation }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Detect source vs documentation changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            source:
+              - 'src/**'
+              - 'include/**'
+              - 'python/**'
+              - 'tests/**'
+              - 'scripts/**'
+              - 'examples/**'
+              - '.github/workflows/**'
+              - 'CMakeLists.txt'
+              - 'pyproject.toml'
+              - '.pre-commit-config.yaml'
+              - 'ruff.toml'
+              - 'Makefile'
+            documentation:
+              - 'docs/**'
+              - 'README.md'
+              - '**/*.md'
+
   lint:
     name: Lint & Style Checks
+    needs: changes
+    if: needs.changes.outputs.source == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -30,7 +65,8 @@ jobs:
 
   build-and-test:
     name: Build & Test C++ (${{ matrix.os }}, ${{ matrix.build_type }})
-    needs: lint
+    needs: [changes, lint]
+    if: needs.changes.outputs.source == 'true'
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -69,7 +105,8 @@ jobs:
 
   build-mingw:
     name: Build MinGW
-    needs: lint
+    needs: [changes, lint]
+    if: needs.changes.outputs.source == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -90,3 +127,35 @@ jobs:
 
       - name: Build Windows binaries
         run: cmake --build build-mingw --config Release
+
+  status-check:
+    name: status-check
+    needs: [changes, lint, build-and-test, build-mingw]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Evaluate CI outcomes
+        shell: bash
+        run: |
+          source_changed="${{ needs.changes.outputs.source }}"
+          lint_result="${{ needs.lint.result }}"
+          build_result="${{ needs.build-and-test.result }}"
+          mingw_result="${{ needs.build-mingw.result }}"
+
+          echo "source_changed=${source_changed}"
+          echo "lint_result=${lint_result}"
+          echo "build_result=${build_result}"
+          echo "mingw_result=${mingw_result}"
+
+          if [[ "${source_changed}" != "true" ]]; then
+            echo "Documentation-only (or non-source) change detected. Passing status-check."
+            exit 0
+          fi
+
+          if [[ "${lint_result}" == "success" && "${build_result}" == "success" && "${mingw_result}" == "success" ]]; then
+            echo "All source-related jobs succeeded."
+            exit 0
+          fi
+
+          echo "One or more source-related jobs failed or were cancelled."
+          exit 1

--- a/.github/workflows/validation-tests.yml
+++ b/.github/workflows/validation-tests.yml
@@ -3,34 +3,49 @@ name: Validation Tests
 on:
   push:
     branches: [ main, master ]
-    paths:
-      - 'src/**'
-      - 'include/**'
-      - 'python/**'
-      - 'cantera_validation_tests/**'
-      - 'scripts/**'
-      - '.github/workflows/**'
-      - 'ruff.toml'
-      - '.pre-commit-config.yaml'
-      - '.python-version'
-      - 'Makefile'
   pull_request:
     branches: [ main, master ]
-    paths:
-      - 'src/**'
-      - 'include/**'
-      - 'python/**'
-      - 'cantera_validation_tests/**'
-      - 'scripts/**'
-      - '.github/workflows/**'
-      - 'ruff.toml'
-      - '.pre-commit-config.yaml'
-      - '.python-version'
-      - 'Makefile'
 
 jobs:
+  changes:
+    name: Detect Changed Paths
+    runs-on: ubuntu-latest
+    outputs:
+      source: ${{ steps.filter.outputs.source }}
+      documentation: ${{ steps.filter.outputs.documentation }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Detect source vs documentation changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            source:
+              - 'src/**'
+              - 'include/**'
+              - 'python/**'
+              - 'tests/**'
+              - 'cantera_validation_tests/**'
+              - 'scripts/**'
+              - 'examples/**'
+              - '.github/workflows/**'
+              - 'CMakeLists.txt'
+              - 'pyproject.toml'
+              - '.pre-commit-config.yaml'
+              - 'ruff.toml'
+              - '.python-version'
+              - 'Makefile'
+            documentation:
+              - 'docs/**'
+              - 'README.md'
+              - '**/*.md'
+
   cantera-validation:
     name: Test Cantera Validation
+    needs: changes
+    if: needs.changes.outputs.source == 'true'
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -68,10 +83,10 @@ jobs:
 
       - name: Build and install CombAero Python package
         run: |
-          pip install build
+          python -m pip install build
           python -m build --wheel
           cd cantera_validation_tests
-          poetry run pip install ../dist/*.whl
+          poetry run python -m pip install --force-reinstall ../dist/*.whl
 
       - name: Run combustion validation tests
         working-directory: cantera_validation_tests
@@ -109,6 +124,8 @@ jobs:
 
   python-unit-tests:
     name: Test Python Unit
+    needs: changes
+    if: needs.changes.outputs.source == 'true'
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -130,9 +147,39 @@ jobs:
         run: |
           python -m pip install --upgrade pip build pytest numpy
           python -m build --wheel
-          pip install dist/*.whl
+          python -m pip install --force-reinstall dist/*.whl
 
       - name: Run Python unit tests
         working-directory: python/tests
         run: |
           python -m pytest -v --tb=short
+
+  status-check:
+    name: status-check
+    needs: [changes, cantera-validation, python-unit-tests]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Evaluate validation workflow outcomes
+        shell: bash
+        run: |
+          source_changed="${{ needs.changes.outputs.source }}"
+          cantera_result="${{ needs.cantera-validation.result }}"
+          py_unit_result="${{ needs.python-unit-tests.result }}"
+
+          echo "source_changed=${source_changed}"
+          echo "cantera_result=${cantera_result}"
+          echo "py_unit_result=${py_unit_result}"
+
+          if [[ "${source_changed}" != "true" ]]; then
+            echo "Documentation-only (or non-source) change detected. Passing status-check."
+            exit 0
+          fi
+
+          if [[ "${cantera_result}" == "success" && "${py_unit_result}" == "success" ]]; then
+            echo "All validation jobs succeeded."
+            exit 0
+          fi
+
+          echo "One or more validation jobs failed or were cancelled."
+          exit 1


### PR DESCRIPTION
Skip expensive build/test jobs when only documentation changes.

Adds change detection (dorny/paths-filter) and non-skippable status-check gatekeeper to both CI and Validation Tests workflows.

Docs-only PRs pass instantly. Source PRs get full CI enforcement.

After Actions run, update Branch Protection required checks to: CI/status-check and Validation Tests/status-check