### PR TITLE
feat: expose solver method selection in the GUI sidebar

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -47,4 +47,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr *)'
-

--- a/COMMIT_MSG.md
+++ b/COMMIT_MSG.md
@@ -1,0 +1,7 @@
+feat: expose solver method selection in the GUI sidebar
+
+Exposed the `method` parameter of `NetworkSolver.solve()` (e.g., `hybr`, `lm`, `krylov`) to the user via the "Solver Configuration" sidebar.
+- Added `method` to `SolverSettings` Pydantic model with Literal validation.
+- Updated FastAPI solve handler to pass the selected method to the solver.
+- Integrated `method` into the frontend Zustand store.
+- Added a dropdown menu in the Sidebar component for algorithm selection.

--- a/gui/backend/main.py
+++ b/gui/backend/main.py
@@ -74,6 +74,7 @@ def _solve_sync(schema: NetworkGraphSchema):
     net = build_network_from_schema(schema)
     solver = NetworkSolver(net)
     result = solver.solve(
+        method=schema.solver_settings.method,
         init_strategy=schema.solver_settings.init_strategy,
         timeout=schema.solver_settings.timeout,
     )

--- a/gui/backend/schemas.py
+++ b/gui/backend/schemas.py
@@ -254,6 +254,18 @@ class SolverSettings(BaseModel):
     model_config = ConfigDict(extra="ignore")
     global_regime: Literal["incompressible", "compressible"] = "incompressible"
     init_strategy: Literal["default", "incompressible_warmstart", "homotopy"] = "default"
+    method: Literal[
+        "hybr",
+        "lm",
+        "broyden1",
+        "broyden2",
+        "anderson",
+        "linearmixing",
+        "diagbroyden",
+        "excitingmixing",
+        "krylov",
+        "df-sane",
+    ] = "hybr"
     timeout: float | None = 180.0
 
 

--- a/gui/frontend/src/components/Sidebar.tsx
+++ b/gui/frontend/src/components/Sidebar.tsx
@@ -286,6 +286,27 @@ const Sidebar = () => {
 				</div>
 				<div className="flex flex-col gap-1">
 					<label className="text-[10px] font-bold text-gray-400 uppercase">
+						Solver Method
+					</label>
+					<select
+						className="p-1 border rounded text-xs bg-white"
+						value={solverSettings.method}
+						onChange={(e) => updateSolverSettings({ method: e.target.value })}
+					>
+						<option value="hybr">hybr (Powell)</option>
+						<option value="lm">lm (Levenberg-M.)</option>
+						<option value="krylov">krylov (Iterative)</option>
+						<option value="broyden1">broyden1 (Quasi-N.)</option>
+						<option value="broyden2">broyden2 (Quasi-N.)</option>
+						<option value="anderson">anderson</option>
+						<option value="linearmixing">linearmixing</option>
+						<option value="diagbroyden">diagbroyden</option>
+						<option value="excitingmixing">excitingmixing</option>
+						<option value="df-sane">df-sane</option>
+					</select>
+				</div>
+				<div className="flex flex-col gap-1">
+					<label className="text-[10px] font-bold text-gray-400 uppercase">
 						Max Solver Time (s)
 					</label>
 					<NumericInput

--- a/gui/frontend/src/store/useStore.ts
+++ b/gui/frontend/src/store/useStore.ts
@@ -31,6 +31,7 @@ export interface RFState {
 	solverSettings: {
 		global_regime: "incompressible" | "compressible";
 		init_strategy: "default" | "incompressible_warmstart" | "homotopy";
+		method: string;
 		timeout: number | null;
 	};
 	updateSolverSettings: (settings: Partial<RFState["solverSettings"]>) => void;
@@ -201,6 +202,7 @@ const useStore = create<RFState>((set, get) => ({
 	solverSettings: {
 		global_regime: "compressible",
 		init_strategy: "default",
+		method: "hybr",
 		timeout: 30,
 	},
 	updateSolverSettings: (settings: Partial<RFState["solverSettings"]>) => {


### PR DESCRIPTION
feat: expose solver method selection in the GUI sidebar

Exposed the `method` parameter of `NetworkSolver.solve()` (e.g., `hybr`, `lm`, `krylov`) to the user via the "Solver Configuration" sidebar.
- Added `method` to `SolverSettings` Pydantic model with Literal validation.
- Updated FastAPI solve handler to pass the selected method to the solver.
- Integrated `method` into the frontend Zustand store.
- Added a dropdown menu in the Sidebar component for algorithm selection.
