### PR TITLE
fix(ci): speed up Windows compilation in build-and-test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,22 +83,41 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up Python (Windows Ninja dependency)
+        if: runner.os == 'Windows'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Ninja (Windows)
+        if: runner.os == 'Windows'
+        run: pip install ninja
+
       - name: Set up CMake
         uses: jwlawson/actions-setup-cmake@v1
 
-      - name: Configure
+      - name: Configure (Ninja on Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          cmake -S . -B build \
+            -G Ninja \
+            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+
+      - name: Configure (default generator)
+        if: runner.os != 'Windows'
         shell: bash
         run: |
           cmake -S . -B build \
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
 
       - name: Build
-        run: cmake --build build --config ${{ matrix.build_type }}
+        run: cmake --build build --config ${{ matrix.build_type }} --parallel
 
       - name: Run tests (ctest)
         working-directory: build
         run: |
-          ctest --output-on-failure
+          ctest --output-on-failure --parallel
 
       - name: Run accuracy tests
         working-directory: build


### PR DESCRIPTION
Improve CI runtime for the Windows build in the C++ matrix job.

## Changes
- Install Ninja only on Windows runners
- Use Ninja generator on Windows (-G Ninja)
- Keep default generator on Linux/macOS
- Enable parallel compilation (cmake --build ... --parallel)
- Enable parallel test execution (ctest --parallel)

## Why
Windows builds were slower under the default generator. This keeps the optimization targeted to Windows while preserving existing behavior on other OS runners.