### PR TITLE
chore: switch versioning to setuptools-scm via git tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install dependencies
-        run: uv sync --all-extras --all-groups
+        run: uv sync --no-install-workspace --all-extras --all-groups
 
       - name: Check Python code style
         run: uv run ./scripts/check-python-style.sh --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Check C++ source code style
         run: ./scripts/check-source-style.sh --verbose
@@ -87,6 +89,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up uv (Build dependencies)
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/validation-tests.yml
+++ b/.github/workflows/validation-tests.yml
@@ -73,6 +73,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
+        env:
+          SETUPTOOLS_SCM_PRETEND_VERSION: "0.0.0.dev0"
         run: uv sync --all-extras --all-groups
 
       - name: Run combustion validation tests
@@ -132,6 +134,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
+        env:
+          SETUPTOOLS_SCM_PRETEND_VERSION: "0.0.0.dev0"
         run: uv sync --all-extras --all-groups
 
       - name: Run Python unit tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["scikit-build-core>=0.12.2", "pybind11>=3.0.4"]
+requires = ["scikit-build-core>=0.12.2", "pybind11>=3.0.4", "setuptools-scm>=8"]
 build-backend = "scikit_build_core.build"
 
 [project]
 name = "combaero"
-version = "0.2.0"
+dynamic = ["version"]
 description = "Combustion and aerothermal tools (C++ core with Python bindings)"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -23,6 +23,7 @@ dev = [
     "pre-commit>=4.0.0",
     "build>=1.2.0",
     "pytest-cov",
+    "setuptools-scm>=10.0.5",
 ]
 
 [tool.scikit-build]
@@ -30,8 +31,13 @@ dev = [
 wheel.packages = ["python/combaero"]
 build.verbose = true
 
+[tool.scikit-build.metadata.version]
+provider = "scikit_build_core.metadata.setuptools_scm"
+
 [tool.scikit-build.cmake]
 args = ["-DCOMBAERO_ENABLE_TESTS=OFF", "-DCOMBAERO_BUILD_PYTHON=ON"]
+
+[tool.setuptools_scm]
 
 [tool.uv]
 managed = true

--- a/uv.lock
+++ b/uv.lock
@@ -154,7 +154,7 @@ wheels = [
 
 [[package]]
 name = "combaero"
-version = "0.2.1.dev1+g9ccabffda.d20260428"
+version = "0.2.1.dev1+g95eaecdd7.d20260428"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },

--- a/uv.lock
+++ b/uv.lock
@@ -154,7 +154,7 @@ wheels = [
 
 [[package]]
 name = "combaero"
-version = "0.2.0"
+version = "0.2.1.dev1+g9ccabffda.d20260428"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },
@@ -181,6 +181,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "setuptools-scm" },
 ]
 
 [package.metadata]
@@ -201,6 +202,7 @@ dev = [
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-cov" },
     { name = "ruff", specifier = ">=0.8.0" },
+    { name = "setuptools-scm", specifier = ">=10.0.5" },
 ]
 
 [[package]]
@@ -1461,6 +1463,29 @@ wheels = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "82.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223 },
+]
+
+[[package]]
+name = "setuptools-scm"
+version = "10.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "setuptools" },
+    { name = "vcs-versioning" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a5/b1/2a6a8ecd6f9e263754036a0b573360bdbd6873b595725e49e11139722041/setuptools_scm-10.0.5.tar.gz", hash = "sha256:bbba8fe754516cdefd017f4456721775e6ef9662bd7887fb52ae26813d4838c3", size = 56748 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e1/342c4434df56aa537f6ce7647eefee521d96fbb828b08acd709865767652/setuptools_scm-10.0.5-py3-none-any.whl", hash = "sha256:f611037d8aae618221503b8fa89319f073438252ae3420e01c9ceec249131a0a", size = 21695 },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1600,6 +1625,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/da/6eee1ff8b6cbeed47eeb5229749168e81eb4b7b999a1a15a7176e51410c9/uvicorn-0.44.0.tar.gz", hash = "sha256:6c942071b68f07e178264b9152f1f16dfac5da85880c4ce06366a96d70d4f31e", size = 86947 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/23/a5bbd9600dd607411fa644c06ff4951bec3a4d82c4b852374024359c19c0/uvicorn-0.44.0-py3-none-any.whl", hash = "sha256:ce937c99a2cc70279556967274414c087888e8cec9f9c94644dfca11bd3ced89", size = 69425 },
+]
+
+[[package]]
+name = "vcs-versioning"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/42/d97a7795055677961c63a1eef8e7b19d5968ed992ed3a70ab8eb012efad8/vcs_versioning-1.1.1.tar.gz", hash = "sha256:fabd75a3cab7dd8ac02fe24a3a9ba936bf258667b5a62ed468c9a1da0f5775bc", size = 97575 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/60/73603fbcdbe5e803855bcce4414f94eaeed449083bd8183e67161af78188/vcs_versioning-1.1.1-py3-none-any.whl", hash = "sha256:b541e2ba79fc6aaa3850f8a7f88af43d97c1c80649c01142ee4146eddbc599e4", size = 79851 },
 ]
 
 [[package]]


### PR DESCRIPTION
Switches versioning to setuptools-scm via git tags and updates uv.lock.