### PR TITLE
fix(gui): add missing gui extra and local test scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,8 @@ benchmarks/runs/
 benchmarks/network_solver_benchmark_latest.json
 gui/nw_*.json
 gui/tmp/
+
+# Local Package Testing Environments
+.package_tests/
+test_venv_env/
+test_uv_env/

--- a/gui/pyproject.toml
+++ b/gui/pyproject.toml
@@ -29,6 +29,9 @@ dependencies = [
     "combaero~=0.2",
 ]
 
+[project.optional-dependencies]
+gui = []
+
 [project.urls]
 Homepage = "https://github.com/thiemom/combaero"
 Repository = "https://github.com/thiemom/combaero"


### PR DESCRIPTION
This PR adds the missing [gui] extra to the combaero-gui package metadata to prevent installation warnings. It also introduces a local testing suite in .package_tests/ (ignored by git) for multi-environment validation.