### PR TITLE
feat(global-settings): global Nu/f multipliers in sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Global Nu/f multipliers in the sidebar "Global Settings" panel. Setting either
+  scales all channel, combustor, momentum-chamber, and discrete-loss elements
+  multiplicatively on top of their per-element values — useful for network-wide
+  sensitivity studies without touching individual elements.
 - `VortexElement` network element: models centrifugal pressure rise in rotating cavities
   (disc pumps, pre-swirl chambers, inter-stage labyrinth spaces) using the Vatistas n-vortex
   model. Parameters: `r_c` (core radius), `r_out`, `r_in` (evaluation radii), `omega_rpm`

--- a/gui/backend/graph_builder.py
+++ b/gui/backend/graph_builder.py
@@ -287,8 +287,9 @@ def build_network_from_schema(schema: NetworkGraphSchema) -> FlowNetwork:
                 surface=ConvectiveSurface(
                     area=data.area,
                     model=map_surface_model(data.surface),
-                    Nu_multiplier=data.Nu_multiplier,
-                    f_multiplier=data.f_multiplier,
+                    Nu_multiplier=data.Nu_multiplier
+                    * (schema.solver_settings.Nu_multiplier or 1.0),
+                    f_multiplier=data.f_multiplier * (schema.solver_settings.f_multiplier or 1.0),
                 ),
             )
             node.initial_guess = _expand_initial_guess(data.initial_guess, node_id)
@@ -302,8 +303,9 @@ def build_network_from_schema(schema: NetworkGraphSchema) -> FlowNetwork:
                 surface=ConvectiveSurface(
                     area=data.area,
                     model=map_surface_model(data.surface),
-                    Nu_multiplier=data.Nu_multiplier,
-                    f_multiplier=data.f_multiplier,
+                    Nu_multiplier=data.Nu_multiplier
+                    * (schema.solver_settings.Nu_multiplier or 1.0),
+                    f_multiplier=data.f_multiplier * (schema.solver_settings.f_multiplier or 1.0),
                 ),
             )
             node.initial_guess = _expand_initial_guess(data.initial_guess, node_id)
@@ -436,8 +438,9 @@ def build_network_from_schema(schema: NetworkGraphSchema) -> FlowNetwork:
                 surface=ConvectiveSurface(
                     area=conv_area,
                     model=map_surface_model(data.surface),
-                    Nu_multiplier=data.Nu_multiplier,
-                    f_multiplier=data.f_multiplier,
+                    Nu_multiplier=data.Nu_multiplier
+                    * (schema.solver_settings.Nu_multiplier or 1.0),
+                    f_multiplier=data.f_multiplier * (schema.solver_settings.f_multiplier or 1.0),
                 ),
             )
             regime = (

--- a/gui/backend/schemas.py
+++ b/gui/backend/schemas.py
@@ -293,6 +293,12 @@ class SolverSettings(BaseModel):
     ] = "hybr"
     timeout: float | None = 180.0
     omega_rpm: float | None = None  # global shaft speed [rpm]; None = disabled
+    Nu_multiplier: float | None = (
+        None  # global heat-transfer scale; stacks multiplicatively with per-element
+    )
+    f_multiplier: float | None = (
+        None  # global friction scale; stacks multiplicatively with per-element
+    )
 
 
 # --- React Flow Wrapper Schemas ---

--- a/gui/frontend/src/components/Inspector.tsx
+++ b/gui/frontend/src/components/Inspector.tsx
@@ -446,6 +446,11 @@ const Inspector = () => {
 									}
 									className="p-2 border rounded"
 								/>
+								<span className="text-[9px] text-stone-400">
+									{solverSettings.Nu_multiplier != null
+										? `global: ×${solverSettings.Nu_multiplier}`
+										: "global: —"}
+								</span>
 							</div>
 							<div className="flex flex-col gap-2">
 								<label className="text-xs font-bold text-gray-500 uppercase">
@@ -458,6 +463,11 @@ const Inspector = () => {
 									}
 									className="p-2 border rounded"
 								/>
+								<span className="text-[9px] text-stone-400">
+									{solverSettings.f_multiplier != null
+										? `global: ×${solverSettings.f_multiplier}`
+										: "global: —"}
+								</span>
 							</div>
 						</div>
 						<div className="flex flex-col gap-2">
@@ -1306,6 +1316,11 @@ const Inspector = () => {
 											}
 											className="p-2 border rounded"
 										/>
+										<span className="text-[9px] text-stone-400">
+											{solverSettings.Nu_multiplier != null
+												? `global: ×${solverSettings.Nu_multiplier}`
+												: "global: —"}
+										</span>
 									</div>
 									<div className="flex flex-col gap-2">
 										<label className="text-xs font-bold text-gray-500 uppercase">
@@ -1320,6 +1335,11 @@ const Inspector = () => {
 											}
 											className="p-2 border rounded"
 										/>
+										<span className="text-[9px] text-stone-400">
+											{solverSettings.f_multiplier != null
+												? `global: ×${solverSettings.f_multiplier}`
+												: "global: —"}
+										</span>
 									</div>
 								</div>
 
@@ -1413,6 +1433,11 @@ const Inspector = () => {
 									}
 									className="p-2 border rounded"
 								/>
+								<span className="text-[9px] text-stone-400">
+									{solverSettings.Nu_multiplier != null
+										? `global: ×${solverSettings.Nu_multiplier}`
+										: "global: —"}
+								</span>
 							</div>
 							<div className="flex flex-col gap-2">
 								<label className="text-xs font-bold text-gray-500 uppercase">
@@ -1428,6 +1453,11 @@ const Inspector = () => {
 									}
 									className="p-2 border rounded"
 								/>
+								<span className="text-[9px] text-stone-400">
+									{solverSettings.f_multiplier != null
+										? `global: ×${solverSettings.f_multiplier}`
+										: "global: —"}
+								</span>
 							</div>
 						</div>
 						<SurfaceEnhancementInspector
@@ -1495,6 +1525,11 @@ const Inspector = () => {
 									}
 									className="p-2 border rounded"
 								/>
+								<span className="text-[9px] text-stone-400">
+									{solverSettings.Nu_multiplier != null
+										? `global: ×${solverSettings.Nu_multiplier}`
+										: "global: —"}
+								</span>
 							</div>
 							<div className="flex flex-col gap-2">
 								<label className="text-xs font-bold text-gray-500 uppercase">
@@ -1510,6 +1545,11 @@ const Inspector = () => {
 									}
 									className="p-2 border rounded"
 								/>
+								<span className="text-[9px] text-stone-400">
+									{solverSettings.f_multiplier != null
+										? `global: ×${solverSettings.f_multiplier}`
+										: "global: —"}
+								</span>
 							</div>
 						</div>
 						<SurfaceEnhancementInspector

--- a/gui/frontend/src/components/Sidebar.tsx
+++ b/gui/frontend/src/components/Sidebar.tsx
@@ -448,6 +448,38 @@ const Sidebar = () => {
 						</select>
 					</div>
 				</div>
+				<div className="flex flex-col gap-1">
+					<label className="text-[10px] font-bold text-gray-400 uppercase">
+						Nu Multiplier
+					</label>
+					<NumericInput
+						className="p-1 border rounded text-xs bg-white h-7 outline-none focus:ring-1 focus:ring-stone-200"
+						value={solverSettings.Nu_multiplier ?? null}
+						onChange={(val) => updateSolverSettings({ Nu_multiplier: val })}
+						onClear={() => updateSolverSettings({ Nu_multiplier: null })}
+						min={0}
+						placeholder="1.0"
+					/>
+					<span className="text-[9px] text-stone-400">
+						Scales heat transfer on all elements multiplicatively
+					</span>
+				</div>
+				<div className="flex flex-col gap-1">
+					<label className="text-[10px] font-bold text-gray-400 uppercase">
+						f Multiplier
+					</label>
+					<NumericInput
+						className="p-1 border rounded text-xs bg-white h-7 outline-none focus:ring-1 focus:ring-stone-200"
+						value={solverSettings.f_multiplier ?? null}
+						onChange={(val) => updateSolverSettings({ f_multiplier: val })}
+						onClear={() => updateSolverSettings({ f_multiplier: null })}
+						min={0}
+						placeholder="1.0"
+					/>
+					<span className="text-[9px] text-stone-400">
+						Scales friction factor on all elements multiplicatively
+					</span>
+				</div>
 			</div>
 		</aside>
 	);

--- a/gui/frontend/src/store/useStore.ts
+++ b/gui/frontend/src/store/useStore.ts
@@ -47,6 +47,8 @@ export interface RFState {
 		method: string;
 		timeout: number | null;
 		omega_rpm: number | null;
+		Nu_multiplier: number | null;
+		f_multiplier: number | null;
 	};
 	updateSolverSettings: (settings: Partial<RFState["solverSettings"]>) => void;
 	unitPreferences: {
@@ -258,6 +260,8 @@ const useStore = create<RFState>((set, get) => ({
 		method: "hybr",
 		timeout: 30,
 		omega_rpm: null,
+		Nu_multiplier: null,
+		f_multiplier: null,
 	},
 	updateSolverSettings: (settings: Partial<RFState["solverSettings"]>) => {
 		set({


### PR DESCRIPTION
## Summary

- Adds `Nu_multiplier` and `f_multiplier` to `SolverSettings` (schema + store, default `null` = 1.0)
- Both stack **multiplicatively** on top of per-element values: `effective = element_value × (global or 1.0)`
- Affects all elements that expose these fields: Channel, Combustor, MomentumChamber, DiscreteLoss
- Two NumericInput fields added to the sidebar "Global Settings" card beneath Shaft Speed
- Existing saved networks unaffected (null = no-op)

## Test plan

- [ ] Set global Nu multiplier to 2.0; verify channel Nusselt output doubles vs baseline
- [ ] Set global f multiplier to 1.5; verify friction pressure drop increases across a channel
- [ ] Clear both back to empty (null); verify results return to baseline
- [ ] Per-element Nu_multiplier still works independently when global is null
- [ ] Per-element × global stacking: element=1.2, global=1.5 → effective=1.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)