### PR TITLE
fix(ci): align gatekeeper names with ruleset required contexts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,9 @@ jobs:
         run: cmake --build build-mingw --config Release
 
   status-check:
-    name: status-check
+    # IMPORTANT: Keep this literal name in sync with Iron ruleset required context:
+    # "CI / status-check". Ruleset matching is strict and relies on exact string equality.
+    name: CI / status-check
     needs: [changes, lint, build-and-test, build-mingw]
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/validation-tests.yml
+++ b/.github/workflows/validation-tests.yml
@@ -159,7 +159,9 @@ jobs:
           python -m pytest -v --tb=short
 
   status-check:
-    name: status-check
+    # IMPORTANT: Keep this literal name in sync with Iron ruleset required context:
+    # "Validation Tests / status-check". Ruleset matching is strict and relies on exact string equality.
+    name: Validation Tests / status-check
     needs: [changes, cantera-validation, python-unit-tests]
     if: always()
     runs-on: ubuntu-latest


### PR DESCRIPTION
Make gatekeeper check names literal to match Iron ruleset required contexts exactly.

## Changes
- CI gatekeeper job name set to 
- Validation gatekeeper job name set to 
- Added comments in both workflows documenting strict literal-name requirement

## Why
Ruleset evaluation only unblocked when these names matched required contexts literally in practice.

## Files
- .github/workflows/ci.yml
- .github/workflows/validation-tests.yml