### PR TITLE
ci: fix path filter inconsistencies and trim unnecessary runner usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Check C++ source code style
         run: ./scripts/check-source-style.sh --verbose

--- a/.github/workflows/validation-tests.yml
+++ b/.github/workflows/validation-tests.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       source: ${{ steps.filter.outputs.source }}
+      gui: ${{ steps.filter.outputs.gui }}
       documentation: ${{ steps.filter.outputs.documentation }}
     steps:
       - name: Checkout
@@ -36,7 +37,6 @@ jobs:
               - 'tests/**'
               - 'cantera_validation_tests/**'
               - 'scripts/**'
-              - 'gui/**'
               - 'examples/**'
               - '.github/workflows/**'
               - 'CMakeLists.txt'
@@ -45,6 +45,8 @@ jobs:
               - 'ruff.toml'
               - '.python-version'
               - 'Makefile'
+            gui:
+              - 'gui/**'
             documentation:
               - 'docs/**'
               - 'README.md'
@@ -120,7 +122,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest ]
         python-version: [ '3.12' ]
 
     steps:
@@ -148,7 +150,7 @@ jobs:
   frontend-validation:
     name: Frontend Validation (Node 24 LTS)
     needs: changes
-    if: needs.changes.outputs.source == 'true'
+    if: needs.changes.outputs.gui == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -185,29 +187,35 @@ jobs:
         shell: bash
         run: |
           source_changed="${{ needs.changes.outputs.source }}"
+          gui_changed="${{ needs.changes.outputs.gui }}"
           cantera_result="${{ needs.cantera-validation.result }}"
           py_unit_result="${{ needs.python-unit-tests.result }}"
           frontend_result="${{ needs.frontend-validation.result }}"
 
           echo "source_changed=${source_changed}"
+          echo "gui_changed=${gui_changed}"
           echo "cantera_result=${cantera_result}"
           echo "py_unit_result=${py_unit_result}"
           echo "frontend_result=${frontend_result}"
 
-          if [[ "${source_changed}" != "true" ]]; then
-            echo "Documentation-only (or non-source) change detected. Passing status-check."
-            exit 0
-          fi
-
-          # Allow success OR skipped if no relevant changes triggered it
+          # Allow success OR skipped
           is_success() {
             [[ "$1" == "success" || "$1" == "skipped" ]]
           }
 
-          if is_success "${cantera_result}" && is_success "${py_unit_result}" && is_success "${frontend_result}"; then
-            echo "All validation jobs succeeded or were correctly skipped."
-            exit 0
+          if [[ "${source_changed}" == "true" ]]; then
+            if ! is_success "${cantera_result}" || ! is_success "${py_unit_result}"; then
+              echo "One or more source validation jobs failed or were cancelled."
+              exit 1
+            fi
           fi
 
-          echo "One or more validation jobs failed or were cancelled."
-          exit 1
+          if [[ "${gui_changed}" == "true" ]]; then
+            if ! is_success "${frontend_result}"; then
+              echo "Frontend validation failed or was cancelled."
+              exit 1
+            fi
+          fi
+
+          echo "All required validation jobs passed."
+          exit 0


### PR DESCRIPTION
## Summary

- **Issue 1** — `validation-tests.yml` still included `gui/**` in its `source` filter after the package-separation split in CI. Pure frontend changes were triggering `cantera-validation` and `python-unit-tests` unnecessarily. Added a `gui` filter output and gated `frontend-validation` on `gui_changed`; updated `status-check` to evaluate the two conditions independently (matching the existing pattern in `ci.yml`).
- **Issue 2** — `python-unit-tests` ran on `[ubuntu-latest, macos-latest]`. These are pure Python tests over C++ bindings with negligible platform divergence risk; macOS ABI and linker coverage is already provided by the 3-platform C++ matrix in `ci.yml`. Dropped macOS from the matrix (saves one runner-job per PR).
- **Issue 3** — The `lint` job in `ci.yml` requested `fetch-depth: 0` (full git history) but only runs style checks that have no need for it. Dropped to the shallow-clone default, consistent with the `lint-gui` job.

## Test plan

- [ ] Open a PR that only touches `gui/frontend/` — verify `cantera-validation` and `python-unit-tests` are skipped, `frontend-validation` runs
- [ ] Open a PR that only touches `python/` — verify `frontend-validation` is skipped, `python-unit-tests` and `cantera-validation` run (Ubuntu only)
- [ ] Open a PR touching `src/` — verify full CI matrix runs as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)