### PR TITLE
fix: compressible solver convergence + rotation-aware edge routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,10 +33,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   causing the initial guess to underestimate the known mass flow and leading hybr to
   converge to a spurious local minimum. The cap is now skipped for elements whose
   immediate upstream node is a `MassFlowBoundary`.
-- Edge connection paths for rotated nodes: `FlowEdge` and `ThermalEdge` now compute
-  bezier `sourcePosition`/`targetPosition` from the actual handle coordinates rather
-  than from the static `position` prop (which does not update when a node is CSS-rotated).
-  Connection lines no longer route behind element bounding boxes after rotation.
+- Edge connection paths for rotated nodes: `FlowEdge` and `ThermalEdge` now apply a
+  `rotatePosition` helper that maps each handle's static `position` prop (e.g.
+  `Position.Left`) through the connected node's CSS rotation in 90° steps. This gives
+  `getBezierPath` the correct perpendicular exit/entry direction after rotation — for
+  example, a 180°-rotated node's `flow-target` (logically Left) is correctly treated as
+  Right, producing a smooth C-curve instead of an initial vertical leg routing behind the
+  element bounding box.
 - `combaero-gui` white page on fresh PyPI install: `frontend/dist/assets/` was not bundled in
   the wheel because the `**` glob in `package-data` is unreliable below setuptools 69; added an
   explicit `assets/*` pattern and a `MANIFEST.in` as belt-and-suspenders.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   viscosity/conductivity vs GRI-Mech at 300/1000/2000 K; NH3/air and H2O/N2 mixtures.
 
 ### Fixed
+- Compressible solver convergence with mass-flow boundary inlets: `_propagate_mdot_guess`
+  was applying a Mach-0.3 cap even to elements directly seeded by a `MassFlowBoundary`,
+  causing the initial guess to underestimate the known mass flow and leading hybr to
+  converge to a spurious local minimum. The cap is now skipped for elements whose
+  immediate upstream node is a `MassFlowBoundary`.
+- Edge connection paths for rotated nodes: `FlowEdge` and `ThermalEdge` now compute
+  bezier `sourcePosition`/`targetPosition` from the actual handle coordinates rather
+  than from the static `position` prop (which does not update when a node is CSS-rotated).
+  Connection lines no longer route behind element bounding boxes after rotation.
 - `combaero-gui` white page on fresh PyPI install: `frontend/dist/assets/` was not bundled in
   the wheel because the `**` glob in `package-data` is unreliable below setuptools 69; added an
   explicit `assets/*` pattern and a `MANIFEST.in` as belt-and-suspenders.

--- a/gui/frontend/src/components/FlowEdge.tsx
+++ b/gui/frontend/src/components/FlowEdge.tsx
@@ -4,40 +4,51 @@ import {
 	EdgeLabelRenderer,
 	getBezierPath,
 	Position,
+	useNodes,
 } from "reactflow";
 
-function coordPosition(
-	fromX: number,
-	fromY: number,
-	toX: number,
-	toY: number,
-): Position {
-	const dx = toX - fromX;
-	const dy = toY - fromY;
-	if (Math.abs(dx) >= Math.abs(dy))
-		return dx >= 0 ? Position.Right : Position.Left;
-	return dy >= 0 ? Position.Bottom : Position.Top;
+function rotatePosition(pos: Position, degrees: number): Position {
+	const cycle: Position[] = [
+		Position.Right,
+		Position.Bottom,
+		Position.Left,
+		Position.Top,
+	];
+	const steps = Math.round((((degrees % 360) + 360) % 360) / 90) % 4;
+	const idx = cycle.indexOf(pos);
+	return idx === -1 ? pos : cycle[(idx + steps) % 4];
 }
 
 export default function FlowEdge({
 	id,
+	source,
+	target,
 	sourceX,
 	sourceY,
 	targetX,
 	targetY,
+	sourcePosition,
+	targetPosition,
 	style = {},
 	markerEnd,
 	data,
 }: EdgeProps) {
-	const sourcePosition = coordPosition(sourceX, sourceY, targetX, targetY);
-	const targetPosition = coordPosition(targetX, targetY, sourceX, sourceY);
+	const nodes = useNodes();
+	const sourceRotation =
+		nodes.find((n) => n.id === source)?.data?.rotation ?? 0;
+	const targetRotation =
+		nodes.find((n) => n.id === target)?.data?.rotation ?? 0;
+
+	const adjSourcePos = rotatePosition(sourcePosition, sourceRotation);
+	const adjTargetPos = rotatePosition(targetPosition, targetRotation);
+
 	const [edgePath, labelX, labelY] = getBezierPath({
 		sourceX,
 		sourceY,
-		sourcePosition,
+		sourcePosition: adjSourcePos,
 		targetX,
 		targetY,
-		targetPosition,
+		targetPosition: adjTargetPos,
 	});
 
 	const showLabel = data?.show_label && data?.label;

--- a/gui/frontend/src/components/FlowEdge.tsx
+++ b/gui/frontend/src/components/FlowEdge.tsx
@@ -35,9 +35,11 @@ export default function FlowEdge({
 }: EdgeProps) {
 	const nodes = useNodes();
 	const sourceRotation =
-		nodes.find((n) => n.id === source)?.data?.rotation ?? 0;
+		(nodes.find((n) => n.id === source)?.data as { rotation?: number })
+			?.rotation ?? 0;
 	const targetRotation =
-		nodes.find((n) => n.id === target)?.data?.rotation ?? 0;
+		(nodes.find((n) => n.id === target)?.data as { rotation?: number })
+			?.rotation ?? 0;
 
 	const adjSourcePos = rotatePosition(sourcePosition, sourceRotation);
 	const adjTargetPos = rotatePosition(targetPosition, targetRotation);

--- a/gui/frontend/src/components/FlowEdge.tsx
+++ b/gui/frontend/src/components/FlowEdge.tsx
@@ -1,5 +1,23 @@
 import type { EdgeProps } from "reactflow";
-import { BaseEdge, EdgeLabelRenderer, getBezierPath } from "reactflow";
+import {
+	BaseEdge,
+	EdgeLabelRenderer,
+	getBezierPath,
+	Position,
+} from "reactflow";
+
+function coordPosition(
+	fromX: number,
+	fromY: number,
+	toX: number,
+	toY: number,
+): Position {
+	const dx = toX - fromX;
+	const dy = toY - fromY;
+	if (Math.abs(dx) >= Math.abs(dy))
+		return dx >= 0 ? Position.Right : Position.Left;
+	return dy >= 0 ? Position.Bottom : Position.Top;
+}
 
 export default function FlowEdge({
 	id,
@@ -7,12 +25,12 @@ export default function FlowEdge({
 	sourceY,
 	targetX,
 	targetY,
-	sourcePosition,
-	targetPosition,
 	style = {},
 	markerEnd,
 	data,
 }: EdgeProps) {
+	const sourcePosition = coordPosition(sourceX, sourceY, targetX, targetY);
+	const targetPosition = coordPosition(targetX, targetY, sourceX, sourceY);
 	const [edgePath, labelX, labelY] = getBezierPath({
 		sourceX,
 		sourceY,

--- a/gui/frontend/src/components/ThermalEdge.tsx
+++ b/gui/frontend/src/components/ThermalEdge.tsx
@@ -1,5 +1,19 @@
 import type { EdgeProps } from "reactflow";
-import { EdgeLabelRenderer, getBezierPath } from "reactflow";
+import { EdgeLabelRenderer, getBezierPath, Position } from "reactflow";
+
+function coordPosition(
+	fromX: number,
+	fromY: number,
+	toX: number,
+	toY: number,
+): Position {
+	const dx = toX - fromX;
+	const dy = toY - fromY;
+	if (Math.abs(dx) >= Math.abs(dy))
+		return dx >= 0 ? Position.Right : Position.Left;
+	return dy >= 0 ? Position.Bottom : Position.Top;
+}
+
 import useStore from "../store/useStore";
 
 const ARROW_COLOR = "#ff9800";
@@ -20,8 +34,6 @@ export default function ThermalEdge({
 	sourceY,
 	targetX,
 	targetY,
-	sourcePosition,
-	targetPosition,
 	style = {},
 	data,
 }: EdgeProps) {
@@ -29,6 +41,8 @@ export default function ThermalEdge({
 	const unit = unitPreferences.length;
 	const scale = unit === "mm" ? 1000 : 1;
 
+	const sourcePosition = coordPosition(sourceX, sourceY, targetX, targetY);
+	const targetPosition = coordPosition(targetX, targetY, sourceX, sourceY);
 	const [edgePath, labelX, labelY] = getBezierPath({
 		sourceX,
 		sourceY,

--- a/gui/frontend/src/components/ThermalEdge.tsx
+++ b/gui/frontend/src/components/ThermalEdge.tsx
@@ -50,9 +50,11 @@ export default function ThermalEdge({
 
 	const nodes = useNodes();
 	const sourceRotation =
-		nodes.find((n) => n.id === source)?.data?.rotation ?? 0;
+		(nodes.find((n) => n.id === source)?.data as { rotation?: number })
+			?.rotation ?? 0;
 	const targetRotation =
-		nodes.find((n) => n.id === target)?.data?.rotation ?? 0;
+		(nodes.find((n) => n.id === target)?.data as { rotation?: number })
+			?.rotation ?? 0;
 
 	const adjSourcePos = rotatePosition(sourcePosition, sourceRotation);
 	const adjTargetPos = rotatePosition(targetPosition, targetRotation);

--- a/gui/frontend/src/components/ThermalEdge.tsx
+++ b/gui/frontend/src/components/ThermalEdge.tsx
@@ -1,20 +1,23 @@
 import type { EdgeProps } from "reactflow";
-import { EdgeLabelRenderer, getBezierPath, Position } from "reactflow";
-
-function coordPosition(
-	fromX: number,
-	fromY: number,
-	toX: number,
-	toY: number,
-): Position {
-	const dx = toX - fromX;
-	const dy = toY - fromY;
-	if (Math.abs(dx) >= Math.abs(dy))
-		return dx >= 0 ? Position.Right : Position.Left;
-	return dy >= 0 ? Position.Bottom : Position.Top;
-}
-
+import {
+	EdgeLabelRenderer,
+	getBezierPath,
+	Position,
+	useNodes,
+} from "reactflow";
 import useStore from "../store/useStore";
+
+function rotatePosition(pos: Position, degrees: number): Position {
+	const cycle: Position[] = [
+		Position.Right,
+		Position.Bottom,
+		Position.Left,
+		Position.Top,
+	];
+	const steps = Math.round((((degrees % 360) + 360) % 360) / 90) % 4;
+	const idx = cycle.indexOf(pos);
+	return idx === -1 ? pos : cycle[(idx + steps) % 4];
+}
 
 const ARROW_COLOR = "#ff9800";
 const MARKER_SIZE = 6;
@@ -30,10 +33,14 @@ function thermalColor(t: number): string {
 
 export default function ThermalEdge({
 	id,
+	source,
+	target,
 	sourceX,
 	sourceY,
 	targetX,
 	targetY,
+	sourcePosition,
+	targetPosition,
 	style = {},
 	data,
 }: EdgeProps) {
@@ -41,15 +48,22 @@ export default function ThermalEdge({
 	const unit = unitPreferences.length;
 	const scale = unit === "mm" ? 1000 : 1;
 
-	const sourcePosition = coordPosition(sourceX, sourceY, targetX, targetY);
-	const targetPosition = coordPosition(targetX, targetY, sourceX, sourceY);
+	const nodes = useNodes();
+	const sourceRotation =
+		nodes.find((n) => n.id === source)?.data?.rotation ?? 0;
+	const targetRotation =
+		nodes.find((n) => n.id === target)?.data?.rotation ?? 0;
+
+	const adjSourcePos = rotatePosition(sourcePosition, sourceRotation);
+	const adjTargetPos = rotatePosition(targetPosition, targetRotation);
+
 	const [edgePath, labelX, labelY] = getBezierPath({
 		sourceX,
 		sourceY,
-		sourcePosition,
+		sourcePosition: adjSourcePos,
 		targetX,
 		targetY,
-		targetPosition,
+		targetPosition: adjTargetPos,
 	});
 
 	const Q: number | undefined = data?.result?.Q;

--- a/python/combaero/network/solver.py
+++ b/python/combaero/network/solver.py
@@ -298,10 +298,16 @@ class NetworkSolver:
             if abs(share) < 1e-12 and not isinstance(node, MassFlowBoundary):
                 share = ref["m_dot"]
 
+            from_mass_boundary = isinstance(node, MassFlowBoundary)
             for elem in down_elems:
                 elem_share = share
                 regime = getattr(elem, "regime", None)
-                if regime == "compressible":
+                # Only apply the Mach cap when the flow is estimated (pressure-
+                # boundary seeded).  When a MassFlowBoundary seeds the element
+                # directly, the mass flow is a known constraint and capping it
+                # produces an initial guess that is too far from the solution,
+                # causing hybr to converge to a spurious local minimum.
+                if regime == "compressible" and not from_mass_boundary:
                     area = getattr(elem, "area", None)
                     if area is not None and area > 0.0:
                         mdot_cap = rho_ref * a_ref * area * mdot_ratio


### PR DESCRIPTION
## Summary

- **Solver convergence** (`solver.py`): The Mach-0.3 cap in `_propagate_mdot_guess` was applied even when the upstream node is a `MassFlowBoundary`, discarding a known mass flow constraint and causing `hybr` to find a spurious local minimum in compressible networks with thermal wall coupling (|F|≈523 instead of <1e-8 with default strategy). The cap is now skipped for elements immediately downstream of a mass-flow boundary.
- **Edge routing for rotated nodes** (`FlowEdge.tsx`, `ThermalEdge.tsx`): Added `rotatePosition()` helper that maps each handle's static `Position` prop through the connected node's CSS rotation in 90° steps before passing to `getBezierPath()`. React Flow's bezier control points extend perpendicular to `sourcePosition`/`targetPosition`; without adjustment these stay at the pre-rotation angle and produce paths that route behind the element bounding box. For example, a 180°-rotated node's `flow-target` (logically `Position.Left`) is correctly treated as `Position.Right`, producing a smooth C-curve instead of an initial vertical leg.

## Test plan

- [ ] Open `gui/tmp/multi_wall_tee.json` in the GUI, set solver to **Compressible / Default** — confirm solve converges (green border, |F| < 1e-3)
- [ ] Rotate any element node 90°/180° — confirm connecting edges leave/arrive perpendicular to the rotated handle face with no path routing behind the node
- [ ] Python test suite: `uv run pytest python/tests/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
