### PR TITLE
ci: implement dependabot semver split strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,16 +5,18 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      python-dependencies:
+      python-safe-updates:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
 
   - package-ecosystem: "npm"
     directory: "/gui/frontend"
     schedule:
       interval: "weekly"
     groups:
-      frontend-dependencies:
+      frontend-safe-updates:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary
This PR refines the Dependabot configuration to implement a **SemVer Split** strategy for the `uv` and `npm` ecosystems.

## Changes
- **Grouped Updates**: Bundles `minor` and `patch` updates into a single weekly PR per ecosystem.
- **Isolated Major Updates**: Requires independent reviews for major (potential breaking) version changes to ensure project stability.
- **Maintained Actions**: Continues the 'All-In' strategy for GitHub Actions to keep CI tools synchronized.

This approach balances developer velocity with robust dependency management.跑方