### PR TITLE
feat: robust solver timeout and verification

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -2431,6 +2431,30 @@ Q = ca.tube_Q(L_damper, D=0.03, nu=nu, alpha=alpha, gamma=gamma, f=f_1T)
 print(f"Estimated Q ≈ {Q:.0f} (±50%, validate experimentally)")
 ```
 
+## Network Solver
+
+### NetworkSolver
+
+Orchestrates the numerical solution of a fluid flow network using `scipy.optimize.root`.
+
+```python
+from combaero.network import NetworkSolver
+
+solver = NetworkSolver(graph)
+# Solve with a 5-second safety timeout
+solution = solver.solve(method="hybr", timeout=5.0, options={"maxfev": 1000})
+
+# Access results
+m_dot = solution["element_id.m_dot"]
+P_tot = solution["node_id.P_total"]
+```
+
+**Methods:**
+- `solve(method: str = "hybr", timeout: float | None = None, options: dict | None = None)`:
+    - **method**: Root-finding algorithm. Supported: `hybr`, `lm`, `broyden1`, `broyden2`, `anderson`, `linearmixing`, `diagbroyden`, `excitingmixing`, `krylov`, `df-sane`.
+    - **timeout**: Wall-clock timeout in seconds. If exceeded, returns the best iterate found so far with a warning.
+    - **options**: Solver-specific options (e.g., `maxfev`, `xtol`).
+
 ## Network Elements
 
 The Python network solver provides specialized flow elements for modeling interconnected systems. All elements inherit from `NetworkElement` and implement `residuals()`, `unknowns()`, and `n_equations()` methods.

--- a/python/combaero/network/__init__.py
+++ b/python/combaero/network/__init__.py
@@ -9,6 +9,8 @@ from .components import (
     OrificeElement,
     PipeElement,
     PlenumNode,
+    NetworkNode,
+    NetworkElement,
     AreaDischargeCoefficientConnectionElement,
 )
 from .graph import FlowNetwork
@@ -28,4 +30,6 @@ __all__: list[str] = [
     "MixtureState",
     "FlowNetwork",
     "NetworkSolver",
+    "NetworkNode",
+    "NetworkElement",
 ]

--- a/python/combaero/network/solver.py
+++ b/python/combaero/network/solver.py
@@ -1,3 +1,7 @@
+import time
+import warnings
+from typing import Any
+
 import numpy as np
 from scipy.optimize import root
 
@@ -10,11 +14,30 @@ from .components import (
 from .graph import FlowNetwork
 
 
+class SolverTimeoutError(Exception):
+    """Raised when the solver exceeds the specified wall-clock timeout."""
+
+    pass
+
+
 class NetworkSolver:
     """
     Orchestrates the numerical solution of a fluid flow network using scipy.optimize.root.
     Translates the graph topology into a flat array of unknowns and residuals.
     """
+
+    SUPPORTED_METHODS = [
+        "hybr",
+        "lm",
+        "broyden1",
+        "broyden2",
+        "anderson",
+        "linearmixing",
+        "diagbroyden",
+        "excitingmixing",
+        "krylov",
+        "df-sane",
+    ]
 
     def __init__(self, network: FlowNetwork):
         self.network = network
@@ -192,14 +215,35 @@ class NetworkSolver:
 
         return np.array(res, dtype=float)
 
-    def solve(self, method="hybr", options=None) -> dict[str, float]:
+    def solve(
+        self,
+        method: str = "hybr",
+        timeout: float | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> dict[str, float]:
         """
         Executes the root finding algorithm to solve the network.
         Returns a dictionary mapping unknown names to their solved values.
+
+        Args:
+            method: The scipy.optimize.root method to use.
+            timeout: Maximum wall-clock time in seconds before stopping and returning the best iterate.
+            options: Dictionary of solver options (e.g., maxiter, maxfev, xtol).
         """
+        if method not in self.SUPPORTED_METHODS:
+            raise ValueError(
+                f"Method '{method}' is not supported. Supported methods are: {', '.join(self.SUPPORTED_METHODS)}"
+            )
+
         if options is None:
-            # Provide sensible defaults to avoid infinite loops on unphysical bounds
-            options = {"maxiter": 500}
+            options = {}
+
+        # Default iteration limits to prevent infinite loops in C extensions
+        if method in ("hybr", "lm"):
+            if "maxfev" not in options:
+                options["maxfev"] = 500
+        elif "maxiter" not in options:
+            options["maxiter"] = 500
 
         # Ensure topology is resolved before solving
         self.network.resolve_all_topology()
@@ -212,17 +256,54 @@ class NetworkSolver:
         if len(x0) != len(res0):
             raise ValueError(f"System not square: {len(x0)} unknowns vs {len(res0)} equations.")
 
+        # State for timeout and best iterate tracking
+        start_time = time.perf_counter()
+        best_x = x0.copy()
+        best_res_norm = np.linalg.norm(res0)
+
+        def residuals_wrapper(x: np.ndarray) -> np.ndarray:
+            nonlocal best_x, best_res_norm
+
+            # Check timeout
+            if timeout is not None and (time.perf_counter() - start_time) > timeout:
+                raise SolverTimeoutError(f"Solver timed out after {timeout} seconds.")
+
+            # Evaluate residuals
+            res = self._residuals(x)
+
+            # Track best iterate
+            res_norm = np.linalg.norm(res)
+            if res_norm < best_res_norm:
+                best_res_norm = res_norm
+                best_x = x.copy()
+
+            return res
+
         # Solve
-        sol = root(self._residuals, x0, method=method, options=options)
+        try:
+            sol = root(residuals_wrapper, x0, method=method, options=options)
+            final_x = sol.x
+            success = sol.success
+            message = sol.message
+            final_norm = float(np.linalg.norm(sol.fun))
+        except SolverTimeoutError as e:
+            final_x = best_x
+            success = False
+            message = str(e)
+            final_norm = float(best_res_norm)
+        except Exception as e:
+            # Fallback for unexpected errors during residuals evaluation
+            final_x = best_x
+            success = False
+            message = f"Unexpected error during residual evaluation: {e}"
+            final_norm = float(best_res_norm)
 
-        if not sol.success:
-            import warnings
-
+        if not success:
             warnings.warn(
-                f"NetworkSolver did not converge: {sol.message} "
-                f"(|F|={float(np.linalg.norm(sol.fun)):.3e}). "
+                f"NetworkSolver did not converge: {message} "
+                f"(|F|={final_norm:.3e}). "
                 "Returning best iterate.",
                 stacklevel=2,
             )
 
-        return dict(zip(self.unknown_names, sol.x, strict=False))
+        return dict(zip(self.unknown_names, final_x, strict=False))

--- a/python/tests/test_solver_methods_stress.py
+++ b/python/tests/test_solver_methods_stress.py
@@ -1,0 +1,91 @@
+import time
+
+import pytest
+
+from combaero.network import (
+    FlowNetwork,
+    LosslessConnectionElement,
+    NetworkNode,
+    NetworkSolver,
+    OrificeElement,
+    PressureBoundary,
+)
+
+
+class DivergentNode(NetworkNode):
+    """A node that has an unsolvable residual equation: x^2 + 1 = 0"""
+
+    def unknowns(self) -> list[str]:
+        return [f"{self.id}.P", f"{self.id}.P_total"]
+
+    def residuals(self, state) -> list[float]:
+        # Return a residual that can never be zero for any real P
+        # We scale it so it doesn't immediately blow up but never converges
+        return [(state.P / 1e5) ** 2 + 1.0]
+
+    def resolve_topology(self, graph) -> None:
+        pass
+
+
+@pytest.mark.parametrize("method", NetworkSolver.SUPPORTED_METHODS)
+def test_timeout_all_methods(method):
+    """
+    Verify that every supported method respects the wall-clock timeout.
+    We use a sleep in the residual function to simulate a slow solver.
+    """
+    graph = FlowNetwork()
+    # Inconsistent network: inlet=2bar, outlet=1bar, connected by lossless.
+    # Plus a node that has an unsolvable residual: x^2 + 1 = 0
+    inlet = PressureBoundary("inlet", P_total=200000.0, T_total=300.0)
+    outlet = PressureBoundary("outlet", P_total=101325.0, T_total=300.0)
+    node = DivergentNode("bad_node")
+
+    conn1 = OrificeElement("orf1", "inlet", "bad_node", Cd=0.6, area=0.001)
+    conn2 = LosslessConnectionElement("c2", "bad_node", "outlet")
+
+    graph.add_node(inlet)
+    graph.add_node(outlet)
+    graph.add_node(node)
+    graph.add_element(conn1)
+    graph.add_element(conn2)
+
+    solver = NetworkSolver(graph)
+
+    original_residuals = solver._residuals
+
+    def slow_residuals(x):
+        time.sleep(0.05)  # 50ms per evaluation
+        return original_residuals(x)
+
+    solver._residuals = slow_residuals
+
+    # Set a very short timeout.
+    # Even if the solver only does 1-2 evaluations, it should hit 0.1s quickly.
+    start = time.perf_counter()
+    with pytest.warns(UserWarning, match="Solver timed out"):
+        solution = solver.solve(method=method, timeout=0.1)
+    duration = time.perf_counter() - start
+
+    # Ensure it didn't take much longer than the timeout + 1 iteration
+    # 0.5s is a safe upper bound for a 0.1s timeout given 0.05s steps
+    assert duration < 0.6, f"Method {method} took too long: {duration:.2f}s"
+    assert "bad_node.P" in solution
+
+
+def test_unsupported_method():
+    """Verify that using an unsupported method raises a ValueError."""
+    graph = FlowNetwork()
+    solver = NetworkSolver(graph)
+    with pytest.raises(ValueError, match="not supported"):
+        solver.solve(method="invalid_method")
+
+
+if __name__ == "__main__":
+    # Allow running this script directly for quick verification
+    for m in NetworkSolver.SUPPORTED_METHODS:
+        print(f"Testing method: {m}...")
+        try:
+            test_timeout_all_methods(m)
+            print(f"  {m}: PASSED")
+        except Exception as e:
+            print(f"  {m}: FAILED - {e}")

--- a/python/tests/test_solver_timeout.py
+++ b/python/tests/test_solver_timeout.py
@@ -1,0 +1,104 @@
+import time
+
+import pytest
+
+from combaero.network import FlowNetwork, NetworkSolver, OrificeElement, PressureBoundary
+
+
+def test_solver_no_timeout():
+    """Verify solver still works normally when no timeout is hit."""
+    graph = FlowNetwork()
+    inlet = PressureBoundary("inlet", P_total=200000, T_total=300)
+    outlet = PressureBoundary("outlet", P_total=100000, T_total=300)
+    orf = OrificeElement("orf", "inlet", "outlet", Cd=0.6, area=0.001)
+
+    graph.add_node(inlet)
+    graph.add_node(outlet)
+    graph.add_element(orf)
+
+    solver = NetworkSolver(graph)
+    solution = solver.solve(timeout=1.0)  # 1 second is plenty
+
+    assert "orf.m_dot" in solution
+    assert solution["orf.m_dot"] > 0
+
+
+def test_solver_timeout_trigger():
+    """Verify solver triggers a timeout and returns the best iterate."""
+    graph = FlowNetwork()
+    inlet = PressureBoundary("inlet", P_total=200000, T_total=300)
+    outlet = PressureBoundary("outlet", P_total=100000, T_total=300)
+    orf = OrificeElement("orf", "inlet", "outlet", Cd=0.6, area=0.001)
+
+    graph.add_node(inlet)
+    graph.add_node(outlet)
+    graph.add_element(orf)
+
+    solver = NetworkSolver(graph)
+
+    # Inject an artificial delay in _residuals to force a timeout
+    original_residuals = solver._residuals
+
+    def slow_residuals(x):
+        time.sleep(0.2)
+        return original_residuals(x)
+
+    solver._residuals = slow_residuals
+
+    with pytest.warns(UserWarning, match="Solver timed out"):
+        solution = solver.solve(timeout=0.1)  # 0.1s is shorter than one evaluation
+
+    # It should return the initial guess (the 'best' seen so far)
+    assert "orf.m_dot" in solution
+    assert solution["orf.m_dot"] == 0.1  # Default initial guess for m_dot
+
+
+def test_solver_maxfev_limit():
+    """Verify solver respects maxfev for hybr method."""
+    graph = FlowNetwork()
+    inlet = PressureBoundary("inlet", P_total=200000, T_total=300)
+    outlet = PressureBoundary("outlet", P_total=100000, T_total=300)
+    orf = OrificeElement("orf", "inlet", "outlet", Cd=0.6, area=0.001)
+
+    graph.add_node(inlet)
+    graph.add_node(outlet)
+    graph.add_element(orf)
+
+    solver = NetworkSolver(graph)
+
+    # Force failure via low maxfev
+    with pytest.warns(UserWarning, match="The number of calls to function has reached maxfev"):
+        solution = solver.solve(method="hybr", options={"maxfev": 1})
+
+    assert "orf.m_dot" in solution
+
+
+def test_solver_unexpected_error_graceful_exit():
+    """Verify solver returns best iterate on unexpected residuals error."""
+    graph = FlowNetwork()
+    inlet = PressureBoundary("inlet", P_total=200000, T_total=300)
+    outlet = PressureBoundary("outlet", P_total=100000, T_total=300)
+    orf = OrificeElement("orf", "inlet", "outlet", Cd=0.6, area=0.001)
+
+    graph.add_node(inlet)
+    graph.add_node(outlet)
+    graph.add_element(orf)
+
+    solver = NetworkSolver(graph)
+    original_residuals = solver._residuals
+
+    call_count = 0
+
+    def failing_residuals(x):
+        nonlocal call_count
+        call_count += 1
+        if call_count > 1:
+            raise RuntimeError("Unexpected failure")
+        return original_residuals(x)
+
+    solver._residuals = failing_residuals
+
+    with pytest.warns(UserWarning, match="Unexpected error during residual evaluation"):
+        solution = solver.solve()
+
+    assert "orf.m_dot" in solution


### PR DESCRIPTION
This PR implements a wall-clock timeout and best-iterate recovery in NetworkSolver.solve(). It also adds a comprehensive stress test suite verifying 10 root-finding methods.