### PR TITLE
fix: add hard solver timeouts and prevent empty network solve

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,10 +21,16 @@
 - Type annotations on all signatures; `-> None` for void functions; `|` union syntax (Python 3.12).
 - No non-ASCII characters, including docstrings and comments.
 
+## Frontend Style (gui/frontend)
+- Package manager: `pnpm`. Use `pnpm install`, `pnpm run dev`, etc.
+- Linting and formatting: `biome`. Run `./scripts/check-gui-style.sh` before committing.
+- Biome config: `biome.json` at repo root.
+
 ## Key Scripts
 ```bash
 ./scripts/check-source-style.sh             # C++ style
 ./scripts/check-python-style.sh --fix       # Python lint + format
+./scripts/check-gui-style.sh                # Frontend lint + format (biome)
 uv pip install -e .                         # rebuild C++ extension
 uv run pytest python/tests/                 # Python tests
 cd build && ctest                           # C++ tests
@@ -40,3 +46,6 @@ uv run scripts/generate_units_md.py         # regenerate docs/UNITS.md
 ## Version Sync Checklist
 When changing Python version or tool versions, keep in sync:
 `.python-version` · `ruff.toml` · `ci.yml` · `validation-tests.yml` · `.pre-commit-config.yaml` · `Makefile`
+
+When changing frontend tool versions, keep in sync:
+`gui/frontend/package.json` · `biome.json` (`$schema` version) · `.pre-commit-config.yaml` (biome rev + `@biomejs/biome` pin)

--- a/gui/backend/graph_builder.py
+++ b/gui/backend/graph_builder.py
@@ -1,4 +1,5 @@
 from combaero.network import (
+    AreaChangeElement,
     ChannelElement,
     CombustorNode,
     ConstantFractionLoss,
@@ -21,10 +22,10 @@ from combaero.network import (
     SmoothModel,
     ThermalWall,
     WallLayer,
-    AreaChangeElement,
 )
 
 from .schemas import (
+    AreaChangeData,
     ChannelData,
     CombustorData,
     CompositionData,
@@ -45,7 +46,6 @@ from .schemas import (
     RibbedModelData,
     SmoothModelData,
     ThermalWallData,
-    AreaChangeData,
 )
 
 

--- a/gui/backend/main.py
+++ b/gui/backend/main.py
@@ -138,10 +138,16 @@ def _solve_sync(schema: NetworkGraphSchema):
 
 @app.post("/solve", response_model=SolveResponse)
 async def solve(schema: NetworkGraphSchema):
+    # Hard async-level deadline: even if a single C++ Fanno/RK4 step blocks,
+    # the event loop stays alive for health checks and subsequent requests.
+    # Add a 10 s buffer on top of the solver's own soft timeout.
+    soft_timeout = schema.solver_settings.timeout or 180.0
+    hard_timeout = soft_timeout + 10.0
     try:
         # Offload CPU-bound C++ solver to a worker thread
-        result, node_results, element_results, edge_results, _ = await asyncio.to_thread(
-            _solve_sync, schema
+        result, node_results, element_results, edge_results, _ = await asyncio.wait_for(
+            asyncio.to_thread(_solve_sync, schema),
+            timeout=hard_timeout,
         )
 
         return SolveResponse(
@@ -152,6 +158,12 @@ async def solve(schema: NetworkGraphSchema):
             element_results=element_results,
             edge_results=edge_results,
         )
+    except TimeoutError:
+        raise HTTPException(
+            status_code=504,
+            detail=f"Solver exceeded the hard timeout of {hard_timeout:.0f}s. "
+            "Try a shorter timeout, a simpler network, or the homotopy init strategy.",
+        ) from None
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as e:
@@ -160,10 +172,13 @@ async def solve(schema: NetworkGraphSchema):
 
 @app.post("/export")
 async def export_results(schema: NetworkGraphSchema):
+    soft_timeout = schema.solver_settings.timeout or 180.0
+    hard_timeout = soft_timeout + 10.0
     try:
         # Solve quickly to get states
-        _, node_results, element_results, edge_results, _ = await asyncio.to_thread(
-            _solve_sync, schema
+        _, node_results, element_results, edge_results, _ = await asyncio.wait_for(
+            asyncio.to_thread(_solve_sync, schema),
+            timeout=hard_timeout,
         )
 
         # Convert to DataFrame
@@ -280,6 +295,11 @@ async def export_results(schema: NetworkGraphSchema):
             media_type="text/csv",
             headers={"Content-Disposition": "attachment; filename=combaero_results.csv"},
         )
+    except TimeoutError:
+        raise HTTPException(
+            status_code=504,
+            detail=f"Export solve exceeded the hard timeout of {hard_timeout:.0f}s.",
+        ) from None
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as e:

--- a/gui/frontend/src/App.tsx
+++ b/gui/frontend/src/App.tsx
@@ -72,7 +72,7 @@ const App = () => {
 					<button
 						type="button"
 						onClick={exportNetworkResults}
-						disabled={isExporting}
+						disabled={isExporting || nodes.length === 0}
 						className="flex items-center gap-2 px-4 py-1.5 border rounded-md hover:bg-slate-50 transition-colors text-sm font-medium disabled:opacity-60 disabled:cursor-not-allowed min-w-[124px] justify-center"
 					>
 						{isExporting ? (
@@ -103,7 +103,7 @@ const App = () => {
 					<button
 						type="button"
 						onClick={handleSolve}
-						disabled={isSolving}
+						disabled={isSolving || nodes.length === 0}
 						className="flex items-center gap-2 px-6 py-1.5 bg-orange-500 text-white rounded-md hover:bg-orange-600 transition-colors shadow-sm text-sm font-bold disabled:opacity-60 disabled:cursor-not-allowed"
 					>
 						{isSolving ? (

--- a/gui/frontend/src/store/useStore.ts
+++ b/gui/frontend/src/store/useStore.ts
@@ -201,7 +201,7 @@ const useStore = create<RFState>((set, get) => ({
 	solverSettings: {
 		global_regime: "compressible",
 		init_strategy: "default",
-		timeout: 180,
+		timeout: 30,
 	},
 	updateSolverSettings: (settings: Partial<RFState["solverSettings"]>) => {
 		set({

--- a/gui/frontend/src/utils/validation.ts
+++ b/gui/frontend/src/utils/validation.ts
@@ -11,6 +11,11 @@ import type { Node } from "reactflow";
 export function validateNetwork(nodes: Node[]): string[] {
 	const errors: string[] = [];
 
+	if (nodes.length === 0) {
+		errors.push("Network is empty. Add nodes and elements before solving.");
+		return errors;
+	}
+
 	for (const node of nodes) {
 		if (node.type === "pressure_boundary" || node.type === "mass_boundary") {
 			if ((node.data.P_total || 0) <= 0 && node.type === "pressure_boundary") {


### PR DESCRIPTION
This PR adds hard asyncio timeouts to the backend solve and export endpoints to prevent worker lockup during long C++ evaluations. It also adds frontend validation to prevent solving empty networks and lowers the default solver timeout to 30s.