### PR TITLE
fix: clamp T/P floors to prevent crash on unphysical Newton steps in combustor networks

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,5 +1,5 @@
 CompileFlags:
-  Add: [-std=c++17, -I${workspaceFolder}/include]
+  Add: [-std=c++17, -Iinclude]
 
 Diagnostics:
   UnusedIncludes: None

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is read-only, matching the CI `lint-gui` job.
 
 ### Fixed
+- Network solver no longer crashes on combustor networks where Newton steps temporarily
+  produce non-physical states (T ≤ 0 or P ≤ 0). `adiabatic_T_complete_and_jacobian_T()`
+  and `adiabatic_T_equilibrium_and_jacobians()` now clamp T and P to safe floors instead of
+  throwing; `_propagate_states` and `_get_node_state` in the Python solver clamp T ≥ 50 K
+  so that reverse-flow mixing artefacts (negative T_mix from negative m_dot streams) never
+  propagate into physics calls.
 - `friction_petukhov()` and `friction_and_jacobian_petukhov()` no longer throw
   for Re < 3000; the Petukhov formula is mathematically continuous so values below
   the validated range are returned as extrapolated rather than raising an error.

--- a/python/combaero/network/solver.py
+++ b/python/combaero/network/solver.py
@@ -677,6 +677,7 @@ class NetworkSolver:
                 wall_contributions = self._evaluate_walls_for_node(nid, up_elems, x)
 
             T, Y, mix_res = node.compute_derived_state(up_states)
+            T = max(float(T), 50.0)
             self._derived_states[nid] = (T, Y, mix_res)
 
             # Store wall coupling debug info on the node
@@ -1012,8 +1013,8 @@ class NetworkSolver:
         return NetworkMixtureState(
             float(state_dict["P"]),
             float(state_dict["Pt"]),
-            float(state_dict["T"]),
-            float(state_dict["Tt"]),
+            max(float(state_dict["T"]), 50.0),
+            max(float(state_dict["Tt"]), 50.0),
             float(state_dict["m_dot"]),
             Y_safe,
         )

--- a/src/solver_interface.cpp
+++ b/src/solver_interface.cpp
@@ -651,10 +651,12 @@ P0_from_static_and_jacobian_M(double P, double T, double M,
 std::tuple<double, double, std::vector<double>>
 adiabatic_T_complete_and_jacobian_T(double T_in, double P,
                                      const std::vector<double> &X_in) {
-  if (T_in <= 0.0 || P <= 0.0) {
-    throw std::invalid_argument(
-        "solver_interface::adiabatic_T_complete requires T_in > 0 and P > 0");
-  }
+  // Clamp to safe physical floor instead of throwing: the solver may
+  // probe unphysical (T<=0, P<=0) intermediates during Newton steps.
+  // Clamping keeps residuals finite with correct gradient direction so
+  // the trust-region can step back toward physical territory.
+  T_in = std::max(T_in, T_SMOOTH_FLOOR_LIMIT);
+  P = std::max(P, 100.0);
 
   State in_state;
   in_state.set_TPX(T_in, P, X_in);
@@ -690,10 +692,8 @@ adiabatic_T_complete_and_jacobian_T(double T_in, double P,
 std::tuple<double, double, double, std::vector<double>>
 adiabatic_T_equilibrium_and_jacobians(double T_in, double P,
                                        const std::vector<double> &X_in) {
-  if (T_in <= 0.0 || P <= 0.0) {
-    throw std::invalid_argument("solver_interface::adiabatic_T_equilibrium "
-                                "requires T_in > 0 and P > 0");
-  }
+  T_in = std::max(T_in, T_SMOOTH_FLOOR_LIMIT);
+  P = std::max(P, 100.0);
 
   State in_state;
   in_state.set_TPX(T_in, P, X_in);


### PR DESCRIPTION
## Summary

- `adiabatic_T_complete_and_jacobian_T` and `adiabatic_T_equilibrium_and_jacobians` clamp T to `T_SMOOTH_FLOOR_LIMIT` (~200 K) and P to 100 Pa instead of throwing when the Newton step enters unphysical territory. Keeps residuals finite with correct gradient direction so the trust-region can recover.
- `_propagate_states` in the Python network solver clamps mixed temperature T ≥ 50 K, preventing reverse-flow artefacts (negative T_mix from negative-m_dot streams at pressure boundaries) from propagating into physics calls.
- `_get_node_state` clamps T and Tt ≥ 50 K as a second line of defence before constructing `NetworkMixtureState`.
- `.clangd`: fix include path from `${workspaceFolder}/include` (VS Code variable, not recognised by clangd) to bare `-Iinclude`.

## Test plan

- [ ] All 1240 Python tests pass (`uv run pytest python/tests/ -x -q`)
- [ ] `test_fully_coupled_compressible_vs_incompressible_mach_sweep` — specifically verified: the P floor in `residuals_wrapper` was reverted (it broke this test); only T clamps are applied
- [ ] Smoke-test `network_comb_p_only_failing.json` no longer crashes with unhandled exception

🤖 Generated with [Claude Code](https://claude.com/claude-code)