### PR TITLE
feat(gui): data-driven thermal wall arrow and hot/cold probe labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Thermal wall GUI: arrow direction, probe hot/cold labels, dropdown options, depth hint
+  ("0 = Hot, L = Cold"), and "Hot Side Wall Temp" now all reflect the actual heat flow
+  direction from the solver (Q sign) rather than the topology of the drawn edge. Wiring a
+  thermal wall in either direction gives correct visual feedback without manual adjustment.
 - Polar molecule transport model (Monchick-Mason Omega*(2,2) table, 37 T* x 8 delta* points):
   - `Transport_Props` struct gains `dipole_moment` [Debye] and `z_rot` fields.
   - `omega22()` refactored to accept `(T_star, delta_star)` and bilinearly interpolate

--- a/gui/frontend/src/components/Inspector.tsx
+++ b/gui/frontend/src/components/Inspector.tsx
@@ -1272,6 +1272,7 @@ const Inspector = () => {
 			];
 
 			let targetX = targetX_manual;
+			let hotSideShortcut = false;
 			if (
 				selectedEdge.data.probe_mode === "preset" &&
 				selectedEdge.data.probe_preset
@@ -1288,22 +1289,27 @@ const Inspector = () => {
 
 				const L = layer?.thickness || 0;
 				if (type === "hot") {
-					targetX = runningX;
+					targetX = flowsForward ? runningX : runningX + L;
 					probeLabel = `L${safeIndex + 1} ${flowsForward ? "Hot" : "Cold"} Side`;
 				} else if (type === "avg") {
 					targetX = runningX + L / 2;
 					probeLabel = `L${safeIndex + 1} Average`;
 				} else {
-					targetX = runningX + L;
+					targetX = flowsForward ? runningX + L : runningX;
 					probeLabel = `L${safeIndex + 1} ${flowsForward ? "Cold" : "Hot"} Side`;
 				}
+			} else if (!selectedEdge.data.probe_mode) {
+				hotSideShortcut = true;
+				probeLabel = "Hot Side";
 			} else {
 				const scale = unitPreferences.length === "mm" ? 1000 : 1;
 				probeLabel = `Custom Depth d=${(targetX * scale).toFixed(unitPreferences.length === "mm" ? 1 : 3)}${unitPreferences.length}`;
 			}
 
 			if (tInt.length === layers.length + 1) {
-				if (targetX <= 0) {
+				if (hotSideShortcut) {
+					probeTemp = flowsForward ? tInt[0] : tInt[tInt.length - 1];
+				} else if (targetX <= 0) {
 					probeTemp = tInt[0];
 				} else {
 					let found = false;
@@ -1319,7 +1325,7 @@ const Inspector = () => {
 						}
 						iterX = nextX;
 					}
-					if (!found) probeTemp = tInt[tInt.length - 1]; // Beyond cold side
+					if (!found) probeTemp = tInt[tInt.length - 1];
 				}
 			} else {
 				probeLabel = "(solve needed)";
@@ -1493,9 +1499,6 @@ const Inspector = () => {
 							placeholder="0.00"
 						/>
 					)}
-					<span className="text-[9px] text-gray-400 font-normal italic text-right -mt-1">
-						{flowsForward ? "0 = Hot, L = Cold" : "0 = Cold, L = Hot"}
-					</span>
 				</div>
 
 				{selectedEdge.data.result && (

--- a/gui/frontend/src/components/Inspector.tsx
+++ b/gui/frontend/src/components/Inspector.tsx
@@ -1254,6 +1254,9 @@ const Inspector = () => {
 
 	// Edge Inspector
 	if (selectedEdge && selectedEdge.data?.type === "thermal") {
+		const edgeQ: number | undefined = selectedEdge.data.result?.Q;
+		const flowsForward = edgeQ === undefined || edgeQ >= 0;
+
 		let probeTemp: number | null = null;
 		let probeLabel = "Probe Temp";
 		if (selectedEdge.data.result?.T_interface) {
@@ -1286,13 +1289,13 @@ const Inspector = () => {
 				const L = layer?.thickness || 0;
 				if (type === "hot") {
 					targetX = runningX;
-					probeLabel = `L${safeIndex + 1} Hot Side`;
+					probeLabel = `L${safeIndex + 1} ${flowsForward ? "Hot" : "Cold"} Side`;
 				} else if (type === "avg") {
 					targetX = runningX + L / 2;
 					probeLabel = `L${safeIndex + 1} Average`;
 				} else {
 					targetX = runningX + L;
-					probeLabel = `L${safeIndex + 1} Cold Side`;
+					probeLabel = `L${safeIndex + 1} ${flowsForward ? "Cold" : "Hot"} Side`;
 				}
 			} else {
 				const scale = unitPreferences.length === "mm" ? 1000 : 1;
@@ -1450,9 +1453,13 @@ const Inspector = () => {
 						>
 							<option value="custom">Custom Position (d=x)</option>
 							{/* Predefined locations for Layer 1 */}
-							<option value="preset:hot:0">L1 Hot Side</option>
+							<option value="preset:hot:0">
+								L1 {flowsForward ? "Hot" : "Cold"} Side
+							</option>
 							<option value="preset:avg:0">L1 Average</option>
-							<option value="preset:cold:0">L1 Cold Side</option>
+							<option value="preset:cold:0">
+								L1 {flowsForward ? "Cold" : "Hot"} Side
+							</option>
 							{/* Dynamic locations for additional layers */}
 							{(selectedEdge.data.layers || [])
 								.slice(1)
@@ -1462,7 +1469,7 @@ const Inspector = () => {
 											L{i + 2} Average
 										</option>
 										<option value={`preset:cold:${i + 1}`}>
-											L{i + 2} Cold Side
+											L{i + 2} {flowsForward ? "Cold" : "Hot"} Side
 										</option>
 									</React.Fragment>
 								))}
@@ -1487,7 +1494,7 @@ const Inspector = () => {
 						/>
 					)}
 					<span className="text-[9px] text-gray-400 font-normal italic text-right -mt-1">
-						0 = Hot, L = Cold
+						{flowsForward ? "0 = Hot, L = Cold" : "0 = Cold, L = Hot"}
 					</span>
 				</div>
 
@@ -1510,7 +1517,17 @@ const Inspector = () => {
 									Hot Side Wall Temp
 								</span>
 								<span className="font-mono text-xs font-black">
-									{selectedEdge.data.result.T_hot?.toFixed(1)} K
+									{(() => {
+										const tInt = selectedEdge.data.result.T_interface as
+											| number[]
+											| undefined;
+										if (tInt && tInt.length >= 2) {
+											return flowsForward
+												? tInt[0].toFixed(1)
+												: tInt[tInt.length - 1].toFixed(1);
+										}
+										return selectedEdge.data.result.T_hot?.toFixed(1);
+									})()} K
 								</span>
 							</div>
 							<div className="grid grid-cols-4 gap-1 pt-2 border-t border-stone-100">

--- a/gui/frontend/src/components/ThermalEdge.tsx
+++ b/gui/frontend/src/components/ThermalEdge.tsx
@@ -5,6 +5,15 @@ import useStore from "../store/useStore";
 const ARROW_COLOR = "#ff9800";
 const MARKER_SIZE = 6;
 
+// Hot end: existing orange. Cool end: sky blue.
+// t=0 → hot, t=1 → cold.
+function thermalColor(t: number): string {
+	const r = Math.round(255 + (41 - 255) * t);
+	const g = Math.round(152 + (182 - 152) * t);
+	const b = Math.round(0 + (246 - 0) * t);
+	return `rgb(${r},${g},${b})`;
+}
+
 export default function ThermalEdge({
 	id,
 	sourceX,
@@ -32,6 +41,13 @@ export default function ThermalEdge({
 	const Q: number | undefined = data?.result?.Q;
 	const flowsForward = Q === undefined || Q >= 0;
 
+	const topoLayers: Array<{ thickness?: number }> = data?.layers || [
+		{ thickness: data?.thickness || 0.003 },
+	];
+	const nLayers = topoLayers.length;
+	const totalT =
+		topoLayers.reduce((s, l) => s + (l.thickness || 0.003), 0) || 0.003;
+
 	const markerId = `thermal-arrow-${id}`;
 	const markerIdReverse = `thermal-arrow-reverse-${id}`;
 
@@ -54,6 +70,7 @@ export default function ThermalEdge({
 
 		let probeDepth = data.probe_depth ?? 0;
 		let displayLabel = `d=${(probeDepth * scale).toFixed(unit === "mm" ? 1 : 3)}${unit}`;
+		let hotSideShortcut = false;
 
 		if (data.probe_mode === "preset" && data.probe_preset) {
 			const { type, index } = data.probe_preset;
@@ -67,22 +84,27 @@ export default function ThermalEdge({
 
 			const L = layer?.thickness || 0;
 			if (type === "hot") {
-				probeDepth = runningX;
+				probeDepth = flowsForward ? runningX : runningX + L;
 				displayLabel = `L${safeIndex + 1} ${flowsForward ? "hot" : "cold"}`;
 			} else if (type === "avg") {
 				probeDepth = runningX + L / 2;
 				displayLabel = `L${safeIndex + 1} avg`;
 			} else {
-				probeDepth = runningX + L;
+				probeDepth = flowsForward ? runningX + L : runningX;
 				displayLabel = `L${safeIndex + 1} ${flowsForward ? "cold" : "hot"}`;
 			}
+		} else if (!data.probe_mode) {
+			hotSideShortcut = true;
+			displayLabel = "hot side";
 		}
 
 		if (temps.length !== layers.length + 1) {
 			probeText = `${displayLabel}: (solve needed)`;
 		} else {
 			let probeTemp: number | null = null;
-			if (probeDepth <= 0) {
+			if (hotSideShortcut) {
+				probeTemp = flowsForward ? temps[0] : temps[temps.length - 1];
+			} else if (probeDepth <= 0) {
 				probeTemp = temps[0];
 			} else {
 				let found = false;
@@ -180,6 +202,64 @@ export default function ThermalEdge({
 						</span>
 					)}
 					<span style={{ fontWeight: 700 }}>{labelText}</span>
+					<div
+						style={{
+							display: "flex",
+							alignItems: "center",
+							gap: 3,
+							marginTop: 2,
+							width: "100%",
+						}}
+					>
+						<span
+							style={{
+								fontSize: 8,
+								fontWeight: 700,
+								color: ARROW_COLOR,
+								lineHeight: 1,
+								flexShrink: 0,
+							}}
+						>
+							L1
+						</span>
+						<div
+							style={{
+								display: "flex",
+								gap: 1,
+								height: 6,
+								flex: 1,
+								minWidth: 32,
+								borderRadius: 2,
+								overflow: "hidden",
+							}}
+						>
+							{topoLayers.map((layer, i) => {
+								const topo = nLayers <= 1 ? 0 : i / (nLayers - 1);
+								const t = flowsForward ? topo : 1 - topo;
+								return (
+									<div
+										key={i}
+										style={{
+											flex: (layer.thickness || 0.003) / totalT,
+											minWidth: 3,
+											background: thermalColor(t),
+										}}
+									/>
+								);
+							})}
+						</div>
+						<span
+							style={{
+								fontSize: 8,
+								fontWeight: 700,
+								color: ARROW_COLOR,
+								lineHeight: 1,
+								flexShrink: 0,
+							}}
+						>
+							L{nLayers}
+						</span>
+					</div>
 					{probeText && (
 						<span
 							style={{ fontWeight: 400 }}

--- a/gui/frontend/src/components/ThermalEdge.tsx
+++ b/gui/frontend/src/components/ThermalEdge.tsx
@@ -2,6 +2,9 @@ import type { EdgeProps } from "reactflow";
 import { EdgeLabelRenderer, getBezierPath } from "reactflow";
 import useStore from "../store/useStore";
 
+const ARROW_COLOR = "#ff9800";
+const MARKER_SIZE = 6;
+
 export default function ThermalEdge({
 	id,
 	sourceX,
@@ -11,7 +14,6 @@ export default function ThermalEdge({
 	sourcePosition,
 	targetPosition,
 	style = {},
-	markerEnd,
 	data,
 }: EdgeProps) {
 	const { unitPreferences } = useStore();
@@ -27,10 +29,15 @@ export default function ThermalEdge({
 		targetPosition,
 	});
 
+	const Q: number | undefined = data?.result?.Q;
+	const flowsForward = Q === undefined || Q >= 0;
+
+	const markerId = `thermal-arrow-${id}`;
+	const markerIdReverse = `thermal-arrow-reverse-${id}`;
+
 	let labelText = "Thermal";
 	let probeText = "";
-	if (data?.result?.Q !== undefined) {
-		const Q = data.result.Q;
+	if (Q !== undefined) {
 		const absQ = Math.abs(Q);
 		const formattedValue =
 			absQ >= 1000 ? `${(Q / 1000).toFixed(1)} kW` : `${Q.toFixed(1)} W`;
@@ -45,13 +52,11 @@ export default function ThermalEdge({
 			},
 		];
 
-		let targetX = data.probe_depth ?? 0;
-		let displayLabel = `d=${(targetX * scale).toFixed(unit === "mm" ? 1 : 3)}${unit}`;
+		let probeDepth = data.probe_depth ?? 0;
+		let displayLabel = `d=${(probeDepth * scale).toFixed(unit === "mm" ? 1 : 3)}${unit}`;
 
-		// 1. Resolve Preset to Depth and Label
 		if (data.probe_mode === "preset" && data.probe_preset) {
 			const { type, index } = data.probe_preset;
-			// Ensure index is valid for current layers
 			const safeIndex = Math.min(index, layers.length - 1);
 			const layer = layers[safeIndex];
 
@@ -62,25 +67,22 @@ export default function ThermalEdge({
 
 			const L = layer?.thickness || 0;
 			if (type === "hot") {
-				targetX = runningX;
-				displayLabel = `L${safeIndex + 1} hot`;
+				probeDepth = runningX;
+				displayLabel = `L${safeIndex + 1} ${flowsForward ? "hot" : "cold"}`;
 			} else if (type === "avg") {
-				targetX = runningX + L / 2;
+				probeDepth = runningX + L / 2;
 				displayLabel = `L${safeIndex + 1} avg`;
 			} else {
-				targetX = runningX + L;
-				displayLabel = `L${safeIndex + 1} cold`;
+				probeDepth = runningX + L;
+				displayLabel = `L${safeIndex + 1} ${flowsForward ? "cold" : "hot"}`;
 			}
 		}
 
-		// 2. DIMENSION SAFETY GUARD
-		// For N layers, we expect N+1 interface temperatures.
-		// If structure changed but solve hasn't run, temps array will be the wrong size.
 		if (temps.length !== layers.length + 1) {
 			probeText = `${displayLabel}: (solve needed)`;
 		} else {
 			let probeTemp: number | null = null;
-			if (targetX <= 0) {
+			if (probeDepth <= 0) {
 				probeTemp = temps[0];
 			} else {
 				let found = false;
@@ -88,9 +90,8 @@ export default function ThermalEdge({
 				for (let i = 0; i < layers.length; i++) {
 					const t = layers[i].thickness;
 					const nextX = iterX + t;
-					if (targetX <= nextX + 1e-9) {
-						// Add small epsilon to handle precision issues at interfaces
-						const frac = t > 0 ? (targetX - iterX) / t : 0;
+					if (probeDepth <= nextX + 1e-9) {
+						const frac = t > 0 ? (probeDepth - iterX) / t : 0;
 						probeTemp = temps[i] + frac * (temps[i + 1] - temps[i]);
 						found = true;
 						break;
@@ -108,31 +109,55 @@ export default function ThermalEdge({
 
 	return (
 		<>
-			{/* Transparent path to carry the solid marker without inheriting the dash array */}
+			<defs>
+				<marker
+					id={markerId}
+					markerWidth={MARKER_SIZE}
+					markerHeight={MARKER_SIZE}
+					refX={MARKER_SIZE}
+					refY={MARKER_SIZE / 2}
+					orient="auto"
+				>
+					<path
+						d={`M 0 0 L ${MARKER_SIZE} ${MARKER_SIZE / 2} L 0 ${MARKER_SIZE} z`}
+						fill={ARROW_COLOR}
+					/>
+				</marker>
+				<marker
+					id={markerIdReverse}
+					markerWidth={MARKER_SIZE}
+					markerHeight={MARKER_SIZE}
+					refX={0}
+					refY={MARKER_SIZE / 2}
+					orient="auto-start-reverse"
+				>
+					<path
+						d={`M 0 0 L ${MARKER_SIZE} ${MARKER_SIZE / 2} L 0 ${MARKER_SIZE} z`}
+						fill={ARROW_COLOR}
+					/>
+				</marker>
+			</defs>
+			{/* Transparent wider path for hit-testing */}
 			<path
-				style={{
-					stroke: "transparent",
-					strokeWidth: 3,
-					fill: "none",
-					pointerEvents: "none",
-				}}
+				style={{ stroke: "transparent", strokeWidth: 10, fill: "none" }}
 				className="react-flow__edge-path"
 				d={edgePath}
-				markerEnd={markerEnd}
 			/>
-			{/* Visible dashed path for the connection line */}
+			{/* Visible dashed path with data-driven arrowhead */}
 			<path
 				id={id}
 				style={{
 					...style,
 					strokeWidth: 3,
-					stroke: "#ff9800",
+					stroke: ARROW_COLOR,
 					strokeDasharray: "5,5",
 					opacity: 0.8,
 					fill: "none",
 				}}
 				className="react-flow__edge-path"
 				d={edgePath}
+				markerEnd={flowsForward ? `url(#${markerId})` : undefined}
+				markerStart={!flowsForward ? `url(#${markerIdReverse})` : undefined}
 			/>
 			<EdgeLabelRenderer>
 				<div
@@ -143,8 +168,8 @@ export default function ThermalEdge({
 						padding: "2px 6px",
 						borderRadius: "4px",
 						fontSize: "12px",
-						color: "#ff9800",
-						border: "2px solid #ff9800",
+						color: ARROW_COLOR,
+						border: `2px solid ${ARROW_COLOR}`,
 						pointerEvents: "all",
 					}}
 					className="nodrag nopan flex flex-col items-center shadow-sm"
@@ -155,7 +180,6 @@ export default function ThermalEdge({
 						</span>
 					)}
 					<span style={{ fontWeight: 700 }}>{labelText}</span>
-
 					{probeText && (
 						<span
 							style={{ fontWeight: 400 }}


### PR DESCRIPTION
## Summary

- Thermal wall arrow direction flips based on Q sign: arrowhead at target when Q >= 0, arrowhead at source when Q < 0 (custom inline SVG markers with `orient="auto-start-reverse"`)
- Probe preset labels ("Hot Side" / "Cold Side"), dropdown options, and the depth hint ("0 = Hot, L = Cold") all swap when Q < 0
- "Hot Side Wall Temp" in the results panel reads `T_interface[0]` when Q >= 0 and `T_interface[N]` when Q < 0

No C++ or Python changes. Frontend only.

## Background

The thermal wall connector was topology-directed: "hot" always meant the source node side (d = 0) regardless of which side was actually hotter. This forced users to wire edges in the correct direction to get meaningful labels and arrows. With this change, the GUI self-corrects after solving — users can wire in either direction and the display reflects actual physics.

## Test plan

- [ ] Wire a thermal wall hot-to-cold in the drawn direction: arrow points source→target, probe labels show "Hot Side" at d=0, hint shows "0 = Hot, L = Cold"
- [ ] Wire the same wall cold-to-hot (swap edge direction): arrow flips to point target→source, probe labels swap, hint shows "0 = Cold, L = Hot", "Hot Side Wall Temp" reads the correct end
- [ ] Multi-layer wall: verify additional layer dropdowns ("L2 Cold Side" etc.) also swap correctly
- [ ] Before solve (Q undefined): arrow and labels default to forward direction (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
