### PR TITLE
chore: add .claude to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,7 @@ diagnostic_reports/
 
 TODO.md
 .aider*
+.claude
 
 # Benchmark run outputs (auto-generated, not for tracking)
 benchmarks/runs/


### PR DESCRIPTION
Excludes the `.claude/` directory (Claude Code local session data) from version control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)