### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-05-20
+
 ### Changed
 - **Solver hardening** against unphysical intermediate states during Newton iteration:
   - Temperature floor raised from 50 K to 200 K (both in `_propagate_states` and


### PR DESCRIPTION
Promotes the [Unreleased] CHANGELOG block to [0.3.0] - 2026-05-20.

After merging, tag the merge commit with `v0.3.0` to trigger the publish workflow.

## What's in v0.3.0

**Added**
- Global ambient conditions (T, P, RH) with ISO 2314 GT defaults; per-node local overrides
- Global Nu/f multipliers for network-wide sensitivity studies
- `VortexElement`: centrifugal pressure rise via Vatistas n-vortex model
- Vatistas (1991) vortex model with full analytical Jacobians
- Channel friction model selector (Haaland, Serghides, Colebrook-White, Petukhov)
- `NetworkRunner` / `NetworkResult` for programmatic / Jupyter use without starting the web server
- Tee junction element with merging/splitting modes

**Fixed**
- Combustor networks with non-physical Newton steps no longer crash
- Petukhov friction no longer throws below Re 3000
- GUI JSON load correctly picks up solver settings (solverSettings → solver_settings normalisation)

**Changed**
- Solver hardening: T floor 50 K → 200 K + 5000 K ceiling, P floor 1000 Pa, smarter penalty residual, warm start from prior results

Generated with Claude Code