### PR TITLE
feat: add AreaDischargeCoefficientConnectionElement for flexible orifice modeling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,13 @@ name: CI
 
 on:
   push:
-    branches: [ main, master ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, master ]
+    branches: [ main ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   changes:

--- a/.github/workflows/validation-tests.yml
+++ b/.github/workflows/validation-tests.yml
@@ -2,9 +2,13 @@ name: Validation Tests
 
 on:
   push:
-    branches: [ main, master ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, master ]
+    branches: [ main ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   changes:

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -2430,3 +2430,102 @@ nu, alpha, gamma = 3e-5, 4e-5, 1.3  # Hot gas properties
 Q = ca.tube_Q(L_damper, D=0.03, nu=nu, alpha=alpha, gamma=gamma, f=f_1T)
 print(f"Estimated Q ≈ {Q:.0f} (±50%, validate experimentally)")
 ```
+
+## Network Elements
+
+The Python network solver provides specialized flow elements for modeling interconnected systems. All elements inherit from `NetworkElement` and implement `residuals()`, `unknowns()`, and `n_equations()` methods.
+
+### OrificeElement
+
+Models compressible orifice flow with user-specified discharge coefficient.
+
+```python
+from combaero.network import OrificeElement, FlowNetwork, NetworkSolver
+
+# Create orifice with Cd=0.8 and area=0.01 m^2
+orifice = OrificeElement("orifice1", "inlet", "outlet", Cd=0.8, area=0.01)
+
+# Add to network and solve
+graph = FlowNetwork()
+graph.add_element(orifice)
+solver = NetworkSolver(graph)
+sol = solver.solve()
+
+# Access mass flow result
+m_dot = sol["orifice1.m_dot"]  # kg/s
+```
+
+**Physics:**
+- Uses compressible orifice equation: `m_dot = Cd * A * sqrt(2 * rho * dP)`
+- Accounts for density variations across pressure drop
+- Valid for subsonic and transonic flow regimes
+
+**Parameters:**
+- `Cd`: Discharge coefficient (0 < Cd ≤ 1)
+- `area`: Geometric area (m²)
+
+### EffectiveAreaConnectionElement
+
+Simplified orifice element where the user specifies the effective area directly (Cd * A product).
+
+```python
+from combaero.network import EffectiveAreaConnectionElement
+
+# Create connection with effective area = 0.008 m^2
+# (equivalent to Cd=0.8 * A=0.01 m^2)
+conn = EffectiveAreaConnectionElement("conn1", "inlet", "outlet", effective_area=0.008)
+
+# Cd is fixed at 1.0 internally
+assert conn.Cd == 1.0
+assert conn.area == 0.008
+```
+
+**Use case:** When you know the combined effect (Cd * A) but not the individual components.
+
+**Parameters:**
+- `effective_area`: Product of discharge coefficient and geometric area (m²)
+
+### AreaDischargeCoefficientConnectionElement
+
+Orifice element with separate physical area and discharge coefficient (or loss coefficient).
+
+```python
+from combaero.network import AreaDischargeCoefficientConnectionElement
+
+# Initialize with Cd
+conn = AreaDischargeCoefficientConnectionElement(
+    "conn1", "inlet", "outlet",
+    area=0.0125,  # Physical area (m^2)
+    Cd=0.8        # Discharge coefficient
+)
+
+# Or initialize with loss coefficient (zeta)
+conn = AreaDischargeCoefficientConnectionElement(
+    "conn1", "inlet", "outlet",
+    area=0.0125,
+    zeta=0.5625  # Equivalent to Cd=0.8
+)
+
+# Relationship: zeta = 1/Cd^2 - 1, or Cd = 1/sqrt(zeta + 1)
+```
+
+**Physics:**
+- Uses compressible orifice equation with `A * Cd` product
+- Accounts for density variations across pressure drop
+- Valid for subsonic and transonic flow regimes
+
+**Parameters:**
+- `area`: Physical geometric area (m²)
+- `Cd`: Discharge coefficient (0 < Cd ≤ 1) — optional if `zeta` provided
+- `zeta`: Loss coefficient (zeta ≥ 0) — optional if `Cd` provided
+
+**Precedence:** If both `Cd` and `zeta` are provided, `Cd` takes precedence and `zeta` is ignored.
+
+**Cd/Zeta Conversion:**
+```python
+# Convert Cd to zeta
+zeta = 1.0 / (Cd ** 2) - 1.0
+
+# Convert zeta to Cd
+Cd = 1.0 / (zeta + 1.0) ** 0.5
+```

--- a/python/combaero/network/__init__.py
+++ b/python/combaero/network/__init__.py
@@ -9,6 +9,7 @@ from .components import (
     OrificeElement,
     PipeElement,
     PlenumNode,
+    AreaDischargeCoefficientConnectionElement,
 )
 from .graph import FlowNetwork
 from .solver import NetworkSolver
@@ -23,6 +24,7 @@ __all__: list[str] = [
     "OrificeElement",
     "EffectiveAreaConnectionElement",
     "LosslessConnectionElement",
+    "AreaDischargeCoefficientConnectionElement",
     "MixtureState",
     "FlowNetwork",
     "NetworkSolver",

--- a/python/combaero/network/components.py
+++ b/python/combaero/network/components.py
@@ -360,6 +360,99 @@ class EffectiveAreaConnectionElement(OrificeElement):
         return 1
 
 
+class AreaDischargeCoefficientConnectionElement(OrificeElement):
+    """
+    An orifice element with user-specified physical area and discharge coefficient or loss coefficient.
+
+    This element calculates orifice flow using the compressible flow equation:
+        m_dot = A * Cd * sqrt(2 * rho * dP)
+
+    where A is the physical area and Cd is the discharge coefficient.
+
+    **Parameters**: User provides either Cd (discharge coefficient) or zeta (loss coefficient).
+    The other parameter is calculated automatically using the relationship:
+        zeta = 1/Cd^2 - 1  or  Cd = 1/sqrt(zeta + 1)
+
+    **Effective Area**: The effective area is calculated as A_eff = A * Cd.
+
+    Unlike LosslessConnectionElement, this element produces pressure drop proportional to flow rate.
+    Use this when you have a physical area measurement and want to specify loss characteristics
+    via discharge coefficient or loss coefficient.
+    """
+
+    def __init__(
+        self,
+        id: str,
+        from_node: str,
+        to_node: str,
+        area: float,
+        Cd: float | None = None,
+        zeta: float | None = None,
+    ) -> None:
+        """
+        Initialize with physical area and either Cd or zeta.
+
+        Args:
+            id: Element identifier
+            from_node: Upstream node ID
+            to_node: Downstream node ID
+            area: Physical geometric area (m^2)
+            Cd: Discharge coefficient (optional, 0 < Cd <= 1)
+            zeta: Loss coefficient (optional, zeta >= 0)
+
+        Note:
+            Exactly one of Cd or zeta must be provided. If both are provided, zeta is ignored.
+            If Cd is provided, zeta is calculated as zeta = 1/Cd^2 - 1.
+            If zeta is provided, Cd is calculated as Cd = 1/sqrt(zeta + 1).
+
+        Example:
+            >>> # Using Cd
+            >>> conn = AreaDischargeCoefficientConnectionElement("conn1", "inlet", "outlet", 0.0125, Cd=0.8)
+            >>> conn.area  # 0.0125 m^2 (physical area)
+            >>> conn.Cd    # 0.8 (discharge coefficient)
+
+            >>> # Using zeta
+            >>> conn = AreaDischargeCoefficientConnectionElement("conn1", "inlet", "outlet", 0.0125, zeta=0.5625)
+            >>> conn.area  # 0.0125 m^2 (physical area)
+            >>> conn.Cd    # 0.8 (calculated from zeta)
+
+        Raises:
+            ValueError: If neither Cd nor zeta is provided, or if invalid values are given.
+        """
+        if Cd is not None and zeta is not None:
+            # If both are provided, use Cd and ignore zeta
+            zeta = None
+        elif Cd is None and zeta is None:
+            raise ValueError("Either Cd or zeta must be provided")
+
+        if Cd is not None:
+            if not (0 < Cd <= 1):
+                raise ValueError("Cd must be in range (0, 1]")
+        else:  # zeta is provided
+            if zeta < 0:
+                raise ValueError("zeta must be >= 0")
+            # Calculate Cd from zeta: Cd = 1/sqrt(zeta + 1)
+            Cd = 1.0 / (zeta + 1.0) ** 0.5
+
+        # Pass physical area and Cd directly to parent
+        # Parent will use A * Cd for flow calculation
+        super().__init__(id, from_node, to_node, Cd=Cd, area=area)
+
+    def resolve_topology(self, graph: "FlowNetwork") -> None:
+        """
+        Skip upstream/downstream geometry discovery.
+
+        The physical area and discharge coefficient are user-specified and already account
+        for all geometric effects. No Beta ratio correction is needed or applied.
+        """
+        # Intentionally empty - area and Cd are pre-computed by user
+        pass
+
+    def n_equations(self) -> int:
+        """Return the number of equations (1: mass flow balance)."""
+        return 1
+
+
 class LosslessConnectionElement(NetworkElement):
     """
     An ideal connection with no friction or momentum loss.

--- a/python/tests/test_area_discharge_coefficient_connection.py
+++ b/python/tests/test_area_discharge_coefficient_connection.py
@@ -1,0 +1,471 @@
+"""
+Test AreaDischargeCoefficientConnectionElement functionality.
+"""
+
+import pytest
+
+from combaero.network import (
+    AreaDischargeCoefficientConnectionElement,
+    FlowNetwork,
+    NetworkSolver,
+    OrificeElement,
+    PlenumNode,
+    PressureBoundary,
+)
+
+
+def _get_air_X():
+    """Helper to create standard air composition."""
+    X = [0.0] * 14
+    X[0] = 0.79  # N2
+    X[1] = 0.21  # O2
+    return X
+
+
+class TestAreaDischargeCoefficientConnectionElement:
+    """Test suite for AreaDischargeCoefficientConnectionElement."""
+
+    def test_initialization_with_cd(self):
+        """Test initialization with discharge coefficient."""
+        area = 0.0125  # m^2
+        Cd = 0.8
+        connection = AreaDischargeCoefficientConnectionElement(
+            "conn1", "node1", "node2", area, Cd=Cd
+        )
+
+        # Verify attributes
+        assert connection.Cd == Cd
+        assert connection.area == area  # Physical area passed to parent
+        assert connection.id == "conn1"
+        assert connection.from_node == "node1"
+        assert connection.to_node == "node2"
+
+    def test_initialization_with_zeta(self):
+        """Test initialization with loss coefficient."""
+        area = 0.0125  # m^2
+        zeta = 0.5625  # Should give Cd = 0.8
+        connection = AreaDischargeCoefficientConnectionElement(
+            "conn1", "node1", "node2", area, zeta=zeta
+        )
+
+        # Verify attributes
+        expected_Cd = 1.0 / (zeta + 1.0) ** 0.5  # Cd = 1/sqrt(zeta + 1)
+        assert connection.Cd == pytest.approx(expected_Cd)
+        assert connection.area == pytest.approx(area)  # Physical area passed to parent
+        assert connection.id == "conn1"
+
+    def test_cd_zeta_equivalence(self):
+        """Test that Cd and zeta produce equivalent results."""
+        area = 0.0125
+        Cd = 0.8
+        zeta = 1.0 / (Cd**2) - 1.0  # zeta = 1/Cd^2 - 1
+
+        # Initialize with Cd
+        conn_cd = AreaDischargeCoefficientConnectionElement(
+            "conn_cd", "node1", "node2", area, Cd=Cd
+        )
+
+        # Initialize with equivalent zeta
+        conn_zeta = AreaDischargeCoefficientConnectionElement(
+            "conn_zeta", "node1", "node2", area, zeta=zeta
+        )
+
+        # Should produce identical results
+        assert conn_cd.Cd == pytest.approx(conn_zeta.Cd)
+        assert conn_cd.area == pytest.approx(conn_zeta.area)
+
+    def test_cd_takes_precedence(self):
+        """Test that Cd takes precedence when both Cd and zeta are provided."""
+        area = 0.01
+        Cd = 0.9
+        zeta = 0.2345  # Different from what Cd=0.9 would give
+
+        connection = AreaDischargeCoefficientConnectionElement(
+            "conn1", "node1", "node2", area, Cd=Cd, zeta=zeta
+        )
+
+        # Should use Cd, not zeta
+        assert connection.Cd == Cd
+        assert connection.area == area  # Physical area passed to parent
+
+    def test_inheritance(self):
+        """Test that AreaDischargeCoefficientConnectionElement inherits from OrificeElement."""
+        connection = AreaDischargeCoefficientConnectionElement(
+            "conn1", "node1", "node2", 0.0125, Cd=0.8
+        )
+        assert isinstance(connection, OrificeElement)
+
+    def test_unknowns(self):
+        """Test unknowns method."""
+        connection = AreaDischargeCoefficientConnectionElement(
+            "conn1", "node1", "node2", 0.0125, Cd=0.8
+        )
+        unknowns = connection.unknowns()
+        assert len(unknowns) == 1
+        assert unknowns[0] == "conn1.m_dot"
+
+    def test_n_equations(self):
+        """Test n_equations method."""
+        connection = AreaDischargeCoefficientConnectionElement(
+            "conn1", "node1", "node2", 0.0125, Cd=0.8
+        )
+        assert connection.n_equations() == 1
+
+    def test_resolve_topology(self):
+        """Test resolve_topology method."""
+        network = FlowNetwork()
+        connection = AreaDischargeCoefficientConnectionElement(
+            "conn1", "node1", "node2", 0.0125, Cd=0.8
+        )
+
+        # Should not raise any errors
+        connection.resolve_topology(network)
+
+        # Should not set upstream/downstream diameters
+        assert connection.upstream_diameter is None
+        assert connection.downstream_diameter is None
+
+    def test_integration_with_network(self):
+        """Test that the element can be added to a network."""
+        network = FlowNetwork()
+
+        # Create nodes
+        plenum1 = PlenumNode("plenum1")
+        plenum2 = PlenumNode("plenum2")
+
+        # Create connection with Cd
+        connection = AreaDischargeCoefficientConnectionElement(
+            "conn1", "plenum1", "plenum2", 0.0125, Cd=0.8
+        )
+
+        # Add to network
+        network.add_node(plenum1)
+        network.add_node(plenum2)
+        network.add_element(connection)
+
+        # Verify network contains the element
+        assert "conn1" in network.elements
+        assert network.elements["conn1"] is connection
+
+    def test_different_discharge_coefficients(self):
+        """Test with various discharge coefficient values."""
+        area = 0.01
+        test_Cds = [0.6, 0.7, 0.8, 0.9, 0.95]
+
+        for i, Cd in enumerate(test_Cds):
+            connection = AreaDischargeCoefficientConnectionElement(
+                f"conn{i}", f"node{i}", f"node{i + 1}", area, Cd=Cd
+            )
+            assert connection.area == pytest.approx(area)  # Physical area
+            assert connection.Cd == pytest.approx(Cd)
+
+    def test_different_loss_coefficients(self):
+        """Test with various loss coefficient values."""
+        area = 0.01
+        test_zetas = [0.0, 0.5, 1.0, 2.0, 5.0]
+
+        for i, zeta in enumerate(test_zetas):
+            connection = AreaDischargeCoefficientConnectionElement(
+                f"conn{i}", f"node{i}", f"node{i + 1}", area, zeta=zeta
+            )
+            expected_Cd = 1.0 / (zeta + 1.0) ** 0.5
+            assert connection.area == pytest.approx(area)  # Physical area
+            assert connection.Cd == pytest.approx(expected_Cd)
+
+    def test_methods_exist(self):
+        """Test that all required methods exist."""
+        connection = AreaDischargeCoefficientConnectionElement(
+            "conn1", "node1", "node2", 0.0125, Cd=0.8
+        )
+
+        assert hasattr(connection, "unknowns")
+        assert hasattr(connection, "residuals")
+        assert hasattr(connection, "n_equations")
+        assert hasattr(connection, "resolve_topology")
+        assert callable(connection.unknowns)
+        assert callable(connection.residuals)
+        assert callable(connection.n_equations)
+        assert callable(connection.resolve_topology)
+
+    def test_flow_calculation_matches_orifice(self):
+        """Verify AreaDischargeCoefficientConnectionElement produces same flow as OrificeElement.
+
+        Both use the compressible flow equation via cb.orifice_mdot_and_jacobian(),
+        which accounts for density variations across the pressure drop.
+        """
+        area = 0.0125  # m^2
+        Cd = 0.8
+
+        # Network 1: Using AreaDischargeCoefficientConnectionElement
+        graph1 = FlowNetwork()
+        inlet1 = PressureBoundary("inlet")
+        inlet1.P_total = 150000.0
+        inlet1.T_total = 300.0
+        inlet1.X = _get_air_X()
+        outlet1 = PressureBoundary("outlet")
+        outlet1.P_total = 100000.0
+        outlet1.T_total = 300.0
+        outlet1.X = _get_air_X()
+        conn1 = AreaDischargeCoefficientConnectionElement("conn", "inlet", "outlet", area, Cd=Cd)
+
+        graph1.add_node(inlet1)
+        graph1.add_node(outlet1)
+        graph1.add_element(conn1)
+
+        solver1 = NetworkSolver(graph1)
+        sol1 = solver1.solve(method="lm")
+
+        # Network 2: Using OrificeElement with same Cd and physical area
+        graph2 = FlowNetwork()
+        inlet2 = PressureBoundary("inlet")
+        inlet2.P_total = 150000.0
+        inlet2.T_total = 300.0
+        inlet2.X = _get_air_X()
+        outlet2 = PressureBoundary("outlet")
+        outlet2.P_total = 100000.0
+        outlet2.T_total = 300.0
+        outlet2.X = _get_air_X()
+        orf2 = OrificeElement("orf", "inlet", "outlet", Cd=Cd, area=area)
+
+        graph2.add_node(inlet2)
+        graph2.add_node(outlet2)
+        graph2.add_element(orf2)
+
+        solver2 = NetworkSolver(graph2)
+        sol2 = solver2.solve(method="lm")
+
+        # Should produce identical results
+        assert sol1["conn.m_dot"] == pytest.approx(sol2["orf.m_dot"], rel=1e-6)
+
+    def test_pressure_drop_with_flow(self):
+        """Verify that AreaDischargeCoefficientConnectionElement produces pressure drop proportional to flow."""
+        area = 0.0125
+        Cd = 0.8
+
+        # Network with AreaDischargeCoefficientConnectionElement
+        graph = FlowNetwork()
+        inlet = PressureBoundary("inlet")
+        inlet.P_total = 150000.0
+        inlet.T_total = 300.0
+        inlet.X = _get_air_X()
+        outlet = PressureBoundary("outlet")
+        outlet.P_total = 100000.0
+        outlet.T_total = 300.0
+        outlet.X = _get_air_X()
+        conn = AreaDischargeCoefficientConnectionElement("conn", "inlet", "outlet", area, Cd=Cd)
+
+        graph.add_node(inlet)
+        graph.add_node(outlet)
+        graph.add_element(conn)
+
+        solver = NetworkSolver(graph)
+        sol = solver.solve(method="lm")
+
+        # Verify positive flow (high to low pressure)
+        assert sol["conn.m_dot"] > 0
+
+        # Verify pressure drop exists
+        assert inlet.P_total > outlet.P_total
+
+    def test_different_cd_produce_different_flows(self):
+        """Verify that different discharge coefficients produce different flow rates."""
+        area = 0.01
+        Cds = [0.6, 0.8, 0.95]
+        flows = []
+
+        for Cd in Cds:
+            graph = FlowNetwork()
+            inlet = PressureBoundary("inlet")
+            inlet.P_total = 150000.0
+            inlet.T_total = 300.0
+            inlet.X = _get_air_X()
+            outlet = PressureBoundary("outlet")
+            outlet.P_total = 100000.0
+            outlet.T_total = 300.0
+            outlet.X = _get_air_X()
+            conn = AreaDischargeCoefficientConnectionElement("conn", "inlet", "outlet", area, Cd=Cd)
+
+            graph.add_node(inlet)
+            graph.add_node(outlet)
+            graph.add_element(conn)
+
+            solver = NetworkSolver(graph)
+            sol = solver.solve(method="lm")
+            flows.append(sol["conn.m_dot"])
+
+        # Higher Cd should produce higher flow
+        assert flows[0] < flows[1] < flows[2]
+
+    def test_different_zeta_produce_different_flows(self):
+        """Verify that different loss coefficients produce different flow rates."""
+        area = 0.01
+        zetas = [2.0, 0.5, 0.1]  # Higher zeta = lower Cd = lower flow
+        flows = []
+
+        for zeta in zetas:
+            graph = FlowNetwork()
+            inlet = PressureBoundary("inlet")
+            inlet.P_total = 150000.0
+            inlet.T_total = 300.0
+            inlet.X = _get_air_X()
+            outlet = PressureBoundary("outlet")
+            outlet.P_total = 100000.0
+            outlet.T_total = 300.0
+            outlet.X = _get_air_X()
+            conn = AreaDischargeCoefficientConnectionElement(
+                "conn", "inlet", "outlet", area, zeta=zeta
+            )
+
+            graph.add_node(inlet)
+            graph.add_node(outlet)
+            graph.add_element(conn)
+
+            solver = NetworkSolver(graph)
+            sol = solver.solve(method="lm")
+            flows.append(sol["conn.m_dot"])
+
+        # Lower zeta should produce higher flow (higher Cd)
+        assert flows[0] < flows[1] < flows[2]
+
+    def test_no_geometry_discovery(self):
+        """Verify that resolve_topology does not discover upstream/downstream geometry."""
+        network = FlowNetwork()
+        plenum1 = PlenumNode("plenum1")
+        plenum2 = PlenumNode("plenum2")
+        conn = AreaDischargeCoefficientConnectionElement(
+            "conn", "plenum1", "plenum2", 0.0125, Cd=0.8
+        )
+
+        network.add_node(plenum1)
+        network.add_node(plenum2)
+        network.add_element(conn)
+
+        # Resolve topology
+        conn.resolve_topology(network)
+
+        # Verify no geometry was discovered
+        assert conn.upstream_diameter is None
+        assert conn.downstream_diameter is None
+
+    def test_error_neither_cd_nor_zeta(self):
+        """Test error when neither Cd nor zeta is provided."""
+        with pytest.raises(ValueError, match="Either Cd or zeta must be provided"):
+            AreaDischargeCoefficientConnectionElement("conn1", "node1", "node2", 0.01)
+
+    def test_error_invalid_cd_range(self):
+        """Test error when Cd is outside valid range."""
+        # Cd > 1
+        with pytest.raises(ValueError, match="Cd must be in range"):
+            AreaDischargeCoefficientConnectionElement("conn1", "node1", "node2", 0.01, Cd=1.5)
+
+        # Cd <= 0
+        with pytest.raises(ValueError, match="Cd must be in range"):
+            AreaDischargeCoefficientConnectionElement("conn1", "node1", "node2", 0.01, Cd=0.0)
+
+        # Cd negative
+        with pytest.raises(ValueError, match="Cd must be in range"):
+            AreaDischargeCoefficientConnectionElement("conn1", "node1", "node2", 0.01, Cd=-0.5)
+
+    def test_error_invalid_zeta_range(self):
+        """Test error when zeta is negative."""
+        with pytest.raises(ValueError, match="zeta must be >= 0"):
+            AreaDischargeCoefficientConnectionElement("conn1", "node1", "node2", 0.01, zeta=-0.1)
+
+    def test_compressible_flow_behavior(self):
+        """Verify that AreaDischargeCoefficientConnectionElement uses compressible flow equation.
+
+        The flow should depend on density, which varies with pressure and temperature.
+        This test verifies that the compressible orifice equation is used, not
+        the incompressible approximation.
+        """
+        area = 0.01
+        Cd = 0.8
+
+        # High pressure drop case (more compressibility effects)
+        graph1 = FlowNetwork()
+        inlet1 = PressureBoundary("inlet")
+        inlet1.P_total = 200000.0
+        inlet1.T_total = 300.0
+        inlet1.X = _get_air_X()
+        outlet1 = PressureBoundary("outlet")
+        outlet1.P_total = 50000.0
+        outlet1.T_total = 300.0
+        outlet1.X = _get_air_X()
+        conn1 = AreaDischargeCoefficientConnectionElement("conn", "inlet", "outlet", area, Cd=Cd)
+
+        graph1.add_node(inlet1)
+        graph1.add_node(outlet1)
+        graph1.add_element(conn1)
+
+        solver1 = NetworkSolver(graph1)
+        sol1 = solver1.solve(method="lm")
+        flow_high_drop = sol1["conn.m_dot"]
+
+        # Low pressure drop case (less compressibility effects)
+        graph2 = FlowNetwork()
+        inlet2 = PressureBoundary("inlet")
+        inlet2.P_total = 110000.0
+        inlet2.T_total = 300.0
+        inlet2.X = _get_air_X()
+        outlet2 = PressureBoundary("outlet")
+        outlet2.P_total = 100000.0
+        outlet2.T_total = 300.0
+        outlet2.X = _get_air_X()
+        conn2 = AreaDischargeCoefficientConnectionElement("conn", "inlet", "outlet", area, Cd=Cd)
+
+        graph2.add_node(inlet2)
+        graph2.add_node(outlet2)
+        graph2.add_element(conn2)
+
+        solver2 = NetworkSolver(graph2)
+        sol2 = solver2.solve(method="lm")
+        flow_low_drop = sol2["conn.m_dot"]
+
+        # Both should have positive flow
+        assert flow_high_drop > 0
+        assert flow_low_drop > 0
+
+        # Higher pressure drop should produce higher flow
+        # For compressible flow, the relationship is more complex than incompressible
+        # but flow should still increase monotonically with pressure drop
+        assert flow_high_drop > flow_low_drop
+
+    def test_zeta_zero_equals_cd_one(self):
+        """Test that zeta=0 gives Cd=1.0."""
+        area = 0.01
+        connection = AreaDischargeCoefficientConnectionElement(
+            "conn1", "node1", "node2", area, zeta=0.0
+        )
+
+        assert connection.Cd == pytest.approx(1.0)
+        assert connection.area == pytest.approx(area)  # Physical area
+
+    def test_high_zeta_low_cd(self):
+        """Test that high zeta values give low Cd values."""
+        area = 0.01
+        high_zeta = 10.0
+        connection = AreaDischargeCoefficientConnectionElement(
+            "conn1", "node1", "node2", area, zeta=high_zeta
+        )
+
+        expected_Cd = 1.0 / (high_zeta + 1.0) ** 0.5
+        assert connection.Cd == pytest.approx(expected_Cd)
+        assert connection.Cd < 0.31  # Should be quite low
+
+    def test_physical_area_preserved_in_calculation(self):
+        """Verify that the physical area is used correctly in flow calculation."""
+        physical_area = 0.0125
+        Cd = 0.8
+
+        connection = AreaDischargeCoefficientConnectionElement(
+            "conn1", "node1", "node2", physical_area, Cd=Cd
+        )
+
+        # Physical area is stored in parent
+        assert connection.area == pytest.approx(physical_area)
+
+        # Cd is stored separately
+        assert connection.Cd == pytest.approx(Cd)
+
+        # Parent will use A * Cd for flow calculation
+        # Effective area = physical_area * Cd


### PR DESCRIPTION
Add new network element that accepts physical area + Cd or zeta (loss coefficient).

## Changes
- New AreaDischargeCoefficientConnectionElement class in components.py
- Automatically converts between Cd and zeta: zeta = 1/Cd^2 - 1
- Inherits from OrificeElement, uses compressible flow equation
- Skips geometry discovery (user-specified parameters)
- 24 comprehensive tests covering initialization, validation, flow calculations
- Updated API_REFERENCE.md with Network Elements section

## Testing
- All 24 tests passing
- Style checks passing (ruff)
- Pre-commit hooks passing