### PR TITLE
fix(tee): correct psi label — F_C/F_branch, not F_C/F_straight

### DIFF
--- a/docs/API_PYTHON.md
+++ b/docs/API_PYTHON.md
@@ -513,7 +513,8 @@ Bassett 2001 tee junction K-factor model with full Jacobians for the network sol
 
 Port convention: MAIN_INLET (A), BRANCH (B), MAIN_OUTLET (C).
 `m_dot_com` = common-port mass flow [kg/s], `m_dot_branch` = branch mass flow [kg/s],
-`F_C` = common-port cross-sectional area [m^2], `psi` = A_branch/A_com, `theta` = branch angle [rad].
+`F_C` = common-port cross-sectional area [m^2],
+`psi` = F_C/F_branch (common-port area / lateral-branch area), `theta` = branch angle [rad].
 
 ```python
 import combaero._core as _core

--- a/gui/backend/schemas.py
+++ b/gui/backend/schemas.py
@@ -214,7 +214,7 @@ class TeeJunctionData(BaseModel):
     tee_type: str = "merging"  # "merging" | "branching"
     theta_deg: float = 90.0  # branch angle [deg], converted to radians in graph_builder
     F_C: float = 0.01  # common-arm area [m^2]
-    psi: float = 1.0  # F_C / F_S area ratio
+    psi: float = 1.0  # F_C / F_branch (common / lateral-branch area ratio)
     initial_guess: dict[str, float] = Field(default_factory=dict)
 
 

--- a/gui/frontend/src/components/Inspector.tsx
+++ b/gui/frontend/src/components/Inspector.tsx
@@ -805,7 +805,7 @@ const Inspector = () => {
 						{/* Area ratio */}
 						<div className="flex flex-col gap-2">
 							<label className="text-xs font-bold text-gray-500 uppercase">
-								Area Ratio psi = F_C / F_S
+								Area Ratio psi = F_C / F_branch
 							</label>
 							<NumericInput
 								value={selectedNode.data.psi ?? 1.0}
@@ -816,7 +816,9 @@ const Inspector = () => {
 								placeholder="1.0"
 							/>
 							<p className="text-[9px] text-gray-400 italic">
-								Ratio of common-arm to straight-arm area. 1.0 = equal areas.
+								Ratio of common-arm to lateral-branch area. 1.0 = equal areas.
+								Straight arm is assumed equal to the common arm (Bassett
+								constraint).
 							</p>
 						</div>
 

--- a/python/combaero/network/components.py
+++ b/python/combaero/network/components.py
@@ -2573,6 +2573,10 @@ class TeeJunctionElement(NetworkElement):
 
     Unknowns: m_dot_com (total common flow) and m_dot_branch (branch flow).
     Straight flow is implicit: m_dot_straight = m_dot_com - m_dot_branch.
+
+    psi = F_C / F_branch (common-arm area / lateral-branch area, default 1.0).
+    Bassett 2001 derives K5/K11 (straight-arm coefficients) under the assumption
+    F_straight = F_C; the straight-arm area is therefore not a free parameter.
     """
 
     def __init__(
@@ -2583,7 +2587,7 @@ class TeeJunctionElement(NetworkElement):
         branch_node: str,
         theta: float,
         F_C: float,
-        psi: float = 1.0,
+        psi: float = 1.0,  # F_C / F_branch: common / lateral-branch area ratio
         tee_type: Literal["merging", "branching"] = "merging",
         blend_k: float = 30.0,
     ):


### PR DESCRIPTION
## Summary

- `psi` is `F_C / F_branch` (common / lateral-branch area) throughout. The previous label `F_C / F_S` pointed at the wrong arm — psi controls the **lateral** branch area via K6/K12, not the straight arm.
- `docs/API_PYTHON.md` had the ratio **inverted** (`A_branch/A_com`), which would produce wrong K-factors for any `psi ≠ 1`.
- Documents the Bassett constraint: K5/K11 (straight-arm loss coefficients) assume `F_straight = F_C`; the straight arm area is not a free parameter.
- `include/tee_junction.h` was already correct and is unchanged. No physics changes.

## Files changed

| File | Change |
|------|--------|
| `docs/API_PYTHON.md` | Fix inverted definition `A_branch/A_com` → `F_C/F_branch` |
| `python/combaero/network/components.py` | Add psi definition to class docstring; inline comment on `__init__` param |
| `gui/backend/schemas.py` | Fix comment `F_C / F_S` → `F_C / F_branch` |
| `gui/frontend/src/components/Inspector.tsx` | Fix label + help text; note Bassett F_straight=F_C constraint |

## Test plan

- [x] 1365 Python tests pass, no regressions
- [x] Pre-commit hooks pass (ruff, biome, cantera, unit tests)
- [x] Inspector label reads "Area Ratio psi = F_C / F_branch" with updated help text

🤖 Generated with [Claude Code](https://claude.com/claude-code)