### PR TITLE
fix(gui): bump combaero dependency pin to ~=0.3

### DIFF
--- a/gui/pyproject.toml
+++ b/gui/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "uvicorn",
     "pydantic",
     "pandas",
-    "combaero~=0.2",
+    "combaero~=0.3",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
`combaero-gui` 0.3.0 imports `TeeJunctionElement` and `VortexElement`, both added after `combaero` 0.2.6. The old `~=0.2` pin resolves to 0.2.6 on PyPI and causes an `ImportError` at startup in the publish verify job.

`combaero` 0.3.0 is already on PyPI, so this one-line change unblocks the GUI publish.

After merging: manually trigger **publish-gui** via `workflow_dispatch` (no new tag needed).