### PR TITLE
feat: add stagnation and transport helpers with performance optimizations

### DIFF
--- a/docs/API_CPP.md
+++ b/docs/API_CPP.md
@@ -122,6 +122,7 @@ double thermal_conductivity(double T, double P, const std::vector<double>& X);
 double prandtl(double T, double P, const std::vector<double>& X);
 double kinematic_viscosity(double T, double P, const std::vector<double>& X);
 double thermal_diffusivity(double T, double P, const std::vector<double>& X);
+double reynolds_from_state(double rho, double v, double L, double mu);
 ```
 
 ---
@@ -191,6 +192,14 @@ double P_from_stagnation(double P0, double T0, double M, const std::vector<doubl
 double T_adiabatic_wall(double T_static, double v, double T, double P,
                         const std::vector<double>& X, bool turbulent = true);
 double recovery_factor(double Pr, bool turbulent = true);
+
+double bulk_velocity(double m_dot, double rho, double area);
+double kinetic_energy(double v);
+
+std::tuple<double, double> stagnation_from_static(
+    double T, double P, double v,
+    const std::vector<double>& X,
+    double tol = 1e-8, std::size_t max_iter = 50);
 ```
 
 ---

--- a/docs/API_PYTHON.md
+++ b/docs/API_PYTHON.md
@@ -522,10 +522,18 @@ T_from_u = cb.calc_T_from_u(u_target=2.2e5, X=air)
 
 ### Flow Analysis
 ```python
+# Bulk velocity and kinetic energy
+v = cb.bulk_velocity(m_dot=0.5, rho=1.2, area=1e-3)   # m/s
+KE = cb.kinetic_energy(v=v)                             # J/kg
+
 # Dimensionless numbers
-Re = cb.reynolds(rho=1.2, v=10, D=0.05, mu=1.8e-5)
-Pe = cb.peclet(rho=1.2, v=10, D=0.05, cp=1000, k=0.026)
-KE = cb.kinetic_energy(rho=1.2, v=10)
+# From full mixture state (recomputes rho, mu internally):
+Re = cb.reynolds(T=300, P=101325, X=air, V=v, L=0.05)
+# From pre-computed state properties (use when CompleteState is available):
+Re = cb.reynolds_from_state(rho=1.2, v=v, L=0.05, mu=1.8e-5)
+
+# Stagnation conditions from static state and velocity
+Tt, Pt = cb.stagnation_from_static(T=300, P=101325, v=v, X=air)  # (K, Pa)
 ```
 
 ---

--- a/docs/UNITS.md
+++ b/docs/UNITS.md
@@ -138,6 +138,7 @@ All functions use consistent units to avoid conversion errors.
 | `kinematic_viscosity`  | T: K, P: Pa, X: mol/mol               | m^2/s       |
 | `thermal_diffusivity`  | T: K, P: Pa, X: mol/mol               | m^2/s       |
 | `reynolds`             | T: K, P: Pa, X: mol/mol, V: m/s, L: m | - (Re)      |
+| `reynolds_from_state`  | rho: kg/m^3, v: m/s, L: m, mu: Pa*s   | - (Re)      |
 | `peclet`               | T: K, P: Pa, X: mol/mol, V: m/s, L: m | - (Pe)      |
 
 ---
@@ -374,20 +375,22 @@ All functions use consistent units to avoid conversion errors.
 
 #### Stagnation/Static Conversions
 
-| Function                | Input Units                                  | Output Unit |
-|-------------------------|----------------------------------------------|-------------|
-| `kinetic_energy`        | v: m/s                                       | J/kg        |
-| `h0_from_static`        | h_static: J/kg, v: m/s                       | J/kg        |
-| `v_from_h0`             | h0: J/kg, h_static: J/kg                     | m/s         |
-| `mach_number`           | v: m/s, T: K, X: mol/mol                     | - (M)       |
-| `T0_from_static`        | T: K, M: -, X: mol/mol                       | K           |
-| `T0_from_static_v`      | T: K, v: m/s, X: mol/mol                     | K           |
-| `T_from_stagnation`     | T0: K, M: -, X: mol/mol                      | K           |
-| `P0_from_static`        | P: Pa, T: K, M: -, X: mol/mol                | Pa          |
-| `P_from_stagnation`     | P0: Pa, T0: K, M: -, X: mol/mol              | Pa          |
-| `recovery_factor`       | Pr: -                                        | - (r)       |
-| `T_adiabatic_wall`      | T_static: K, v: m/s, T: K, P: Pa, X: mol/mol | K           |
-| `T_adiabatic_wall_mach` | T_static: K, M: -, T: K, P: Pa, X: mol/mol   | K           |
+| Function                 | Input Units                                  | Output Unit  |
+|--------------------------|----------------------------------------------|--------------|
+| `kinetic_energy`         | v: m/s                                       | J/kg         |
+| `bulk_velocity`          | m_dot: kg/s, rho: kg/m^3, area: m^2          | m/s          |
+| `h0_from_static`         | h_static: J/kg, v: m/s                       | J/kg         |
+| `v_from_h0`              | h0: J/kg, h_static: J/kg                     | m/s          |
+| `mach_number`            | v: m/s, T: K, X: mol/mol                     | - (M)        |
+| `T0_from_static`         | T: K, M: -, X: mol/mol                       | K            |
+| `T0_from_static_v`       | T: K, v: m/s, X: mol/mol                     | K            |
+| `T_from_stagnation`      | T0: K, M: -, X: mol/mol                      | K            |
+| `P0_from_static`         | P: Pa, T: K, M: -, X: mol/mol                | Pa           |
+| `P_from_stagnation`      | P0: Pa, T0: K, M: -, X: mol/mol              | Pa           |
+| `recovery_factor`        | Pr: -                                        | - (r)        |
+| `T_adiabatic_wall`       | T_static: K, v: m/s, T: K, P: Pa, X: mol/mol | K            |
+| `T_adiabatic_wall_mach`  | T_static: K, M: -, T: K, P: Pa, X: mol/mol   | K            |
+| `stagnation_from_static` | T: K, P: Pa, v: m/s, X: mol/mol              | tuple(K, Pa) |
 
 ### composition.h - Composition Utilities
 

--- a/include/stagnation.h
+++ b/include/stagnation.h
@@ -34,11 +34,17 @@ namespace combaero {
 //   Incropera et al. (2007) Fundamentals of Heat and Mass Transfer, 6th ed.
 
 // -------------------------------------------------------------
-// Kinetic energy
+// Kinetic energy and bulk velocity
 // -------------------------------------------------------------
 
 // Specific kinetic energy: v^2/2  [J/kg]
 inline double kinetic_energy(double v) { return 0.5 * v * v; }
+
+// Bulk velocity from mass flow, density, and cross-sectional area.
+// v = m_dot / (rho * area)  [m/s]
+inline double bulk_velocity(double m_dot, double rho, double area) {
+    return m_dot / (rho * area);
+}
 
 // -------------------------------------------------------------
 // Stagnation enthalpy (exact, no iteration)
@@ -139,6 +145,15 @@ double P_from_stagnation(double P0, double T0, double M,
 double T_adiabatic_wall(double T_static, double v,
                         double T, double P, const std::vector<double>& X,
                         bool turbulent = true);
+
+// Combined stagnation state from static conditions and velocity.
+// Returns (Tt, Pt) = (T0, P0) in a single call.
+// Equivalent to calling T0_from_static_v then P0_from_static, but avoids
+// recomputing Mach number internally.
+std::tuple<double, double> stagnation_from_static(
+    double T, double P, double v,
+    const std::vector<double>& X,
+    double tol = 1e-8, std::size_t max_iter = 50);
 
 // Convenience: T_aw from static temperature and Mach number.
 // Computes v = M * a(T, X) internally.

--- a/include/transport.h
+++ b/include/transport.h
@@ -16,8 +16,16 @@ double thermal_conductivity(double T, double P, const std::vector<double>& X);
 double prandtl(double T, double P, const std::vector<double>& X);
 double kinematic_viscosity(double T, double P, const std::vector<double>& X);
 double thermal_diffusivity(double T, double P, const std::vector<double>& X);  // α = k/(ρ·cp) [m²/s]
-double reynolds(double T, double P, const std::vector<double>& X, double V, double L);  // Re = ρVL/μ [-]
-double peclet(double T, double P, const std::vector<double>& X, double V, double L);    // Pe = VL/α [-]
+double reynolds(double T, double P, const std::vector<double>& X, double V, double L);  // Re = rho*VL/mu [-]
+double peclet(double T, double P, const std::vector<double>& X, double V, double L);    // Pe = VL/alpha [-]
+
+// Reynolds number from pre-computed density and dynamic viscosity.
+// Use this when a CompleteState/TransportState is already available to avoid
+// re-evaluating mixture properties.
+// Re = rho * v * L / mu  [-]
+inline double reynolds_from_state(double rho, double v, double L, double mu) {
+    return (rho * v * L) / mu;
+}
 
 // -------------------------------------------------------------
 // Transport State Bundle

--- a/include/units_data.h
+++ b/include/units_data.h
@@ -172,6 +172,7 @@ inline constexpr Entry function_units[] = {
     {"kinematic_viscosity", "T: K, P: Pa, X: mol/mol", "m^2/s"},
     {"thermal_diffusivity", "T: K, P: Pa, X: mol/mol", "m^2/s"},
     {"reynolds", "T: K, P: Pa, X: mol/mol, V: m/s, L: m", "- (Re)"},
+    {"reynolds_from_state", "rho: kg/m^3, v: m/s, L: m, mu: Pa*s", "- (Re)"},
     {"peclet", "T: K, P: Pa, X: mol/mol, V: m/s, L: m", "- (Pe)"},
 
     // -------------------------------------------------------------------------
@@ -614,6 +615,7 @@ inline constexpr Entry function_units[] = {
     // stagnation.h - Stagnation/Static Conversions
     // -------------------------------------------------------------------------
     {"kinetic_energy", "v: m/s", "J/kg"},
+    {"bulk_velocity", "m_dot: kg/s, rho: kg/m^3, area: m^2", "m/s"},
     {"h0_from_static", "h_static: J/kg, v: m/s", "J/kg"},
     {"v_from_h0", "h0: J/kg, h_static: J/kg", "m/s"},
     {"mach_number", "v: m/s, T: K, X: mol/mol", "- (M)"},
@@ -626,6 +628,7 @@ inline constexpr Entry function_units[] = {
     {"T_adiabatic_wall", "T_static: K, v: m/s, T: K, P: Pa, X: mol/mol", "K"},
     {"T_adiabatic_wall_mach", "T_static: K, M: -, T: K, P: Pa, X: mol/mol",
      "K"},
+    {"stagnation_from_static", "T: K, P: Pa, v: m/s, X: mol/mol", "tuple(K, Pa)"},
 
     // -------------------------------------------------------------------------
     // heat_transfer.h - ChannelResult fields

--- a/python/combaero/_core.cpp
+++ b/python/combaero/_core.cpp
@@ -5272,6 +5272,30 @@ PYBIND11_MODULE(_core, m) {
       "Computes v = M * a(T, X) internally, then applies recovery factor "
       "correction.");
 
+  m.def(
+      "stagnation_from_static",
+      [](double T, double P, double v,
+         py::array_t<double, py::array::c_style | py::array::forcecast> X_arr,
+         double tol, std::size_t max_iter) {
+        return stagnation_from_static(T, P, v, to_vec(X_arr), tol, max_iter);
+      },
+      py::arg("T"), py::arg("P"), py::arg("v"), py::arg("X"),
+      py::arg("tol") = 1e-8, py::arg("max_iter") = 50,
+      "Combined stagnation state (Tt, Pt) from static (T, P) and velocity v.\n"
+      "Returns tuple (Tt [K], Pt [Pa]).\n"
+      "Preferred over calling T0_from_static_v + P0_from_static separately\n"
+      "as it uses a single Newton loop and avoids redundant physics calls.");
+
+  m.def("bulk_velocity", &bulk_velocity, py::arg("m_dot"), py::arg("rho"),
+        py::arg("area"),
+        "Bulk velocity v = m_dot / (rho * area)  [m/s].");
+
+  m.def("reynolds_from_state", &reynolds_from_state, py::arg("rho"),
+        py::arg("v"), py::arg("L"), py::arg("mu"),
+        "Reynolds number Re = rho * v * L / mu  [-].\n"
+        "Use when rho and mu are already available from CompleteState or\n"
+        "TransportState to avoid recomputing mixture properties.");
+
   // -----------------------------------------------------------------
   // ChannelResult struct
   // -----------------------------------------------------------------

--- a/src/stagnation.cpp
+++ b/src/stagnation.cpp
@@ -238,4 +238,33 @@ double T_adiabatic_wall_mach(double T_static, double M,
     return T_adiabatic_wall(T_static, v, T, P, X, turbulent);
 }
 
+std::tuple<double, double> stagnation_from_static(
+    double T, double P, double v,
+    const std::vector<double>& X,
+    double tol, std::size_t max_iter)
+{
+    if (T <= 0.0)
+        throw std::invalid_argument("stagnation_from_static: T must be positive");
+    if (P <= 0.0)
+        throw std::invalid_argument("stagnation_from_static: P must be positive");
+    if (v < 0.0)
+        throw std::invalid_argument("stagnation_from_static: v must be non-negative");
+    if (v == 0.0) return {T, P};
+
+    // One Newton loop for Tt.
+    double Tt = T0_from_static_v(T, v, X, tol, max_iter);
+
+    // Pt from isentropic entropy conservation: s(T, P) = s(Tt, Pt).
+    // Bypasses P0_from_static to avoid its internal T0_from_static call,
+    // which would repeat the Newton loop and re-evaluate speed_of_sound(T, X).
+    constexpr double P_REF = 101325.0;
+    const double mw_kg  = mwmix(X) / 1000.0;
+    const double R_spec = specific_gas_constant(X);
+    const double s_static = s(T,  X, P,     P_REF) / mw_kg;
+    const double s_stag   = s(Tt, X, P_REF, P_REF) / mw_kg;
+    double Pt = P_REF * std::exp((s_stag - s_static) / R_spec);
+
+    return {Tt, Pt};
+}
+
 } // namespace combaero


### PR DESCRIPTION
Integrated new flow analysis utilities in the C++ backend and Python API. Includes stagnation_from_static, bulk_velocity, and reynolds_from_state. The stagnation solver is optimized to use entropy conservation, avoiding redundant Newton loops and acoustic evaluations.