### PR TITLE
ci(gui): trigger publish directly on tag push, drop workflow_run dependency

### DIFF
--- a/.github/workflows/publish-gui.yml
+++ b/.github/workflows/publish-gui.yml
@@ -1,10 +1,8 @@
 name: Publish combaero-gui to PyPI
 
 on:
-  workflow_run:
-    workflows: ["Publish to PyPI"]
-    types: [completed]
-    branches:
+  push:
+    tags:
       - 'v*'
   workflow_dispatch:
 
@@ -15,14 +13,10 @@ jobs:
   build:
     name: Build combaero-gui
     runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
 
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
           fetch-depth: 0
 
       - uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
## Summary

- The `workflow_run` trigger caused `publish-gui.yml` to be **skipped** whenever the upstream `Publish to PyPI` (combaero) workflow ended with anything other than `success` — most notably when a tag is re-pushed after a hotfix and combaero 0.x.y is already on PyPI (400 "File already exists" → conclusion `failure`).
- `combaero-gui` has no hard ordering dependency on combaero being freshly published; it only needs `combaero~=0.2` available on PyPI at install time, which it always is.
- Switch to a direct `push: tags: ['v*']` trigger: simpler, unconditional, fires on every version tag regardless of the combaero workflow outcome.
- Remove the now-redundant `if:` conditional and the `workflow_run.head_sha` ref override.

## Test plan
- [ ] CI passes on this PR
- [ ] On next tag push, `publish-gui.yml` fires immediately without waiting for or depending on the combaero publish workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)