### PR TITLE
fix: state property units mismatch and example runner automation

### DIFF
--- a/COMMIT_MSG.md
+++ b/COMMIT_MSG.md
@@ -1,9 +1,6 @@
-fix: compressible momentum chambers and robust friction blending
+fix: state property units mismatch and example runner automation
 
-Implemented compressible momentum chambers and a robust friction model transition between laminar and turbulent regimes.
-
-- Added MomentumBoundary node and compressible support for MomentumChamberNode.
-- Implemented smooth C1 blending between laminar (64/Re) and turbulent friction models.
-- Added analytical Jacobians for blended friction to solver interface.
-- Optimized benchmark suite with dynamic repeats and parameterized grid tests.
-- Consolidated grid examples in python/examples.
+- Fixed critical units mismatch in `_core.cpp` where `State` properties (SP, HP, etc.) were double-converting mass-based units.
+- Created `scripts/run_examples.py` for automated discovery and verification of Python examples.
+- Simplified `network_from_grid.py` and moved intensive Mach sweep to `benchmarks/mach_sweep_network.py`.
+- Fixed multiple API regressions in examples and corrected orifice dimensions.

--- a/benchmarks/mach_sweep_network.py
+++ b/benchmarks/mach_sweep_network.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Benchmark: Fully coupled Mach sweep (0.05 to 1.0).
+
+This script performs an intensive Mach sweep calculation for both
+compressible and incompressible coupled network models.
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+from dataclasses import dataclass
+from typing import Literal
+
+import combaero as cb
+from combaero.heat_transfer import ConvectiveSurface, SmoothModel
+from combaero.network import (
+    FlowNetwork,
+    MassFlowBoundary,
+    NetworkSolver,
+    OrificeElement,
+    PipeElement,
+    PlenumNode,
+    PressureBoundary,
+    WallConnection,
+)
+
+# Reuse logic from example but with full resolution
+Regime = Literal["compressible", "incompressible"]
+
+@dataclass(frozen=True)
+class SweepConfig:
+    t_hot_in: float = 750.0
+    t_cold_in: float = 320.0
+    p_out_hot: float = 2.0e5
+    p_out_cold: float = 2.0e5
+    d_pipe_hot: float = 0.018
+    d_pipe_cold: float = 0.014
+    l_pipe: float = 1.2
+    roughness: float = 1.0e-5
+    cd: float = 0.72
+    d_orifice_hot: float = 0.012
+    d_orifice_cold: float = 0.010
+    wall_thickness: float = 0.002
+    wall_k: float = 20.0
+
+def _area_from_diameter(diameter: float) -> float:
+    return float(np.pi * (diameter / 2.0) ** 2)
+
+def _mdot_for_target_mach(mach: float, T: float, P_ref: float, X_mole: list[float], area: float) -> float:
+    rho = cb.density(T, P_ref, X_mole)
+    a = cb.speed_of_sound(T, X_mole)
+    return float(mach * rho * a * area)
+
+def _build_coupled_network(regime: Regime, mach_target: float, cfg: SweepConfig) -> tuple[FlowNetwork, float]:
+    x_mole = cb.standard_dry_air_composition()
+    y_mass = list(cb.mole_to_mass(x_mole))
+    area_hot = _area_from_diameter(cfg.d_pipe_hot)
+    area_cold = _area_from_diameter(cfg.d_pipe_cold)
+    mdot_hot = _mdot_for_target_mach(mach_target, cfg.t_hot_in, cfg.p_out_hot, x_mole, area_hot)
+    mdot_cold = 0.65 * _mdot_for_target_mach(mach_target, cfg.t_cold_in, cfg.p_out_cold, x_mole, area_cold)
+    net = FlowNetwork()
+    net.add_node(MassFlowBoundary("hot_inlet", m_dot=mdot_hot, T_total=cfg.t_hot_in, Y=y_mass))
+    net.add_node(PlenumNode("hot_plenum"))
+    net.add_node(PressureBoundary("hot_outlet", P_total=cfg.p_out_hot, T_total=cfg.t_hot_in, Y=y_mass))
+    net.add_node(MassFlowBoundary("cold_inlet", m_dot=mdot_cold, T_total=cfg.t_cold_in, Y=y_mass))
+    net.add_node(PlenumNode("cold_plenum"))
+    net.add_node(PressureBoundary("cold_outlet", P_total=cfg.p_out_cold, T_total=cfg.t_cold_in, Y=y_mass))
+    pipe_regime = "compressible_fanno" if regime == "compressible" else "incompressible"
+    orifice_regime = "compressible" if regime == "compressible" else "incompressible"
+    hot_surface = ConvectiveSurface(area=np.pi * cfg.d_pipe_hot * cfg.l_pipe, model=SmoothModel())
+    cold_surface = ConvectiveSurface(area=np.pi * cfg.d_pipe_cold * cfg.l_pipe, model=SmoothModel())
+    net.add_element(PipeElement(id="hot_pipe", from_node="hot_inlet", to_node="hot_plenum", length=cfg.l_pipe, diameter=cfg.d_pipe_hot, roughness=cfg.roughness, regime=pipe_regime, surface=hot_surface))
+    net.add_element(OrificeElement(id="hot_orifice", from_node="hot_plenum", to_node="hot_outlet", Cd=cfg.cd, area=_area_from_diameter(cfg.d_orifice_hot), regime=orifice_regime))
+    net.add_element(PipeElement(id="cold_pipe", from_node="cold_inlet", to_node="cold_plenum", length=cfg.l_pipe, diameter=cfg.d_pipe_cold, roughness=cfg.roughness, regime=pipe_regime, surface=cold_surface))
+    net.add_element(OrificeElement(id="cold_orifice", from_node="cold_plenum", to_node="cold_outlet", Cd=cfg.cd, area=_area_from_diameter(cfg.d_orifice_cold), regime=orifice_regime))
+    net.add_wall(WallConnection(id="coupling_wall", element_a="hot_pipe", element_b="cold_pipe", wall_thickness=cfg.wall_thickness, wall_conductivity=cfg.wall_k))
+    net.thermal_coupling_enabled = True
+    return net, mdot_hot
+
+def run_sweep(mach_values: np.ndarray, regime: Regime, cfg: SweepConfig) -> dict[str, np.ndarray]:
+    pr_hot, pr_cold, mach_solved_hot, delta_t_hot, delta_t_cold = [], [], [], [], []
+    x_mole = cb.standard_dry_air_composition()
+    area_hot = _area_from_diameter(cfg.d_pipe_hot)
+    x0_prev = None
+    for m_target in mach_values:
+        net, mdot_hot = _build_coupled_network(regime=regime, mach_target=float(m_target), cfg=cfg)
+        solver = NetworkSolver(net)
+        sol = solver.solve(method="hybr")
+        if not sol.get("__success__", False) and x0_prev is not None:
+            sol = solver.solve(method="hybr", x0=x0_prev)
+        if not sol.get("__success__", False):
+            print(f"WARNING: {regime} solve failed at target Mach={m_target:.3f}")
+            continue
+        x0_prev = solver._last_x
+        p_in_hot, p_in_cold = float(sol["hot_inlet.P_total"]), float(sol["cold_inlet.P_total"])
+        pr_hot.append(cfg.p_out_hot / p_in_hot)
+        pr_cold.append(cfg.p_out_cold / p_in_cold)
+        rho_hot = cb.density(cfg.t_hot_in, p_in_hot, x_mole)
+        a_hot = cb.speed_of_sound(cfg.t_hot_in, x_mole)
+        mach_solved_hot.append(mdot_hot / (rho_hot * a_hot * area_hot))
+        t_hot_out = float(solver._derived_states["hot_plenum"][0])
+        t_cold_out = float(solver._derived_states["cold_plenum"][0])
+        delta_t_hot.append(cfg.t_hot_in - t_hot_out)
+        delta_t_cold.append(t_cold_out - cfg.t_cold_in)
+
+    return {k: np.array(v) for k, v in zip(["mach_solved_hot", "pr_hot", "pr_cold", "delta_t_hot", "delta_t_cold"],
+                                          [mach_solved_hot, pr_hot, pr_cold, delta_t_hot, delta_t_cold])}
+
+import sys
+import os
+# Add examples directory to path to import plot_utils
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "python", "examples")))
+
+try:
+    from plot_utils import show_or_save
+except ImportError:
+    # Fallback if invoked from a different location
+    def show_or_save(fig, filename):
+        fig.savefig(filename)
+        print(f"Saved: {filename}")
+
+
+if __name__ == "__main__":
+    cfg = SweepConfig()
+    mach_values = np.linspace(0.05, 1.0, 30)
+    print(f"Running intensive Mach sweep ({len(mach_values)} points)...")
+
+    data_comp = run_sweep(mach_values, "compressible", cfg)
+    data_incomp = run_sweep(mach_values, "incompressible", cfg)
+
+    # Plotting
+    fig, ax = plt.subplots(nrows=2, ncols=1, figsize=(10, 8), sharex=True)
+
+    ax[0].plot(data_comp["mach_solved_hot"], data_comp["pr_hot"], "-", label="Compressible")
+    ax[0].plot(data_incomp["mach_solved_hot"], data_incomp["pr_hot"], "--", label="Incompressible")
+    ax[0].set_ylabel("Pressure Ratio (P_out / P_in)")
+    ax[0].set_title("Benchmark: Coupled Network Mach Sweep")
+    ax[0].grid(True, alpha=0.3)
+    ax[0].legend()
+
+    pr_diff = 100.0 * (data_incomp["pr_hot"] - data_comp["pr_hot"]) / data_comp["pr_hot"]
+    ax[1].plot(data_comp["mach_solved_hot"], pr_diff, "r-")
+    ax[1].set_ylabel("PR Difference [%]\n(Incomp - Comp)")
+    ax[1].set_xlabel("Mach Number")
+    ax[1].grid(True, alpha=0.3)
+
+    fig.tight_layout()
+    show_or_save(fig, "benchmark_mach_sweep.png")
+    print("Done. Benchmark complete.")

--- a/python/combaero/_core.cpp
+++ b/python/combaero/_core.cpp
@@ -1272,8 +1272,7 @@ PYBIND11_MODULE(_core, m) {
       .def_property(
           "HP",
           [](const State &s) {
-            double h_mass = s.h() / s.mw() * 1000.0;
-            return py::make_tuple(h_mass, s.P);
+            return py::make_tuple(s.h(), s.P);
           },
           [](State &s, py::tuple t) {
             if (t.size() != 2)
@@ -1284,8 +1283,7 @@ PYBIND11_MODULE(_core, m) {
       .def_property(
           "SP",
           [](const State &s) {
-            double s_mass = s.s() / s.mw() * 1000.0;
-            return py::make_tuple(s_mass, s.P);
+            return py::make_tuple(s.s(), s.P);
           },
           [](State &s, py::tuple t) {
             if (t.size() != 2)
@@ -1296,9 +1294,8 @@ PYBIND11_MODULE(_core, m) {
       .def_property(
           "UV",
           [](const State &s) {
-            double u_mass = s.u() / s.mw() * 1000.0;
             double v_mass = 1.0 / s.rho();
-            return py::make_tuple(u_mass, v_mass);
+            return py::make_tuple(s.u(), v_mass);
           },
           [](State &s, py::tuple t) {
             if (t.size() != 2)
@@ -1310,9 +1307,8 @@ PYBIND11_MODULE(_core, m) {
       .def_property(
           "SV",
           [](const State &s) {
-            double s_mass = s.s() / s.mw() * 1000.0;
             double v_mass = 1.0 / s.rho();
-            return py::make_tuple(s_mass, v_mass);
+            return py::make_tuple(s.s(), v_mass);
           },
           [](State &s, py::tuple t) {
             if (t.size() != 2)
@@ -1337,8 +1333,7 @@ PYBIND11_MODULE(_core, m) {
       .def_property(
           "UP",
           [](const State &s) {
-            double u_mass = s.u() / s.mw() * 1000.0;
-            return py::make_tuple(u_mass, s.P);
+            return py::make_tuple(s.u(), s.P);
           },
           [](State &s, py::tuple t) {
             if (t.size() != 2)
@@ -1351,8 +1346,7 @@ PYBIND11_MODULE(_core, m) {
           "VH",
           [](const State &s) {
             double v_mass = 1.0 / s.rho();
-            double h_mass = s.h() / s.mw() * 1000.0;
-            return py::make_tuple(v_mass, h_mass);
+            return py::make_tuple(v_mass, s.h());
           },
           [](State &s, py::tuple t) {
             if (t.size() != 2)
@@ -1364,9 +1358,7 @@ PYBIND11_MODULE(_core, m) {
       .def_property(
           "SH",
           [](const State &s) {
-            double s_mass = s.s() / s.mw() * 1000.0;
-            double h_mass = s.h() / s.mw() * 1000.0;
-            return py::make_tuple(s_mass, h_mass);
+            return py::make_tuple(s.s(), s.h());
           },
           [](State &s, py::tuple t) {
             if (t.size() != 2)

--- a/python/examples/combustor_network_example.py
+++ b/python/examples/combustor_network_example.py
@@ -45,7 +45,7 @@ def main():
     p_out = PressureBoundary("exhaust", P_total=101325.0, T_total=300.0, Y=Y_air)
 
     # --- Inner Nodes ---
-    combustor = CombustorNode("combustor", method="complete", pressure_loss_frac=0.05)
+    combustor = CombustorNode("combustor", method="complete")
 
     # Provide an initial guess to avoid dP=0 singularity across the nozzle at x0
     combustor.initial_guess = {

--- a/python/examples/compressible_vs_incompressible_network.py
+++ b/python/examples/compressible_vs_incompressible_network.py
@@ -47,8 +47,8 @@ class SweepConfig:
     l_pipe: float = 1.2
     roughness: float = 1.0e-5
     cd: float = 0.72
-    d_orifice_hot: float = 0.030
-    d_orifice_cold: float = 0.025
+    d_orifice_hot: float = 0.012
+    d_orifice_cold: float = 0.010
     wall_thickness: float = 0.002
     wall_k: float = 20.0
 
@@ -211,7 +211,9 @@ def run_sweep(mach_values: np.ndarray, regime: Regime, cfg: SweepConfig) -> dict
 
 def main() -> None:
     cfg = SweepConfig()
-    mach_values = np.linspace(0.05, 1.0, 25)
+    # Reduced sweep for fast demonstration.
+    # For a full Mach sweep (0.05 to 1.0), see benchmarks/mach_sweep_network.py
+    mach_values = np.array([0.1, 0.4, 0.7])
 
     data_incomp = run_sweep(mach_values, regime="incompressible", cfg=cfg)
     data_comp = run_sweep(mach_values, regime="compressible", cfg=cfg)

--- a/python/examples/network_from_grid.py
+++ b/python/examples/network_from_grid.py
@@ -256,40 +256,8 @@ def main():
     total_area = 0.25 * math.pi * (0.8) ** 2  # Even safer Mach numbers, max total diameter 0.8m
     tests = [
         {"m_dot_air": 10.0, "T_ad": 1700.0, "n_parallel": 1, "n_serial": 1, "total_ht_area": 50.0},
-        {"m_dot_air": 10.0, "T_ad": 1700.0, "n_parallel": 2, "n_serial": 1, "total_ht_area": 50.0},
-        {"m_dot_air": 10.0, "T_ad": 1700.0, "n_parallel": 1, "n_serial": 5, "total_ht_area": 50.0},
         {"m_dot_air": 10.0, "T_ad": 1700.0, "n_parallel": 2, "n_serial": 5, "total_ht_area": 50.0},
-        {"m_dot_air": 20.0, "T_ad": 1700.0, "n_parallel": 2, "n_serial": 2, "total_ht_area": 50.0},
-        {"m_dot_air": 20.0, "T_ad": 2200.0, "n_parallel": 2, "n_serial": 2, "total_ht_area": 50.0},
-        {
-            "m_dot_air": 10.0,
-            "T_ad": 1700.0,
-            "n_parallel": 1,
-            "n_serial": 10,
-            "total_ht_area": 100.0,
-        },
-        {"m_dot_air": 10.0, "T_ad": 1700.0, "n_parallel": 4, "n_serial": 4, "total_ht_area": 100.0},
-        {
-            "m_dot_air": 10.0,
-            "T_ad": 1700.0,
-            "n_parallel": 10,
-            "n_serial": 10,
-            "total_ht_area": 200.0,
-        },
-        {
-            "m_dot_air": 10.0,
-            "T_ad": 1700.0,
-            "n_parallel": 20,
-            "n_serial": 5,
-            "total_ht_area": 200.0,
-        },
-        {
-            "m_dot_air": 10.0,
-            "T_ad": 1700.0,
-            "n_parallel": 5,
-            "n_serial": 20,
-            "total_ht_area": 200.0,
-        },
+        {"m_dot_air": 20.0, "T_ad": 2200.0, "n_parallel": 4, "n_serial": 4, "total_ht_area": 100.0},
     ]
 
     print(f"--- Running Combustor Full Coupling Limits ({len(tests)} cases) ---")

--- a/python/examples/wall_coupling_simple.py
+++ b/python/examples/wall_coupling_simple.py
@@ -61,9 +61,10 @@ print("=" * 70)
 print()
 
 # Hot side
-h_hot, T_aw_hot, A_hot = hot_surface.htc_and_T(
+res_hot = hot_surface.htc_and_T(
     T=T_hot, P=P_hot, X=X_air, velocity=u_hot, diameter=D_hot, length=L_hot
 )
+h_hot, T_aw_hot, A_hot = res_hot.h, res_hot.T_aw, hot_surface.area
 
 print("Hot Side (Smooth Channel):")
 print(f"  T_bulk = {T_hot:.1f} K")
@@ -73,9 +74,10 @@ print(f"  A_conv = {A_hot:.4f} m^2")
 print()
 
 # Cold side
-h_cold, T_aw_cold, A_cold = cold_surface.htc_and_T(
+res_cold = cold_surface.htc_and_T(
     T=T_cold, P=P_cold, X=X_air, velocity=u_cold, diameter=D_cold, length=L_cold
 )
+h_cold, T_aw_cold, A_cold = res_cold.h, res_cold.T_aw, cold_surface.area
 
 print("Cold Side (Ribbed Channel):")
 print(f"  T_bulk = {T_cold:.1f} K")

--- a/scripts/run_examples.py
+++ b/scripts/run_examples.py
@@ -1,0 +1,116 @@
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import TypedDict
+
+class ExampleResult(TypedDict):
+    name: str
+    success: bool
+    duration: float
+    error: str | None
+
+def run_example(example_path: Path, timeout: int = 120) -> ExampleResult:
+    """Run a single example script and return the result."""
+    start_time = time.perf_counter()
+    try:
+        # Run with the same python interpreter and headless plotting
+        env = os.environ.copy()
+        env["COMBAERO_SAVE_PLOTS"] = "1"
+
+        result = subprocess.run(
+            [sys.executable, str(example_path)],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=env,
+        )
+        duration = time.perf_counter() - start_time
+        if result.returncode == 0:
+            return {
+                "name": example_path.name,
+                "success": True,
+                "duration": duration,
+                "error": None,
+            }
+        else:
+            return {
+                "name": example_path.name,
+                "success": False,
+                "duration": duration,
+                "error": result.stderr.strip() or "Process exited with non-zero return code.",
+            }
+    except subprocess.TimeoutExpired:
+        duration = time.perf_counter() - start_time
+        return {
+            "name": example_path.name,
+            "success": False,
+            "duration": duration,
+            "error": f"Timeout expired after {timeout}s",
+        }
+    except Exception as e:
+        duration = time.perf_counter() - start_time
+        return {
+            "name": example_path.name,
+            "success": False,
+            "duration": duration,
+            "error": str(e),
+        }
+
+def main() -> None:
+    """Discover and run all Python examples."""
+    examples_dir = Path("python/examples")
+    if not examples_dir.exists():
+        print(f"Error: {examples_dir} not found.")
+        sys.exit(1)
+
+    # Discover all .py files, excluding utilities
+    example_files = sorted([
+        f for f in examples_dir.glob("*.py")
+        if f.name != "plot_utils.py"
+    ])
+
+    print(f"Found {len(example_files)} examples in {examples_dir}")
+    print("-" * 60)
+
+    results: list[ExampleResult] = []
+
+    for i, example_file in enumerate(example_files, 1):
+        print(f"[{i}/{len(example_files)}] Running {example_file.name}...", end=" ", flush=True)
+        res = run_example(example_file)
+        results.append(res)
+
+        if res["success"]:
+            print(f"SUCCESS ({res['duration']:.2f}s)")
+        else:
+            print("FAILED")
+
+    print("\n" + "=" * 60)
+    print("SUMMARY REPORT")
+    print("=" * 60)
+
+    successful = [r for r in results if r["success"]]
+    failed = [r for r in results if not r["success"]]
+
+    total_time = sum(r["duration"] for r in results)
+
+    print(f"Total Examples: {len(results)}")
+    print(f"Successful:     {len(successful)}")
+    print(f"Failed:         {len(failed)}")
+    print(f"Total Wall Time: {total_time:.2f}s")
+    print("-" * 60)
+
+    if failed:
+        print("\nFAILED EXAMPLES DIAGNOSIS:")
+        for res in failed:
+            print(f"\n--- {res['name']} ---")
+            print(f"Error:\n{res['error']}")
+        print("-" * 60)
+        sys.exit(1)
+    else:
+        print("\nAll examples ran successfully!")
+        sys.exit(0)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
fix: state property units mismatch and example runner automation

- Fixed critical units mismatch in `_core.cpp` where `State` properties (SP, HP, etc.) were double-converting mass-based units.
- Created `scripts/run_examples.py` for automated discovery and verification of Python examples.
- Simplified `network_from_grid.py` and moved intensive Mach sweep to `benchmarks/mach_sweep_network.py`.
- Fixed multiple API regressions in examples and corrected orifice dimensions.
