### PR TITLE
feat(canvas): copy-paste nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Copy-paste nodes** (Ctrl/Cmd+C / Ctrl/Cmd+V): selected nodes can be duplicated
+  on the canvas. Physics and configuration data (including orientation) are copied;
+  custom labels and stale solver results are not. Connections are not duplicated —
+  the pasted nodes start unconnected. Pasted nodes land 50 px offset from the
+  originals and are immediately selected so they can be repositioned.
 - **Upstream geometry inheritance**: geometry fields on elements and nodes can now
   be left blank (schema value `null`); the GUI Inspector shows an inherited value
   as a greyed placeholder with a "Reset to inherited" / "Reset to circular" button.

--- a/gui/frontend/src/components/NetworkCanvas.tsx
+++ b/gui/frontend/src/components/NetworkCanvas.tsx
@@ -6,6 +6,7 @@ import ReactFlow, {
 } from "reactflow";
 import "reactflow/dist/style.css";
 import { useCallback } from "react";
+import { useCopyPaste } from "../hooks/useCopyPaste";
 import useStore from "../store/useStore";
 import { edgeTypes, nodeTypes } from "./flowTypes";
 import SolverStatusBadge from "./SolverStatusBadge";
@@ -13,6 +14,7 @@ import SolverStatusBadge from "./SolverStatusBadge";
 const NetworkCanvas = () => {
 	const { nodes, edges, setNodes, onNodesChange, onEdgesChange, onConnect } =
 		useStore();
+	useCopyPaste();
 	const { screenToFlowPosition } = useReactFlow();
 
 	const onDragOver = useCallback((event: React.DragEvent) => {

--- a/gui/frontend/src/hooks/useCopyPaste.ts
+++ b/gui/frontend/src/hooks/useCopyPaste.ts
@@ -1,0 +1,76 @@
+import { useEffect, useRef } from "react";
+import type { Node } from "reactflow";
+import useStore from "../store/useStore";
+
+const PASTE_OFFSET = 50;
+
+type Clipboard = Node[];
+
+export const useCopyPaste = () => {
+	const { nodes, setNodes } = useStore();
+	const nodesRef = useRef(nodes);
+	const clipboard = useRef<Clipboard | null>(null);
+
+	useEffect(() => {
+		nodesRef.current = nodes;
+	}, [nodes]);
+
+	useEffect(() => {
+		const onKeyDown = (e: KeyboardEvent) => {
+			if (!(e.ctrlKey || e.metaKey)) return;
+
+			// Do not intercept copy/paste when the user is editing text
+			const target = e.target as HTMLElement;
+			if (
+				target.tagName === "INPUT" ||
+				target.tagName === "TEXTAREA" ||
+				target.tagName === "SELECT" ||
+				target.isContentEditable
+			)
+				return;
+
+			if (e.key === "c") {
+				const selected = nodesRef.current.filter((n) => n.selected);
+				if (!selected.length) return;
+				clipboard.current = selected;
+			}
+
+			if (e.key === "v" && clipboard.current?.length) {
+				e.preventDefault();
+				const stamp = Date.now().toString(36);
+				const newNodes: Node[] = clipboard.current.map((n, i) => {
+					// Copy physics/config data; strip identity fields and stale results
+					const {
+						id: _id,
+						label: _label,
+						result: _result,
+						...physicsData
+					} = n.data as Record<string, unknown>;
+					const newId = `node_${stamp}_${i}`;
+					return {
+						...n,
+						id: newId,
+						position: {
+							x: n.position.x + PASTE_OFFSET,
+							y: n.position.y + PASTE_OFFSET,
+						},
+						selected: true,
+						data: {
+							...physicsData,
+							id: newId,
+						},
+					};
+				});
+
+				const current = nodesRef.current;
+				setNodes([
+					...current.map((n) => ({ ...n, selected: false })),
+					...newNodes,
+				]);
+			}
+		};
+
+		document.addEventListener("keydown", onKeyDown);
+		return () => document.removeEventListener("keydown", onKeyDown);
+	}, [setNodes]);
+};


### PR DESCRIPTION
## Summary

- Adds src/hooks/useCopyPaste.ts: a focused hook that registers a single keydown listener on document for Ctrl/Cmd+C and Ctrl/Cmd+V
- Wired into NetworkCanvas with one line: useCopyPaste()
- No store changes, no component changes

## Behaviour

- Copy: captures all currently selected nodes into a session-local ref (not the system clipboard)
- Paste: duplicates them at +50 px offset, auto-selects the new nodes so they can be repositioned immediately
- Physics / config data (D, L, area, rotation, friction model, ...) is copied
- Not copied: custom labels, solver results, connections -- pasted nodes start unconnected

## Test plan

- [ ] Select one node, Ctrl/Cmd+C, Ctrl/Cmd+V: copy appears offset and selected
- [ ] Select multiple nodes (shift-click / drag-select), copy/paste: all appear
- [ ] Paste twice: second paste stacks another +50 px
- [ ] Click into an Inspector text input, Ctrl+C / Ctrl+V: native text copy/paste works, no node duplication
- [ ] Verify pasted node has no custom label and no solver result shown
- [ ] Verify rotation is preserved on paste

Generated with Claude Code