### PR TITLE
test: probe unique gatekeeper check contexts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
         run: cmake --build build-mingw --config Release
 
   status-check:
-    name: ci-gatekeeper
+    name: CI / status-check
     needs: [changes, lint, build-and-test, build-mingw]
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
         run: cmake --build build-mingw --config Release
 
   status-check:
-    name: status-check
+    name: ci-gatekeeper
     needs: [changes, lint, build-and-test, build-mingw]
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,8 @@ jobs:
         run: cmake --build build-mingw --config Release
 
   status-check:
+    # IMPORTANT: Keep this literal name in sync with Iron ruleset required context:
+    # "CI / status-check". Ruleset matching is strict and relies on exact string equality.
     name: CI / status-check
     needs: [changes, lint, build-and-test, build-mingw]
     if: always()

--- a/.github/workflows/validation-tests.yml
+++ b/.github/workflows/validation-tests.yml
@@ -159,7 +159,7 @@ jobs:
           python -m pytest -v --tb=short
 
   status-check:
-    name: status-check
+    name: validation-gatekeeper
     needs: [changes, cantera-validation, python-unit-tests]
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/validation-tests.yml
+++ b/.github/workflows/validation-tests.yml
@@ -159,7 +159,7 @@ jobs:
           python -m pytest -v --tb=short
 
   status-check:
-    name: validation-gatekeeper
+    name: Validation Tests / status-check
     needs: [changes, cantera-validation, python-unit-tests]
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/validation-tests.yml
+++ b/.github/workflows/validation-tests.yml
@@ -159,6 +159,8 @@ jobs:
           python -m pytest -v --tb=short
 
   status-check:
+    # IMPORTANT: Keep this literal name in sync with Iron ruleset required context:
+    # "Validation Tests / status-check". Ruleset matching is strict and relies on exact string equality.
     name: Validation Tests / status-check
     needs: [changes, cantera-validation, python-unit-tests]
     if: always()


### PR DESCRIPTION
Rename gatekeeper job names to unique values to test ruleset context resolution:\n- CI -> ci-gatekeeper\n- Validation Tests -> validation-gatekeeper\n\nGoal: verify required-check matching and unblock ruleset evaluation.