### PR TITLE
feat(vortex): VortexElement for rotating cavity pressure rise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `VortexElement` network element: models centrifugal pressure rise in rotating cavities
+  (disc pumps, pre-swirl chambers, inter-stage labyrinth spaces) using the Vatistas n-vortex
+  model. Parameters: `r_c` (core radius), `r_out`, `r_in` (evaluation radii), `omega_rpm`
+  (shaft speed; `None` = inherit global setting), `n` (Vatistas shape parameter, default 2).
+  Residual `Pt_out - Pt_in - dP_vortex = 0` with analytical Jacobians w.r.t. Pt and inlet
+  density. GUI: Tornado icon (violet), inspectable from the sidebar with a global shaft-speed
+  field and per-element override.
 - Vatistas (1991) n-vortex model: `vatistas_v0_bar`, `vatistas_vr_bar`,
   `vatistas_pressure_integral` and their analytical derivatives, plus dimensional
   `vatistas_v_theta` / `vatistas_delta_p` with full analytical Jacobians w.r.t.

--- a/docs/API_PYTHON.md
+++ b/docs/API_PYTHON.md
@@ -418,7 +418,7 @@ energy = EnergyBoundary("energy", Q=50000)  # Heat addition [W]
 from combaero.network import (
     OrificeElement, ChannelElement, EffectiveAreaConnectionElement,
     LosslessConnectionElement, DiameterDischargeCoefficientConnectionElement,
-    TeeJunctionElement,
+    TeeJunctionElement, VortexElement,
 )
 
 # Flow elements
@@ -444,6 +444,21 @@ tee_branch = TeeJunctionElement(
 )
 # Solved unknowns: tee.m_dot_com (total), tee.m_dot_branch (branch arm)
 # Straight flow is implicit: m_dot_straight = m_dot_com - m_dot_branch
+
+# Rotating cavity / disc-pump pressure rise (Vatistas n-vortex model)
+vortex = VortexElement(
+    "vortex", "node_in", "node_out",
+    r_c=0.02,       # vortex core radius [m]
+    r_out=0.10,     # outer evaluation radius [m]
+    r_in=0.0,       # inner evaluation radius [m] (0 = on-axis)
+    omega_rpm=3000, # shaft speed [rpm]
+    n=2.0,          # Vatistas shape parameter (>= 1, default n=2)
+)
+# Residual: Pt_out - Pt_in - dP_vortex = 0
+# dP_vortex = vatistas_delta_p(r_out, ...) - vatistas_delta_p(r_in, ...)
+# Gamma is derived from omega so that V_theta(r_c) = omega * r_c exactly (solid-body core).
+# Diagnostics include: m_dot, omega_rpm, dP_vortex [Pa], Pt_in, Pt_out.
+# If omega_rpm=0 the element is lossless (transparent); r_in=0 omits the on-axis term.
 ```
 
 ### Combustion Integration

--- a/gui/backend/graph_builder.py
+++ b/gui/backend/graph_builder.py
@@ -24,6 +24,7 @@ from combaero.network import (
     SmoothModel,
     TeeJunctionElement,
     ThermalWall,
+    VortexElement,
     WallLayer,
 )
 
@@ -50,6 +51,7 @@ from .schemas import (
     SmoothModelData,
     TeeJunctionData,
     ThermalWallData,
+    VortexData,
 )
 
 
@@ -504,6 +506,25 @@ def build_network_from_schema(schema: NetworkGraphSchema) -> FlowNetwork:
                 theta_source=theta_source,
                 area=area,
                 surface=surface,
+            )
+            elem.initial_guess = _expand_initial_guess(data.initial_guess, elem_id)
+            net.add_element(elem)
+        elif elem_type == "vortex":
+            data = VortexData(**elem_data)
+            omega = (
+                data.omega_rpm
+                if data.omega_rpm is not None
+                else (schema.solver_settings.omega_rpm or 0.0)
+            )
+            elem = VortexElement(
+                elem_id,
+                from_node=source_id,
+                to_node=target_id,
+                r_c=data.r_c,
+                r_out=data.r_out,
+                r_in=data.r_in,
+                omega_rpm=float(omega),
+                n=data.n,
             )
             elem.initial_guess = _expand_initial_guess(data.initial_guess, elem_id)
             net.add_element(elem)

--- a/gui/backend/schemas.py
+++ b/gui/backend/schemas.py
@@ -212,6 +212,17 @@ class TeeJunctionData(BaseModel):
     initial_guess: dict[str, float] = Field(default_factory=dict)
 
 
+class VortexData(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    label: str | None = None
+    r_c: float = 0.02  # vortex core radius [m]
+    r_out: float = 0.10  # outer radius where pressure is evaluated [m]
+    r_in: float = 0.0  # inner radius (0 = on-axis)
+    omega_rpm: float | None = None  # shaft speed [rpm]; None = use global solver setting
+    n: float = 2.0  # Vatistas shape parameter (>= 1, default n=2)
+    initial_guess: dict[str, float] = Field(default_factory=dict)
+
+
 class DiscreteLossData(BaseModel):
     model_config = ConfigDict(extra="ignore")
     correlation_type: Literal[
@@ -281,6 +292,7 @@ class SolverSettings(BaseModel):
         "df-sane",
     ] = "hybr"
     timeout: float | None = 180.0
+    omega_rpm: float | None = None  # global shaft speed [rpm]; None = disabled
 
 
 # --- React Flow Wrapper Schemas ---

--- a/gui/frontend/src/components/Inspector.tsx
+++ b/gui/frontend/src/components/Inspector.tsx
@@ -27,6 +27,7 @@ const Inspector = () => {
 		isExporting,
 		exportNetworkResults,
 		displaySettings,
+		solverSettings,
 	} = useStore();
 
 	const validationErrors = validateNetwork(nodes);
@@ -885,6 +886,94 @@ const Inspector = () => {
 											{(selectedNode.data.result.K_branch ?? 0).toFixed(3)}
 										</span>
 									</div>
+								</div>
+							</div>
+						)}
+					</div>
+				)}
+
+				{selectedNode.type === "vortex" && (
+					<div className="flex flex-col gap-4">
+						<div className="flex flex-col gap-1">
+							<label className="text-xs font-bold text-gray-500 uppercase">
+								Rotational Speed
+							</label>
+							<div className="flex items-center gap-1">
+								<NumericInput
+									id={`omega_rpm_${selectedNode.id}`}
+									className="p-1 border rounded text-xs bg-white h-7 outline-none focus:ring-1 focus:ring-stone-200 flex-1"
+									value={selectedNode.data.omega_rpm ?? null}
+									onChange={(val) =>
+										updateNodeData(selectedNode.id, { omega_rpm: val })
+									}
+									onClear={() =>
+										updateNodeData(selectedNode.id, { omega_rpm: null })
+									}
+									min={0}
+									placeholder={
+										solverSettings.omega_rpm != null
+											? `global: ${solverSettings.omega_rpm}`
+											: "global (not set)"
+									}
+								/>
+								<span className="text-xs text-stone-400 shrink-0">rpm</span>
+							</div>
+						</div>
+						<LengthInput
+							id={`r_c_${selectedNode.id}`}
+							label="Core Radius r_c"
+							value={selectedNode.data.r_c ?? 0.02}
+							onChange={(val) => updateNodeData(selectedNode.id, { r_c: val })}
+						/>
+						<LengthInput
+							id={`r_out_${selectedNode.id}`}
+							label="Outer Radius r_out"
+							value={selectedNode.data.r_out ?? 0.1}
+							onChange={(val) =>
+								updateNodeData(selectedNode.id, { r_out: val })
+							}
+						/>
+						<LengthInput
+							id={`r_in_${selectedNode.id}`}
+							label="Inner Radius r_in"
+							value={selectedNode.data.r_in ?? 0.0}
+							onChange={(val) => updateNodeData(selectedNode.id, { r_in: val })}
+						/>
+						<div className="flex flex-col gap-1">
+							<label className="text-xs font-bold text-gray-500 uppercase">
+								Shape Parameter n
+							</label>
+							<NumericInput
+								id={`n_${selectedNode.id}`}
+								className="p-1 border rounded text-xs bg-white h-7 outline-none focus:ring-1 focus:ring-stone-200"
+								value={selectedNode.data.n ?? 2.0}
+								onChange={(val) => updateNodeData(selectedNode.id, { n: val })}
+								min={1}
+								placeholder="2.0"
+							/>
+							<span className="text-[9px] text-stone-400">
+								Vatistas n ≥ 1, default n=2
+							</span>
+						</div>
+						{selectedNode.data.result && (
+							<div className="rounded border border-stone-200 bg-stone-50 px-3 py-2 text-xs">
+								<div className="font-bold uppercase text-stone-400 mb-1 text-[9px]">
+									Result
+								</div>
+								<div className="flex justify-between">
+									<span className="text-stone-500">ΔP vortex</span>
+									<span className="font-mono font-bold">
+										{((selectedNode.data.result.dP_vortex ?? 0) / 1000).toFixed(
+											2,
+										)}{" "}
+										kPa
+									</span>
+								</div>
+								<div className="flex justify-between">
+									<span className="text-stone-500">ṁ</span>
+									<span className="font-mono font-bold">
+										{(selectedNode.data.result.m_dot ?? 0).toFixed(4)} kg/s
+									</span>
 								</div>
 							</div>
 						)}
@@ -1928,6 +2017,7 @@ const InitialGuessEditor = ({ node }: { node: any }) => {
 			{ key: "m_dot_com", unit: "kg/s" },
 			{ key: "m_dot_branch", unit: "kg/s" },
 		],
+		vortex: [{ key: "m_dot", unit: "kg/s" }],
 	};
 	const guessFields = FIELDS_BY_TYPE[node.type as string] ?? [];
 	if (guessFields.length === 0) {

--- a/gui/frontend/src/components/Inspector.tsx
+++ b/gui/frontend/src/components/Inspector.tsx
@@ -24,6 +24,7 @@ const Inspector = () => {
 		updateEdgeData,
 		speciesMetadata,
 		unitPreferences,
+		setRotSpeedUnit,
 		isExporting,
 		exportNetworkResults,
 		displaySettings,
@@ -902,9 +903,17 @@ const Inspector = () => {
 								<NumericInput
 									id={`omega_rpm_${selectedNode.id}`}
 									className="p-1 border rounded text-xs bg-white h-7 outline-none focus:ring-1 focus:ring-stone-200 flex-1"
-									value={selectedNode.data.omega_rpm ?? null}
+									value={
+										selectedNode.data.omega_rpm != null
+											? selectedNode.data.omega_rpm *
+												(unitPreferences.rotSpeed === "Hz" ? 1 / 60 : 1)
+											: null
+									}
 									onChange={(val) =>
-										updateNodeData(selectedNode.id, { omega_rpm: val })
+										updateNodeData(selectedNode.id, {
+											omega_rpm:
+												val * (unitPreferences.rotSpeed === "Hz" ? 60 : 1),
+										})
 									}
 									onClear={() =>
 										updateNodeData(selectedNode.id, { omega_rpm: null })
@@ -912,11 +921,20 @@ const Inspector = () => {
 									min={0}
 									placeholder={
 										solverSettings.omega_rpm != null
-											? `global: ${solverSettings.omega_rpm}`
+											? `global: ${(solverSettings.omega_rpm * (unitPreferences.rotSpeed === "Hz" ? 1 / 60 : 1)).toFixed(unitPreferences.rotSpeed === "Hz" ? 3 : 0)}`
 											: "global (not set)"
 									}
 								/>
-								<span className="text-xs text-stone-400 shrink-0">rpm</span>
+								<select
+									value={unitPreferences.rotSpeed}
+									onChange={(e) =>
+										setRotSpeedUnit(e.target.value as "rpm" | "Hz")
+									}
+									className="w-14 h-[30px] border rounded text-[9px] bg-white outline-none shrink-0"
+								>
+									<option value="rpm">rpm</option>
+									<option value="Hz">Hz</option>
+								</select>
 							</div>
 						</div>
 						<LengthInput

--- a/gui/frontend/src/components/NetworkCanvas.tsx
+++ b/gui/frontend/src/components/NetworkCanvas.tsx
@@ -106,6 +106,15 @@ const NetworkCanvas = () => {
 					F_C: 0.01,
 					psi: 1.0,
 				} as any;
+			} else if (type === "vortex") {
+				data = {
+					...data,
+					r_c: 0.02,
+					r_out: 0.1,
+					r_in: 0.0,
+					omega_rpm: null,
+					n: 2.0,
+				} as any;
 			}
 
 			const newNode = {

--- a/gui/frontend/src/components/Sidebar.tsx
+++ b/gui/frontend/src/components/Sidebar.tsx
@@ -31,6 +31,8 @@ const Sidebar = () => {
 		loadNetwork,
 		solverSettings,
 		updateSolverSettings,
+		unitPreferences,
+		setRotSpeedUnit,
 		nodes,
 		setNodes,
 		solveResults,
@@ -395,13 +397,29 @@ const Sidebar = () => {
 					<div className="flex items-center gap-1">
 						<NumericInput
 							className="p-1 border rounded text-xs bg-white h-7 outline-none focus:ring-1 focus:ring-stone-200 flex-1"
-							value={solverSettings.omega_rpm ?? null}
-							onChange={(val) => updateSolverSettings({ omega_rpm: val })}
+							value={
+								solverSettings.omega_rpm != null
+									? solverSettings.omega_rpm *
+										(unitPreferences.rotSpeed === "Hz" ? 1 / 60 : 1)
+									: null
+							}
+							onChange={(val) =>
+								updateSolverSettings({
+									omega_rpm: val * (unitPreferences.rotSpeed === "Hz" ? 60 : 1),
+								})
+							}
 							onClear={() => updateSolverSettings({ omega_rpm: null })}
 							min={0}
 							placeholder="None"
 						/>
-						<span className="text-[10px] text-stone-400 shrink-0">rpm</span>
+						<select
+							value={unitPreferences.rotSpeed}
+							onChange={(e) => setRotSpeedUnit(e.target.value as "rpm" | "Hz")}
+							className="w-12 h-7 border rounded text-[9px] bg-white outline-none shrink-0"
+						>
+							<option value="rpm">rpm</option>
+							<option value="Hz">Hz</option>
+						</select>
 					</div>
 				</div>
 

--- a/gui/frontend/src/components/Sidebar.tsx
+++ b/gui/frontend/src/components/Sidebar.tsx
@@ -390,9 +390,35 @@ const Sidebar = () => {
 					/>
 				</div>
 
+				<div className="border-t border-stone-200 pt-2 flex flex-col gap-2">
+					<button
+						type="button"
+						onClick={resetAllInitialGuesses}
+						className="w-full text-[10px] font-bold uppercase tracking-wider bg-white hover:bg-amber-50 text-amber-700 border border-amber-200 rounded px-2 py-1.5 transition-colors"
+						title="Clear initial-guess overrides on every node and element; solver reverts to auto-seeding"
+					>
+						Reset All Initial Guesses
+					</button>
+
+					{solveResults && (solveResults as any).isTopologyMismatch && (
+						<button
+							type="button"
+							onClick={() => updateSolverSettings({ init_strategy: "default" })}
+							className="w-full text-[10px] font-bold uppercase tracking-wider bg-red-50 hover:bg-red-100 text-red-700 border border-red-200 rounded px-2 py-1.5 transition-colors"
+						>
+							Reset Solver (Cold Start)
+						</button>
+					)}
+				</div>
+			</div>
+
+			<div className="mt-6 text-sm font-bold text-gray-500 uppercase tracking-wider">
+				Shaft Speed
+			</div>
+			<div className="flex flex-col gap-4 mt-2 p-3 bg-stone-50 rounded border border-stone-200">
 				<div className="flex flex-col gap-1">
 					<label className="text-[10px] font-bold text-gray-400 uppercase">
-						Shaft Speed (Global)
+						Global
 					</label>
 					<div className="flex items-center gap-1 w-full">
 						<NumericInput
@@ -421,27 +447,6 @@ const Sidebar = () => {
 							<option value="Hz">Hz</option>
 						</select>
 					</div>
-				</div>
-
-				<div className="border-t border-stone-200 pt-2 flex flex-col gap-2">
-					<button
-						type="button"
-						onClick={resetAllInitialGuesses}
-						className="w-full text-[10px] font-bold uppercase tracking-wider bg-white hover:bg-amber-50 text-amber-700 border border-amber-200 rounded px-2 py-1.5 transition-colors"
-						title="Clear initial-guess overrides on every node and element; solver reverts to auto-seeding"
-					>
-						Reset All Initial Guesses
-					</button>
-
-					{solveResults && (solveResults as any).isTopologyMismatch && (
-						<button
-							type="button"
-							onClick={() => updateSolverSettings({ init_strategy: "default" })}
-							className="w-full text-[10px] font-bold uppercase tracking-wider bg-red-50 hover:bg-red-100 text-red-700 border border-red-200 rounded px-2 py-1.5 transition-colors"
-						>
-							Reset Solver (Cold Start)
-						</button>
-					)}
 				</div>
 			</div>
 		</aside>

--- a/gui/frontend/src/components/Sidebar.tsx
+++ b/gui/frontend/src/components/Sidebar.tsx
@@ -394,9 +394,9 @@ const Sidebar = () => {
 					<label className="text-[10px] font-bold text-gray-400 uppercase">
 						Shaft Speed (Global)
 					</label>
-					<div className="flex items-center gap-1">
+					<div className="flex items-center gap-1 w-full">
 						<NumericInput
-							className="p-1 border rounded text-xs bg-white h-7 outline-none focus:ring-1 focus:ring-stone-200 flex-1"
+							className="p-1 border rounded text-xs bg-white h-7 outline-none focus:ring-1 focus:ring-stone-200 flex-1 min-w-0"
 							value={
 								solverSettings.omega_rpm != null
 									? solverSettings.omega_rpm *

--- a/gui/frontend/src/components/Sidebar.tsx
+++ b/gui/frontend/src/components/Sidebar.tsx
@@ -413,12 +413,12 @@ const Sidebar = () => {
 			</div>
 
 			<div className="mt-6 text-sm font-bold text-gray-500 uppercase tracking-wider">
-				Shaft Speed
+				Global Settings
 			</div>
 			<div className="flex flex-col gap-4 mt-2 p-3 bg-stone-50 rounded border border-stone-200">
 				<div className="flex flex-col gap-1">
 					<label className="text-[10px] font-bold text-gray-400 uppercase">
-						Global
+						Shaft Speed
 					</label>
 					<div className="flex items-center gap-1 w-full">
 						<NumericInput

--- a/gui/frontend/src/components/Sidebar.tsx
+++ b/gui/frontend/src/components/Sidebar.tsx
@@ -11,6 +11,7 @@ import {
 	Maximize2,
 	Save,
 	Split,
+	Tornado,
 	Upload,
 	Wind,
 } from "lucide-react";
@@ -277,6 +278,16 @@ const Sidebar = () => {
 				<span>Tee Junction</span>
 			</button>
 
+			<button
+				type="button"
+				className="flex items-center gap-2 p-2 border rounded cursor-grab hover:bg-stone-50 transition-colors w-full text-left bg-white"
+				onDragStart={(event) => onDragStart(event, "vortex")}
+				draggable
+			>
+				<Tornado size={18} className="text-violet-500" />
+				<span>Vortex</span>
+			</button>
+
 			{/* Diagnostics divider */}
 			<div className="text-[10px] font-bold text-stone-400 uppercase tracking-wider mt-2 mb-0.5">
 				Diagnostics
@@ -375,6 +386,23 @@ const Sidebar = () => {
 						min={0}
 						placeholder="None"
 					/>
+				</div>
+
+				<div className="flex flex-col gap-1">
+					<label className="text-[10px] font-bold text-gray-400 uppercase">
+						Shaft Speed (Global)
+					</label>
+					<div className="flex items-center gap-1">
+						<NumericInput
+							className="p-1 border rounded text-xs bg-white h-7 outline-none focus:ring-1 focus:ring-stone-200 flex-1"
+							value={solverSettings.omega_rpm ?? null}
+							onChange={(val) => updateSolverSettings({ omega_rpm: val })}
+							onClear={() => updateSolverSettings({ omega_rpm: null })}
+							min={0}
+							placeholder="None"
+						/>
+						<span className="text-[10px] text-stone-400 shrink-0">rpm</span>
+					</div>
 				</div>
 
 				<div className="border-t border-stone-200 pt-2 flex flex-col gap-2">

--- a/gui/frontend/src/components/flowTypes.ts
+++ b/gui/frontend/src/components/flowTypes.ts
@@ -11,6 +11,7 @@ import PlenumNode from "./nodes/PlenumNode";
 import PressureBoundaryNode from "./nodes/PressureBoundaryNode";
 import ProbeNode from "./nodes/ProbeNode";
 import TeeJunctionNode from "./nodes/TeeJunctionNode";
+import VortexNode from "./nodes/VortexNode";
 import ThermalEdge from "./ThermalEdge";
 
 export const nodeTypes = {
@@ -26,6 +27,7 @@ export const nodeTypes = {
 	probe: ProbeNode,
 	area_change: AreaChangeNode,
 	tee_junction: TeeJunctionNode,
+	vortex: VortexNode,
 };
 
 export const edgeTypes = {

--- a/gui/frontend/src/components/nodes/VortexNode.tsx
+++ b/gui/frontend/src/components/nodes/VortexNode.tsx
@@ -31,6 +31,13 @@ const VortexNode = ({ data, selected }: NodeProps) => {
 				{isSolved && <NodeDiagRows result={data.result} maxRows={1} />}
 			</div>
 
+			<div className="absolute -left-3 top-1/2 -translate-y-1/2 text-[7px] font-extrabold leading-none select-none pointer-events-none bg-white/70 rounded-sm px-0.5 text-blue-500">
+				i
+			</div>
+			<div className="absolute -right-3 top-1/2 -translate-y-1/2 text-[7px] font-extrabold leading-none select-none pointer-events-none bg-white/70 rounded-sm px-0.5 text-green-500">
+				o
+			</div>
+
 			<Handle type="target" position={Position.Left} id="flow-target" />
 			<Handle type="source" position={Position.Right} id="flow-source" />
 		</div>

--- a/gui/frontend/src/components/nodes/VortexNode.tsx
+++ b/gui/frontend/src/components/nodes/VortexNode.tsx
@@ -1,0 +1,40 @@
+import { Tornado } from "lucide-react";
+import { Handle, type NodeProps, Position } from "reactflow";
+import { NodeDiagRows } from "../NodeDiagRows";
+
+const VortexNode = ({ data, selected }: NodeProps) => {
+	const isSolved = !!data.result;
+	const hasLocalRpm = data.omega_rpm != null;
+
+	return (
+		<div
+			className={`shadow-sm rounded bg-stone-50 border-2 flex items-center gap-2 px-3 py-1 ${
+				selected
+					? "border-blue-500 shadow-blue-100"
+					: isSolved
+						? "border-green-400"
+						: "border-stone-300"
+			}`}
+			style={{ width: 140, height: 56 }}
+		>
+			<div className="flex items-center justify-center p-1 bg-violet-50 border border-violet-200 rounded shrink-0">
+				<Tornado size={16} className="text-violet-500" />
+			</div>
+
+			<div className="flex flex-col items-start flex-1 min-w-0">
+				<div className="text-[10px] font-bold uppercase leading-none whitespace-nowrap">
+					{data.label ? data.label : "Vortex"}
+				</div>
+				<div className="text-[9px] font-mono text-violet-500 whitespace-nowrap">
+					{hasLocalRpm ? `${data.omega_rpm} rpm` : "global rpm"}
+				</div>
+				{isSolved && <NodeDiagRows result={data.result} maxRows={1} />}
+			</div>
+
+			<Handle type="target" position={Position.Left} id="flow-target" />
+			<Handle type="source" position={Position.Right} id="flow-source" />
+		</div>
+	);
+};
+
+export default VortexNode;

--- a/gui/frontend/src/store/useStore.ts
+++ b/gui/frontend/src/store/useStore.ts
@@ -46,6 +46,7 @@ export interface RFState {
 			| "continuation";
 		method: string;
 		timeout: number | null;
+		omega_rpm: number | null;
 	};
 	updateSolverSettings: (settings: Partial<RFState["solverSettings"]>) => void;
 	unitPreferences: {
@@ -254,6 +255,7 @@ const useStore = create<RFState>((set, get) => ({
 		init_strategy: "default",
 		method: "hybr",
 		timeout: 30,
+		omega_rpm: null,
 	},
 	updateSolverSettings: (settings: Partial<RFState["solverSettings"]>) => {
 		set({

--- a/gui/frontend/src/store/useStore.ts
+++ b/gui/frontend/src/store/useStore.ts
@@ -53,10 +53,12 @@ export interface RFState {
 		pressure: "Pa" | "kPa" | "MPa";
 		length: "m" | "mm";
 		area: "m²" | "mm²";
+		rotSpeed: "rpm" | "Hz";
 	};
 	setPressureUnit: (unit: "Pa" | "kPa" | "MPa") => void;
 	setLengthUnit: (unit: "m" | "mm") => void;
 	setAreaUnit: (unit: "m²" | "mm²") => void;
+	setRotSpeedUnit: (unit: "rpm" | "Hz") => void;
 	saveNetwork: (filename?: string) => void | Promise<void>;
 	loadNetwork: (data: any) => void;
 	dismissSolveStatus: () => void;
@@ -263,7 +265,12 @@ const useStore = create<RFState>((set, get) => ({
 		});
 	},
 
-	unitPreferences: { pressure: "kPa", length: "m", area: "m²" },
+	unitPreferences: {
+		pressure: "kPa",
+		length: "m",
+		area: "m²",
+		rotSpeed: "rpm",
+	},
 	setPressureUnit: (unit: "Pa" | "kPa" | "MPa") => {
 		set((state) => ({
 			unitPreferences: { ...state.unitPreferences, pressure: unit },
@@ -277,6 +284,11 @@ const useStore = create<RFState>((set, get) => ({
 	setAreaUnit: (unit: "m²" | "mm²") => {
 		set((state) => ({
 			unitPreferences: { ...state.unitPreferences, area: unit },
+		}));
+	},
+	setRotSpeedUnit: (unit: "rpm" | "Hz") => {
+		set((state) => ({
+			unitPreferences: { ...state.unitPreferences, rotSpeed: unit },
 		}));
 	},
 

--- a/python/combaero/network/__init__.py
+++ b/python/combaero/network/__init__.py
@@ -24,6 +24,7 @@ from .components import (
     ThermalWall,
     AreaChangeElement,
     TeeJunctionElement,
+    VortexElement,
 )
 from .combustion import (
     CombustionResult,
@@ -57,6 +58,7 @@ __all__: list[str] = [
     "PressureLossElement",
     "AreaChangeElement",
     "TeeJunctionElement",
+    "VortexElement",
     "EnergyBoundary",
     "NetworkMixtureState",
     "CombustionResult",

--- a/python/combaero/network/components.py
+++ b/python/combaero/network/components.py
@@ -2744,3 +2744,115 @@ class TeeJunctionElement(NetworkElement):
             "K_branch": float(res.K_branch),
             "correlation_extrapolated": 1.0 if is_extrapolated else 0.0,
         }
+
+
+# ---------------------------------------------------------------------------
+# Vortex element: rotating-cavity centrifugal pressure rise (Vatistas 1991)
+# ---------------------------------------------------------------------------
+
+
+class VortexElement(NetworkElement):
+    """
+    Models the centrifugal pressure rise of a rotating cavity or disc
+    using the Vatistas (1991) n-vortex model.
+
+    The shaft angular velocity omega drives a vortex whose circulation is
+    Gamma = 2*pi * r_c^2 * omega * 2^(1/n), i.e. the core rotates as solid
+    body at omega.  The pressure rise from r_in to r_out follows from
+    integrating the centripetal acceleration:
+        dP_rise = vatistas_delta_p(r_out, rho, Gamma, r_c, n)
+                - vatistas_delta_p(r_in,  rho, Gamma, r_c, n)
+    where rho is taken from the upstream node state.
+    """
+
+    def __init__(
+        self,
+        id: str,
+        from_node: str,
+        to_node: str,
+        r_c: float = 0.02,
+        r_out: float = 0.10,
+        r_in: float = 0.0,
+        omega_rpm: float = 0.0,
+        n: float = 2.0,
+    ):
+        super().__init__(id, from_node, to_node)
+        if n < 1.0:
+            raise ValueError(f"Vatistas shape parameter n must be >= 1; got {n}")
+        if r_c <= 0.0:
+            raise ValueError(f"Core radius r_c must be > 0; got {r_c}")
+        if r_out <= 0.0:
+            raise ValueError(f"Outer radius r_out must be > 0; got {r_out}")
+        if r_in < 0.0:
+            raise ValueError(f"Inner radius r_in must be >= 0; got {r_in}")
+        self.r_c = float(r_c)
+        self.r_out = float(r_out)
+        self.r_in = float(r_in)
+        self.omega_rpm = float(omega_rpm)
+        self.n = float(n)
+
+    def _gamma(self) -> float:
+        """Circulation [m^2/s] from shaft speed assuming solid-body vortex core."""
+        omega = self.omega_rpm * 2.0 * math.pi / 60.0
+        return 2.0 * math.pi * self.r_c**2 * omega * 2.0 ** (1.0 / self.n)
+
+    def _dp_rise(self, rho: float) -> float:
+        """Total pressure rise [Pa] at inlet density rho."""
+        gamma = self._gamma()
+        if gamma == 0.0:
+            return 0.0
+        dp_out = cb.vatistas_delta_p(self.r_out, rho, gamma, self.r_c, self.n)
+        dp_in = (
+            cb.vatistas_delta_p(self.r_in, rho, gamma, self.r_c, self.n) if self.r_in > 0.0 else 0.0
+        )
+        return dp_out - dp_in
+
+    def resolve_topology(self, graph: "FlowNetwork") -> None:
+        pass
+
+    def unknowns(self) -> list[str]:
+        return [f"{self.id}.m_dot"]
+
+    def n_equations(self) -> int:
+        return 1
+
+    def residuals(
+        self, state_in: NetworkMixtureState, state_out: NetworkMixtureState
+    ) -> tuple[list[float], dict[int, dict[str, float]]]:
+        rho_raw = state_in.density()
+        rho, d_rho_safe = _safe_rho(rho_raw)
+        dp_rise = self._dp_rise(rho)
+
+        res = [state_out.Pt - state_in.Pt - dp_rise]
+
+        # d(dp_rise)/d(rho) = dp_rise / rho  (dP scales linearly with rho)
+        # d(rho)/d(P)  ~  rho / P  for ideal gas
+        # d(rho)/d(T)  ~ -rho / T  for ideal gas
+        dp_drho = (dp_rise / rho) * d_rho_safe if rho > 0 else 0.0
+        drho_dP = rho / state_in.P if state_in.P > 0 else 0.0
+        drho_dT = -rho / state_in.T if state_in.T > 0 else 0.0
+
+        jac: dict[int, dict[str, float]] = {
+            0: {
+                f"{self.to_node}.Pt": 1.0,
+                f"{self.from_node}.Pt": -1.0,
+                f"{self.from_node}.P": -dp_drho * drho_dP,
+                f"{self.from_node}.T": -dp_drho * drho_dT,
+            }
+        }
+        return res, jac
+
+    def diagnostics(
+        self, state_in: NetworkMixtureState, state_out: NetworkMixtureState
+    ) -> dict[str, float]:
+        if state_in.P <= 0 or state_in.T <= 0:
+            return {}
+        cs_in = cb.complete_state(state_in.T, state_in.P, state_in.X)
+        rho = cs_in.thermo.rho
+        dp_rise = self._dp_rise(rho)
+        return {
+            "m_dot": float(state_in.m_dot),
+            "omega_rpm": float(self.omega_rpm),
+            "dP_vortex": float(dp_rise),
+            **_element_pressure_block(state_in, state_out, mach_in=0.0, mach_out=0.0),
+        }


### PR DESCRIPTION
## Summary

- Adds `VortexElement`, a two-port network element modelling centrifugal pressure rise in rotating cavities (disc pumps, pre-swirl chambers, inter-stage labyrinth spaces) using the **Vatistas n-vortex model**
- Circulation Γ is derived from shaft speed ω so that `V_theta(r_c) = ω·r_c` exactly (solid-body core assumption)
- Residual: `Pt_out − Pt_in − dP_vortex = 0` with analytical Jacobians w.r.t. total pressure and inlet density (via `_safe_rho`), no finite differences
- Backend: `VortexData` schema, `graph_builder.py` case with global-rpm fallback
- GUI: Tornado icon (violet-500), global shaft-speed field in solver panel, per-element RPM override in inspector, drop defaults in canvas
- All 1364 existing tests pass; units-sync test passes without IGNORE_LIST entry

## Test plan

- [ ] Drag Vortex element onto canvas; verify Tornado icon appears in violet
- [ ] Set global rpm in sidebar solver panel; verify element shows "global rpm" sub-label
- [ ] Set local rpm on element in inspector; verify override is reflected in node
- [ ] Connect PressureBoundary → Vortex → Plenum → Orifice → PressureBoundary; solve; verify Pt_out > Pt_in across vortex
- [ ] Set omega_rpm=0; verify ΔP=0 (element transparent)
- [ ] Two vortex elements with different local rpm; verify both solve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)