### PR TITLE
fix(solver): harden Newton iteration against unphysical intermediate states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Solver hardening** against unphysical intermediate states during Newton iteration:
+  - Temperature floor raised from 50 K to 200 K (both in `_propagate_states` and
+    `_get_node_state`); ceiling of 5000 K added to bound combustion runaway.
+  - Static pressure floor of 1000 Pa added in `_get_node_state` to prevent NaN
+    propagation in thermo calls when P drifts near zero.
+  - Penalty residual (triggered on unphysical state exceptions) now encodes
+    `F = x_scaled − x_best_scaled` with `J = I`, so the Newton step jumps back
+    exactly to the best physical iterate seen so far — previously the constant
+    penalty `[10,…,10]` could drive iterates further into unphysical territory.
+  - `CombustorNode.compute_derived_state` now wraps the C++ combustion call in a
+    try/except and re-raises with a diagnostic message; the solver penalty path
+    already handled C++ exceptions, but the new wrapper provides traceability.
+  - `graph_builder` now seeds `initial_guess` from the previous solve result
+    (`data.result` in node/element data) when no explicit user override exists,
+    giving repeated solves a warm start without requiring the `continuation`
+    strategy.
+
 ### Added
 - Global ambient conditions (T, P, RH) in the sidebar "Global Settings" panel, defaulting
   to ISO 2314 gas-turbine reference conditions (288.15 K, 101325 Pa, RH 0.6). When set,

--- a/gui/backend/graph_builder.py
+++ b/gui/backend/graph_builder.py
@@ -185,6 +185,35 @@ def _expand_initial_guess(short_guess: dict, prefix: str) -> dict:
     return result
 
 
+def _guess_from_prior_result(node_data: dict, prefix: str) -> dict:
+    """Build an initial-guess dict from a prior solve result stored in node_data.
+
+    The GUI frontend writes the last solve result into node_data["result"].
+    When data.initial_guess is empty (no explicit user override), this
+    provides a warm-start from the previously found state so that repeated
+    solves on a difficult network benefit from accumulated Newton progress.
+    Works for both pressure-node results (state.P/T/Pt/Tt) and element
+    results (m_dot stored at the top level).
+    """
+    prior = node_data.get("result")
+    if not prior:
+        return {}
+    short: dict[str, float] = {}
+    state = prior.get("state")
+    if state:
+        if (p := state.get("P")) is not None:
+            short["P"] = float(p)
+        if (t := state.get("T")) is not None:
+            short["T"] = float(t)
+        if (pt := state.get("Pt")) is not None:
+            short["Pt"] = float(pt)
+        if (tt := state.get("Tt")) is not None:
+            short["Tt"] = float(tt)
+    if (m_dot := prior.get("m_dot")) is not None:
+        short["m_dot"] = float(m_dot)
+    return _expand_initial_guess(short, prefix)
+
+
 def _build_discrete_loss_correlation(
     corr_type: str,
     xi: float,
@@ -277,6 +306,8 @@ def build_network_from_schema(schema: NetworkGraphSchema) -> FlowNetwork:
             data = PlenumData(**node_data)
             node = PlenumNode(node_id)
             node.initial_guess = _expand_initial_guess(data.initial_guess, node_id)
+            if not node.initial_guess:
+                node.initial_guess = _guess_from_prior_result(node_data, node_id)
             net.add_node(node)
             nodes_map[node_id] = node
             plenum_node_ids.add(node_id)
@@ -285,6 +316,8 @@ def build_network_from_schema(schema: NetworkGraphSchema) -> FlowNetwork:
             Y = resolve_composition(data.composition, data.Tt, 101325.0, schema.solver_settings)
             node = MassFlowBoundary(node_id, m_dot=data.m_dot, Tt=data.Tt, Y=Y)
             node.initial_guess = _expand_initial_guess(data.initial_guess, node_id)
+            if not node.initial_guess:
+                node.initial_guess = _guess_from_prior_result(node_data, node_id)
             net.add_node(node)
             nodes_map[node_id] = node
         elif node_type == "pressure_boundary":
@@ -310,6 +343,8 @@ def build_network_from_schema(schema: NetworkGraphSchema) -> FlowNetwork:
                 ),
             )
             node.initial_guess = _expand_initial_guess(data.initial_guess, node_id)
+            if not node.initial_guess:
+                node.initial_guess = _guess_from_prior_result(node_data, node_id)
             net.add_node(node)
             nodes_map[node_id] = node
         elif node_type == "momentum_chamber":
@@ -326,6 +361,8 @@ def build_network_from_schema(schema: NetworkGraphSchema) -> FlowNetwork:
                 ),
             )
             node.initial_guess = _expand_initial_guess(data.initial_guess, node_id)
+            if not node.initial_guess:
+                node.initial_guess = _guess_from_prior_result(node_data, node_id)
             net.add_node(node)
             nodes_map[node_id] = node
         elif node_type == "probe":
@@ -410,6 +447,8 @@ def build_network_from_schema(schema: NetworkGraphSchema) -> FlowNetwork:
                 tee_type=_d.tee_type,
             )
             _tee.initial_guess = _expand_initial_guess(_d.initial_guess, elem_id)
+            if not _tee.initial_guess:
+                _tee.initial_guess = _guess_from_prior_result(elem_data, elem_id)
             net.add_element(_tee)
             continue
 
@@ -465,6 +504,8 @@ def build_network_from_schema(schema: NetworkGraphSchema) -> FlowNetwork:
             )
             elem.regime = regime
             elem.initial_guess = _expand_initial_guess(data.initial_guess, elem_id)
+            if not elem.initial_guess:
+                elem.initial_guess = _guess_from_prior_result(elem_data, elem_id)
             net.add_element(elem)
         elif elem_type == "orifice":
             data = OrificeData(**elem_data)
@@ -483,6 +524,8 @@ def build_network_from_schema(schema: NetworkGraphSchema) -> FlowNetwork:
             )
             elem.regime = regime
             elem.initial_guess = _expand_initial_guess(data.initial_guess, elem_id)
+            if not elem.initial_guess:
+                elem.initial_guess = _guess_from_prior_result(elem_data, elem_id)
             net.add_element(elem)
         elif elem_type == "area_change":
             data = AreaChangeData(**elem_data)
@@ -497,6 +540,8 @@ def build_network_from_schema(schema: NetworkGraphSchema) -> FlowNetwork:
                 D_h=data.D_h,
             )
             elem.initial_guess = _expand_initial_guess(data.initial_guess, elem_id)
+            if not elem.initial_guess:
+                elem.initial_guess = _guess_from_prior_result(elem_data, elem_id)
             net.add_element(elem)
         elif elem_type == "lossless_connection":
             elem = LosslessConnectionElement(elem_id, from_node=source_id, to_node=target_id)
@@ -528,6 +573,8 @@ def build_network_from_schema(schema: NetworkGraphSchema) -> FlowNetwork:
                 surface=surface,
             )
             elem.initial_guess = _expand_initial_guess(data.initial_guess, elem_id)
+            if not elem.initial_guess:
+                elem.initial_guess = _guess_from_prior_result(elem_data, elem_id)
             net.add_element(elem)
         elif elem_type == "vortex":
             data = VortexData(**elem_data)
@@ -547,6 +594,8 @@ def build_network_from_schema(schema: NetworkGraphSchema) -> FlowNetwork:
                 n=data.n,
             )
             elem.initial_guess = _expand_initial_guess(data.initial_guess, elem_id)
+            if not elem.initial_guess:
+                elem.initial_guess = _guess_from_prior_result(elem_data, elem_id)
             net.add_element(elem)
 
     # 3. Third Pass: Auto-connections

--- a/python/combaero/network/components.py
+++ b/python/combaero/network/components.py
@@ -1146,14 +1146,22 @@ class CombustorNode(NetworkNode):
         fraction_total = sum(eb.fraction for eb in self.energy_boundaries)
 
         # Combustor only: mixing + combustion, NO pressure loss (that's on the edge).
-        mix_res = _solver_tools.combustor_residuals_and_jacobians(
-            streams,
-            P_ref,
-            Q=Q_total,
-            fraction=fraction_total,
-            pressure_loss=_zero_loss,
-            use_equilibrium=(self.method == "equilibrium"),
-        )
+        try:
+            mix_res = _solver_tools.combustor_residuals_and_jacobians(
+                streams,
+                P_ref,
+                Q=Q_total,
+                fraction=fraction_total,
+                pressure_loss=_zero_loss,
+                use_equilibrium=(self.method == "equilibrium"),
+            )
+        except Exception as exc:
+            # Unphysical intermediate state during Newton iteration (e.g. extreme phi).
+            # Re-raise so the solver penalty path can guide the step back to physics.
+            raise RuntimeError(
+                f"CombustorNode '{self.id}': combustion call failed "
+                f"(T_unburned={self._T_unburned:.1f} K)"
+            ) from exc
         self._last_mix_res = mix_res
         # Expose burned temperature for adjacent PressureLossElement (theta source).
         self._T_burned = float(mix_res.T_mix)

--- a/python/combaero/network/solver.py
+++ b/python/combaero/network/solver.py
@@ -677,7 +677,7 @@ class NetworkSolver:
                 wall_contributions = self._evaluate_walls_for_node(nid, up_elems, x)
 
             T, Y, mix_res = node.compute_derived_state(up_states)
-            T = max(float(T), 50.0)
+            T = min(max(float(T), 200.0), 5000.0)
             self._derived_states[nid] = (T, Y, mix_res)
 
             # Store wall coupling debug info on the node
@@ -1010,11 +1010,14 @@ class NetworkSolver:
         if y_sum > 0:
             Y_safe = [yi / y_sum for yi in Y_safe]
 
+        # P5: Floor on static pressure to prevent NaN in thermo calls at near-zero P.
+        P_safe = max(float(state_dict["P"]), 1000.0)
+
         return NetworkMixtureState(
-            float(state_dict["P"]),
+            P_safe,
             float(state_dict["Pt"]),
-            max(float(state_dict["T"]), 50.0),
-            max(float(state_dict["Tt"]), 50.0),
+            min(max(float(state_dict["T"]), 200.0), 5000.0),
+            min(max(float(state_dict["Tt"]), 200.0), 5000.0),
             float(state_dict["m_dot"]),
             Y_safe,
         )
@@ -1473,7 +1476,12 @@ class NetworkSolver:
                         stacklevel=2,
                     )
                     self._penalty_warning_issued = True
-                penalty = np.full(len(x_scaled), 10.0, dtype=float)
+                # Penalty that pulls Newton back toward the best physical point
+                # seen so far.  F = x_scaled - x_best means Newton step = x_best
+                # exactly (J=I), so hybr retreats to a known-safe iterate rather
+                # than stepping deeper into unphysical territory.
+                x_best_scaled = best_x * inv_D_x
+                penalty = x_scaled - x_best_scaled
                 if use_jac and method in ("hybr", "lm"):
                     return penalty, np.eye(len(x_scaled))
                 return penalty


### PR DESCRIPTION
## Summary

- T floor raised 50 K to 200 K with new 5000 K ceiling in both _propagate_states and _get_node_state
- P floor at 1000 Pa in _get_node_state to prevent NaN in C++ thermo calls at near-zero pressure
- Penalty residual replaced: constant [10,10,...] + identity Jacobian replaced with F = x_scaled - x_best_scaled + I, so Newton jumps back to the best known physical iterate
- CombustorNode wraps combustion C++ call in try/except with diagnostic re-raise for extreme-phi failures
- graph_builder seeds initial_guess from data.result (prior solve result) when no explicit user override exists

## Motivation

Diagnosed using gui/tmp/unstable_network.json: hot air + CH4 combustion network where all nodes failed. Combustor showed phi=17.2, exposing: no T ceiling, penalty driving Newton away from physics, and no reuse of prior results as warm start.

## Test plan
- [x] All 1365 tests pass
- [x] Python style clean
- [x] Jacobian tests pass (T/P clamping does not affect Jacobian accuracy at normal operating points)

Generated with Claude Code