### PR TITLE
fix(ci): upgrade Node to 22 in publish-gui workflow

### DIFF
--- a/.github/workflows/publish-gui.yml
+++ b/.github/workflows/publish-gui.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
           cache-dependency-path: gui/frontend/pnpm-lock.yaml
 


### PR DESCRIPTION
pnpm latest (v11) requires Node >=22. The previous pin of Node 20 caused `ERR_UNKNOWN_BUILTIN_MODULE: node:sqlite` when pnpm tried to initialise its store.