### PR TITLE
fix(nodes/edges): correct handle positions, triangle orientation and edge tangents for rotated nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   example, a 180°-rotated node's `flow-target` (logically Left) is correctly treated as
   Right, producing a smooth C-curve instead of an initial vertical leg routing behind the
   element bounding box.
+- Rotated-node handle placement and connector triangle orientation: each `Handle` now
+  receives an inline style from `handleStyle(basePos, rotation)` in `nodeUtils.ts`.
+  This overrides ReactFlow's position CSS classes (which apply in the rotated coordinate
+  system and would land a handle on the wrong visual edge) and counter-rotates the handle
+  by `−rotation` so the `::after` CSS triangle defined in `index.css` always points
+  perpendicular to the edge it sits on.  The centering uses `calc(50% − 6px)` rather than
+  `transform:translate`, so `getBoundingClientRect()` returns the correct screen centre
+  regardless of node rotation — keeping edge spline endpoints accurate.
 - `combaero-gui` white page on fresh PyPI install: `frontend/dist/assets/` was not bundled in
   the wheel because the `**` glob in `package-data` is unreliable below setuptools 69; added an
   explicit `assets/*` pattern and a `MANIFEST.in` as belt-and-suspenders.

--- a/gui/frontend/src/components/FlowEdge.tsx
+++ b/gui/frontend/src/components/FlowEdge.tsx
@@ -1,28 +1,8 @@
 import type { EdgeProps } from "reactflow";
-import {
-	BaseEdge,
-	EdgeLabelRenderer,
-	getBezierPath,
-	Position,
-	useNodes,
-} from "reactflow";
-
-function rotatePosition(pos: Position, degrees: number): Position {
-	const cycle: Position[] = [
-		Position.Right,
-		Position.Bottom,
-		Position.Left,
-		Position.Top,
-	];
-	const steps = Math.round((((degrees % 360) + 360) % 360) / 90) % 4;
-	const idx = cycle.indexOf(pos);
-	return idx === -1 ? pos : cycle[(idx + steps) % 4];
-}
+import { BaseEdge, EdgeLabelRenderer, getBezierPath } from "reactflow";
 
 export default function FlowEdge({
 	id,
-	source,
-	target,
 	sourceX,
 	sourceY,
 	targetX,
@@ -33,24 +13,13 @@ export default function FlowEdge({
 	markerEnd,
 	data,
 }: EdgeProps) {
-	const nodes = useNodes();
-	const sourceRotation =
-		(nodes.find((n) => n.id === source)?.data as { rotation?: number })
-			?.rotation ?? 0;
-	const targetRotation =
-		(nodes.find((n) => n.id === target)?.data as { rotation?: number })
-			?.rotation ?? 0;
-
-	const adjSourcePos = rotatePosition(sourcePosition, sourceRotation);
-	const adjTargetPos = rotatePosition(targetPosition, targetRotation);
-
 	const [edgePath, labelX, labelY] = getBezierPath({
 		sourceX,
 		sourceY,
-		sourcePosition: adjSourcePos,
+		sourcePosition,
 		targetX,
 		targetY,
-		targetPosition: adjTargetPos,
+		targetPosition,
 	});
 
 	const showLabel = data?.show_label && data?.label;

--- a/gui/frontend/src/components/ThermalEdge.tsx
+++ b/gui/frontend/src/components/ThermalEdge.tsx
@@ -1,23 +1,6 @@
 import type { EdgeProps } from "reactflow";
-import {
-	EdgeLabelRenderer,
-	getBezierPath,
-	Position,
-	useNodes,
-} from "reactflow";
+import { EdgeLabelRenderer, getBezierPath } from "reactflow";
 import useStore from "../store/useStore";
-
-function rotatePosition(pos: Position, degrees: number): Position {
-	const cycle: Position[] = [
-		Position.Right,
-		Position.Bottom,
-		Position.Left,
-		Position.Top,
-	];
-	const steps = Math.round((((degrees % 360) + 360) % 360) / 90) % 4;
-	const idx = cycle.indexOf(pos);
-	return idx === -1 ? pos : cycle[(idx + steps) % 4];
-}
 
 const ARROW_COLOR = "#ff9800";
 const MARKER_SIZE = 6;
@@ -33,8 +16,6 @@ function thermalColor(t: number): string {
 
 export default function ThermalEdge({
 	id,
-	source,
-	target,
 	sourceX,
 	sourceY,
 	targetX,
@@ -48,24 +29,13 @@ export default function ThermalEdge({
 	const unit = unitPreferences.length;
 	const scale = unit === "mm" ? 1000 : 1;
 
-	const nodes = useNodes();
-	const sourceRotation =
-		(nodes.find((n) => n.id === source)?.data as { rotation?: number })
-			?.rotation ?? 0;
-	const targetRotation =
-		(nodes.find((n) => n.id === target)?.data as { rotation?: number })
-			?.rotation ?? 0;
-
-	const adjSourcePos = rotatePosition(sourcePosition, sourceRotation);
-	const adjTargetPos = rotatePosition(targetPosition, targetRotation);
-
 	const [edgePath, labelX, labelY] = getBezierPath({
 		sourceX,
 		sourceY,
-		sourcePosition: adjSourcePos,
+		sourcePosition,
 		targetX,
 		targetY,
-		targetPosition: adjTargetPos,
+		targetPosition,
 	});
 
 	const Q: number | undefined = data?.result?.Q;

--- a/gui/frontend/src/components/nodes/AreaChangeNode.tsx
+++ b/gui/frontend/src/components/nodes/AreaChangeNode.tsx
@@ -6,7 +6,7 @@ import {
 	Position,
 	useUpdateNodeInternals,
 } from "reactflow";
-import { HANDLE_CSS, rotPos } from "../../utils/nodeUtils";
+import { handleStyle, rotPos } from "../../utils/nodeUtils";
 import { NodeDiagRows } from "../NodeDiagRows";
 
 const AreaChangeNode = ({ id, data, selected }: NodeProps) => {
@@ -91,25 +91,25 @@ const AreaChangeNode = ({ id, data, selected }: NodeProps) => {
 			<Handle
 				type="target"
 				position={rotPos(Position.Left, rotation)}
-				style={HANDLE_CSS[Position.Left]}
+				style={handleStyle(Position.Left, rotation)}
 				id="flow-target"
 			/>
 			<Handle
 				type="source"
 				position={rotPos(Position.Right, rotation)}
-				style={HANDLE_CSS[Position.Right]}
+				style={handleStyle(Position.Right, rotation)}
 				id="flow-source"
 			/>
 			<Handle
 				type="target"
 				position={rotPos(Position.Top, rotation)}
-				style={HANDLE_CSS[Position.Top]}
+				style={handleStyle(Position.Top, rotation)}
 				id="thermal-target"
 			/>
 			<Handle
 				type="source"
 				position={rotPos(Position.Bottom, rotation)}
-				style={HANDLE_CSS[Position.Bottom]}
+				style={handleStyle(Position.Bottom, rotation)}
 				id="thermal-source"
 			/>
 		</div>

--- a/gui/frontend/src/components/nodes/AreaChangeNode.tsx
+++ b/gui/frontend/src/components/nodes/AreaChangeNode.tsx
@@ -6,6 +6,7 @@ import {
 	Position,
 	useUpdateNodeInternals,
 } from "reactflow";
+import { rotPos } from "../../utils/nodeUtils";
 import { NodeDiagRows } from "../NodeDiagRows";
 
 const AreaChangeNode = ({ id, data, selected }: NodeProps) => {
@@ -87,10 +88,26 @@ const AreaChangeNode = ({ id, data, selected }: NodeProps) => {
 				q
 			</div>
 
-			<Handle type="target" position={Position.Left} id="flow-target" />
-			<Handle type="source" position={Position.Right} id="flow-source" />
-			<Handle type="target" position={Position.Top} id="thermal-target" />
-			<Handle type="source" position={Position.Bottom} id="thermal-source" />
+			<Handle
+				type="target"
+				position={rotPos(Position.Left, rotation)}
+				id="flow-target"
+			/>
+			<Handle
+				type="source"
+				position={rotPos(Position.Right, rotation)}
+				id="flow-source"
+			/>
+			<Handle
+				type="target"
+				position={rotPos(Position.Top, rotation)}
+				id="thermal-target"
+			/>
+			<Handle
+				type="source"
+				position={rotPos(Position.Bottom, rotation)}
+				id="thermal-source"
+			/>
 		</div>
 	);
 };

--- a/gui/frontend/src/components/nodes/AreaChangeNode.tsx
+++ b/gui/frontend/src/components/nodes/AreaChangeNode.tsx
@@ -6,7 +6,7 @@ import {
 	Position,
 	useUpdateNodeInternals,
 } from "reactflow";
-import { rotPos } from "../../utils/nodeUtils";
+import { HANDLE_CSS, rotPos } from "../../utils/nodeUtils";
 import { NodeDiagRows } from "../NodeDiagRows";
 
 const AreaChangeNode = ({ id, data, selected }: NodeProps) => {
@@ -91,21 +91,25 @@ const AreaChangeNode = ({ id, data, selected }: NodeProps) => {
 			<Handle
 				type="target"
 				position={rotPos(Position.Left, rotation)}
+				style={HANDLE_CSS[Position.Left]}
 				id="flow-target"
 			/>
 			<Handle
 				type="source"
 				position={rotPos(Position.Right, rotation)}
+				style={HANDLE_CSS[Position.Right]}
 				id="flow-source"
 			/>
 			<Handle
 				type="target"
 				position={rotPos(Position.Top, rotation)}
+				style={HANDLE_CSS[Position.Top]}
 				id="thermal-target"
 			/>
 			<Handle
 				type="source"
 				position={rotPos(Position.Bottom, rotation)}
+				style={HANDLE_CSS[Position.Bottom]}
 				id="thermal-source"
 			/>
 		</div>

--- a/gui/frontend/src/components/nodes/ChannelNode.tsx
+++ b/gui/frontend/src/components/nodes/ChannelNode.tsx
@@ -6,7 +6,7 @@ import {
 	Position,
 	useUpdateNodeInternals,
 } from "reactflow";
-import { rotPos } from "../../utils/nodeUtils";
+import { HANDLE_CSS, rotPos } from "../../utils/nodeUtils";
 import { NodeDiagRows } from "../NodeDiagRows";
 
 const ChannelNode = ({ id, data, selected }: NodeProps) => {
@@ -81,21 +81,25 @@ const ChannelNode = ({ id, data, selected }: NodeProps) => {
 			<Handle
 				type="target"
 				position={rotPos(Position.Left, rotation)}
+				style={HANDLE_CSS[Position.Left]}
 				id="flow-target"
 			/>
 			<Handle
 				type="source"
 				position={rotPos(Position.Right, rotation)}
+				style={HANDLE_CSS[Position.Right]}
 				id="flow-source"
 			/>
 			<Handle
 				type="target"
 				position={rotPos(Position.Top, rotation)}
+				style={HANDLE_CSS[Position.Top]}
 				id="thermal-target"
 			/>
 			<Handle
 				type="source"
 				position={rotPos(Position.Bottom, rotation)}
+				style={HANDLE_CSS[Position.Bottom]}
 				id="thermal-source"
 			/>
 		</div>

--- a/gui/frontend/src/components/nodes/ChannelNode.tsx
+++ b/gui/frontend/src/components/nodes/ChannelNode.tsx
@@ -6,7 +6,7 @@ import {
 	Position,
 	useUpdateNodeInternals,
 } from "reactflow";
-import { HANDLE_CSS, rotPos } from "../../utils/nodeUtils";
+import { handleStyle, rotPos } from "../../utils/nodeUtils";
 import { NodeDiagRows } from "../NodeDiagRows";
 
 const ChannelNode = ({ id, data, selected }: NodeProps) => {
@@ -81,25 +81,25 @@ const ChannelNode = ({ id, data, selected }: NodeProps) => {
 			<Handle
 				type="target"
 				position={rotPos(Position.Left, rotation)}
-				style={HANDLE_CSS[Position.Left]}
+				style={handleStyle(Position.Left, rotation)}
 				id="flow-target"
 			/>
 			<Handle
 				type="source"
 				position={rotPos(Position.Right, rotation)}
-				style={HANDLE_CSS[Position.Right]}
+				style={handleStyle(Position.Right, rotation)}
 				id="flow-source"
 			/>
 			<Handle
 				type="target"
 				position={rotPos(Position.Top, rotation)}
-				style={HANDLE_CSS[Position.Top]}
+				style={handleStyle(Position.Top, rotation)}
 				id="thermal-target"
 			/>
 			<Handle
 				type="source"
 				position={rotPos(Position.Bottom, rotation)}
-				style={HANDLE_CSS[Position.Bottom]}
+				style={handleStyle(Position.Bottom, rotation)}
 				id="thermal-source"
 			/>
 		</div>

--- a/gui/frontend/src/components/nodes/ChannelNode.tsx
+++ b/gui/frontend/src/components/nodes/ChannelNode.tsx
@@ -6,6 +6,7 @@ import {
 	Position,
 	useUpdateNodeInternals,
 } from "reactflow";
+import { rotPos } from "../../utils/nodeUtils";
 import { NodeDiagRows } from "../NodeDiagRows";
 
 const ChannelNode = ({ id, data, selected }: NodeProps) => {
@@ -77,10 +78,26 @@ const ChannelNode = ({ id, data, selected }: NodeProps) => {
 				q
 			</div>
 
-			<Handle type="target" position={Position.Left} id="flow-target" />
-			<Handle type="source" position={Position.Right} id="flow-source" />
-			<Handle type="target" position={Position.Top} id="thermal-target" />
-			<Handle type="source" position={Position.Bottom} id="thermal-source" />
+			<Handle
+				type="target"
+				position={rotPos(Position.Left, rotation)}
+				id="flow-target"
+			/>
+			<Handle
+				type="source"
+				position={rotPos(Position.Right, rotation)}
+				id="flow-source"
+			/>
+			<Handle
+				type="target"
+				position={rotPos(Position.Top, rotation)}
+				id="thermal-target"
+			/>
+			<Handle
+				type="source"
+				position={rotPos(Position.Bottom, rotation)}
+				id="thermal-source"
+			/>
 		</div>
 	);
 };

--- a/gui/frontend/src/components/nodes/CombustorNode.tsx
+++ b/gui/frontend/src/components/nodes/CombustorNode.tsx
@@ -6,7 +6,7 @@ import {
 	Position,
 	useUpdateNodeInternals,
 } from "reactflow";
-import { rotPos } from "../../utils/nodeUtils";
+import { HANDLE_CSS, rotPos } from "../../utils/nodeUtils";
 import { NodeDiagRows } from "../NodeDiagRows";
 
 const CombustorNode = ({ id, data, selected }: NodeProps) => {
@@ -79,21 +79,25 @@ const CombustorNode = ({ id, data, selected }: NodeProps) => {
 			<Handle
 				type="target"
 				position={rotPos(Position.Left, rotation)}
+				style={HANDLE_CSS[Position.Left]}
 				id="flow-target"
 			/>
 			<Handle
 				type="source"
 				position={rotPos(Position.Right, rotation)}
+				style={HANDLE_CSS[Position.Right]}
 				id="flow-source"
 			/>
 			<Handle
 				type="target"
 				position={rotPos(Position.Top, rotation)}
+				style={HANDLE_CSS[Position.Top]}
 				id="thermal-target"
 			/>
 			<Handle
 				type="source"
 				position={rotPos(Position.Bottom, rotation)}
+				style={HANDLE_CSS[Position.Bottom]}
 				id="thermal-source"
 			/>
 		</div>

--- a/gui/frontend/src/components/nodes/CombustorNode.tsx
+++ b/gui/frontend/src/components/nodes/CombustorNode.tsx
@@ -6,7 +6,7 @@ import {
 	Position,
 	useUpdateNodeInternals,
 } from "reactflow";
-import { HANDLE_CSS, rotPos } from "../../utils/nodeUtils";
+import { handleStyle, rotPos } from "../../utils/nodeUtils";
 import { NodeDiagRows } from "../NodeDiagRows";
 
 const CombustorNode = ({ id, data, selected }: NodeProps) => {
@@ -79,25 +79,25 @@ const CombustorNode = ({ id, data, selected }: NodeProps) => {
 			<Handle
 				type="target"
 				position={rotPos(Position.Left, rotation)}
-				style={HANDLE_CSS[Position.Left]}
+				style={handleStyle(Position.Left, rotation)}
 				id="flow-target"
 			/>
 			<Handle
 				type="source"
 				position={rotPos(Position.Right, rotation)}
-				style={HANDLE_CSS[Position.Right]}
+				style={handleStyle(Position.Right, rotation)}
 				id="flow-source"
 			/>
 			<Handle
 				type="target"
 				position={rotPos(Position.Top, rotation)}
-				style={HANDLE_CSS[Position.Top]}
+				style={handleStyle(Position.Top, rotation)}
 				id="thermal-target"
 			/>
 			<Handle
 				type="source"
 				position={rotPos(Position.Bottom, rotation)}
-				style={HANDLE_CSS[Position.Bottom]}
+				style={handleStyle(Position.Bottom, rotation)}
 				id="thermal-source"
 			/>
 		</div>

--- a/gui/frontend/src/components/nodes/CombustorNode.tsx
+++ b/gui/frontend/src/components/nodes/CombustorNode.tsx
@@ -6,6 +6,7 @@ import {
 	Position,
 	useUpdateNodeInternals,
 } from "reactflow";
+import { rotPos } from "../../utils/nodeUtils";
 import { NodeDiagRows } from "../NodeDiagRows";
 
 const CombustorNode = ({ id, data, selected }: NodeProps) => {
@@ -75,10 +76,26 @@ const CombustorNode = ({ id, data, selected }: NodeProps) => {
 			</div>
 
 			{/* Flow handles */}
-			<Handle type="target" position={Position.Left} id="flow-target" />
-			<Handle type="source" position={Position.Right} id="flow-source" />
-			<Handle type="target" position={Position.Top} id="thermal-target" />
-			<Handle type="source" position={Position.Bottom} id="thermal-source" />
+			<Handle
+				type="target"
+				position={rotPos(Position.Left, rotation)}
+				id="flow-target"
+			/>
+			<Handle
+				type="source"
+				position={rotPos(Position.Right, rotation)}
+				id="flow-source"
+			/>
+			<Handle
+				type="target"
+				position={rotPos(Position.Top, rotation)}
+				id="thermal-target"
+			/>
+			<Handle
+				type="source"
+				position={rotPos(Position.Bottom, rotation)}
+				id="thermal-source"
+			/>
 		</div>
 	);
 };

--- a/gui/frontend/src/components/nodes/DiscreteLossNode.tsx
+++ b/gui/frontend/src/components/nodes/DiscreteLossNode.tsx
@@ -6,7 +6,7 @@ import {
 	Position,
 	useUpdateNodeInternals,
 } from "reactflow";
-import { rotPos } from "../../utils/nodeUtils";
+import { HANDLE_CSS, rotPos } from "../../utils/nodeUtils";
 import { NodeDiagRows } from "../NodeDiagRows";
 
 const DiscreteLossNode = ({ id, data, selected }: NodeProps) => {
@@ -96,21 +96,25 @@ const DiscreteLossNode = ({ id, data, selected }: NodeProps) => {
 			<Handle
 				type="target"
 				position={rotPos(Position.Left, rotation)}
+				style={HANDLE_CSS[Position.Left]}
 				id="flow-target"
 			/>
 			<Handle
 				type="source"
 				position={rotPos(Position.Right, rotation)}
+				style={HANDLE_CSS[Position.Right]}
 				id="flow-source"
 			/>
 			<Handle
 				type="target"
 				position={rotPos(Position.Top, rotation)}
+				style={HANDLE_CSS[Position.Top]}
 				id="thermal-target"
 			/>
 			<Handle
 				type="source"
 				position={rotPos(Position.Bottom, rotation)}
+				style={HANDLE_CSS[Position.Bottom]}
 				id="thermal-source"
 			/>
 		</div>

--- a/gui/frontend/src/components/nodes/DiscreteLossNode.tsx
+++ b/gui/frontend/src/components/nodes/DiscreteLossNode.tsx
@@ -6,6 +6,7 @@ import {
 	Position,
 	useUpdateNodeInternals,
 } from "reactflow";
+import { rotPos } from "../../utils/nodeUtils";
 import { NodeDiagRows } from "../NodeDiagRows";
 
 const DiscreteLossNode = ({ id, data, selected }: NodeProps) => {
@@ -92,10 +93,26 @@ const DiscreteLossNode = ({ id, data, selected }: NodeProps) => {
 				q
 			</div>
 
-			<Handle type="target" position={Position.Left} id="flow-target" />
-			<Handle type="source" position={Position.Right} id="flow-source" />
-			<Handle type="target" position={Position.Top} id="thermal-target" />
-			<Handle type="source" position={Position.Bottom} id="thermal-source" />
+			<Handle
+				type="target"
+				position={rotPos(Position.Left, rotation)}
+				id="flow-target"
+			/>
+			<Handle
+				type="source"
+				position={rotPos(Position.Right, rotation)}
+				id="flow-source"
+			/>
+			<Handle
+				type="target"
+				position={rotPos(Position.Top, rotation)}
+				id="thermal-target"
+			/>
+			<Handle
+				type="source"
+				position={rotPos(Position.Bottom, rotation)}
+				id="thermal-source"
+			/>
 		</div>
 	);
 };

--- a/gui/frontend/src/components/nodes/DiscreteLossNode.tsx
+++ b/gui/frontend/src/components/nodes/DiscreteLossNode.tsx
@@ -6,7 +6,7 @@ import {
 	Position,
 	useUpdateNodeInternals,
 } from "reactflow";
-import { HANDLE_CSS, rotPos } from "../../utils/nodeUtils";
+import { handleStyle, rotPos } from "../../utils/nodeUtils";
 import { NodeDiagRows } from "../NodeDiagRows";
 
 const DiscreteLossNode = ({ id, data, selected }: NodeProps) => {
@@ -96,25 +96,25 @@ const DiscreteLossNode = ({ id, data, selected }: NodeProps) => {
 			<Handle
 				type="target"
 				position={rotPos(Position.Left, rotation)}
-				style={HANDLE_CSS[Position.Left]}
+				style={handleStyle(Position.Left, rotation)}
 				id="flow-target"
 			/>
 			<Handle
 				type="source"
 				position={rotPos(Position.Right, rotation)}
-				style={HANDLE_CSS[Position.Right]}
+				style={handleStyle(Position.Right, rotation)}
 				id="flow-source"
 			/>
 			<Handle
 				type="target"
 				position={rotPos(Position.Top, rotation)}
-				style={HANDLE_CSS[Position.Top]}
+				style={handleStyle(Position.Top, rotation)}
 				id="thermal-target"
 			/>
 			<Handle
 				type="source"
 				position={rotPos(Position.Bottom, rotation)}
-				style={HANDLE_CSS[Position.Bottom]}
+				style={handleStyle(Position.Bottom, rotation)}
 				id="thermal-source"
 			/>
 		</div>

--- a/gui/frontend/src/components/nodes/MassBoundaryNode.tsx
+++ b/gui/frontend/src/components/nodes/MassBoundaryNode.tsx
@@ -6,7 +6,7 @@ import {
 	Position,
 	useUpdateNodeInternals,
 } from "reactflow";
-import { HANDLE_CSS, rotPos } from "../../utils/nodeUtils";
+import { handleStyle, rotPos } from "../../utils/nodeUtils";
 
 const MassBoundaryNode = ({ id, data, selected }: NodeProps) => {
 	const rotation = data.rotation || 0;
@@ -47,13 +47,13 @@ const MassBoundaryNode = ({ id, data, selected }: NodeProps) => {
 			<Handle
 				type="source"
 				position={rotPos(Position.Right, rotation)}
-				style={HANDLE_CSS[Position.Right]}
+				style={handleStyle(Position.Right, rotation)}
 				id="flow-source"
 			/>
 			<Handle
 				type="target"
 				position={rotPos(Position.Left, rotation)}
-				style={HANDLE_CSS[Position.Left]}
+				style={handleStyle(Position.Left, rotation)}
 				id="flow-target"
 			/>
 		</div>

--- a/gui/frontend/src/components/nodes/MassBoundaryNode.tsx
+++ b/gui/frontend/src/components/nodes/MassBoundaryNode.tsx
@@ -6,7 +6,7 @@ import {
 	Position,
 	useUpdateNodeInternals,
 } from "reactflow";
-import { rotPos } from "../../utils/nodeUtils";
+import { HANDLE_CSS, rotPos } from "../../utils/nodeUtils";
 
 const MassBoundaryNode = ({ id, data, selected }: NodeProps) => {
 	const rotation = data.rotation || 0;
@@ -47,11 +47,13 @@ const MassBoundaryNode = ({ id, data, selected }: NodeProps) => {
 			<Handle
 				type="source"
 				position={rotPos(Position.Right, rotation)}
+				style={HANDLE_CSS[Position.Right]}
 				id="flow-source"
 			/>
 			<Handle
 				type="target"
 				position={rotPos(Position.Left, rotation)}
+				style={HANDLE_CSS[Position.Left]}
 				id="flow-target"
 			/>
 		</div>

--- a/gui/frontend/src/components/nodes/MassBoundaryNode.tsx
+++ b/gui/frontend/src/components/nodes/MassBoundaryNode.tsx
@@ -6,6 +6,7 @@ import {
 	Position,
 	useUpdateNodeInternals,
 } from "reactflow";
+import { rotPos } from "../../utils/nodeUtils";
 
 const MassBoundaryNode = ({ id, data, selected }: NodeProps) => {
 	const rotation = data.rotation || 0;
@@ -43,8 +44,16 @@ const MassBoundaryNode = ({ id, data, selected }: NodeProps) => {
 				</div>
 			</div>
 
-			<Handle type="source" position={Position.Right} id="flow-source" />
-			<Handle type="target" position={Position.Left} id="flow-target" />
+			<Handle
+				type="source"
+				position={rotPos(Position.Right, rotation)}
+				id="flow-source"
+			/>
+			<Handle
+				type="target"
+				position={rotPos(Position.Left, rotation)}
+				id="flow-target"
+			/>
 		</div>
 	);
 };

--- a/gui/frontend/src/components/nodes/MomentumChamberNode.tsx
+++ b/gui/frontend/src/components/nodes/MomentumChamberNode.tsx
@@ -6,7 +6,7 @@ import {
 	Position,
 	useUpdateNodeInternals,
 } from "reactflow";
-import { HANDLE_CSS, rotPos } from "../../utils/nodeUtils";
+import { handleStyle, rotPos } from "../../utils/nodeUtils";
 import { NodeDiagRows } from "../NodeDiagRows";
 
 const MomentumChamberNode = ({ id, data, selected }: NodeProps) => {
@@ -79,25 +79,25 @@ const MomentumChamberNode = ({ id, data, selected }: NodeProps) => {
 			<Handle
 				type="target"
 				position={rotPos(Position.Left, rotation)}
-				style={HANDLE_CSS[Position.Left]}
+				style={handleStyle(Position.Left, rotation)}
 				id="flow-target"
 			/>
 			<Handle
 				type="source"
 				position={rotPos(Position.Right, rotation)}
-				style={HANDLE_CSS[Position.Right]}
+				style={handleStyle(Position.Right, rotation)}
 				id="flow-source"
 			/>
 			<Handle
 				type="target"
 				position={rotPos(Position.Top, rotation)}
-				style={HANDLE_CSS[Position.Top]}
+				style={handleStyle(Position.Top, rotation)}
 				id="thermal-target"
 			/>
 			<Handle
 				type="source"
 				position={rotPos(Position.Bottom, rotation)}
-				style={HANDLE_CSS[Position.Bottom]}
+				style={handleStyle(Position.Bottom, rotation)}
 				id="thermal-source"
 			/>
 		</div>

--- a/gui/frontend/src/components/nodes/MomentumChamberNode.tsx
+++ b/gui/frontend/src/components/nodes/MomentumChamberNode.tsx
@@ -6,6 +6,7 @@ import {
 	Position,
 	useUpdateNodeInternals,
 } from "reactflow";
+import { rotPos } from "../../utils/nodeUtils";
 import { NodeDiagRows } from "../NodeDiagRows";
 
 const MomentumChamberNode = ({ id, data, selected }: NodeProps) => {
@@ -75,10 +76,26 @@ const MomentumChamberNode = ({ id, data, selected }: NodeProps) => {
 			</div>
 
 			{/* Flow handles */}
-			<Handle type="target" position={Position.Left} id="flow-target" />
-			<Handle type="source" position={Position.Right} id="flow-source" />
-			<Handle type="target" position={Position.Top} id="thermal-target" />
-			<Handle type="source" position={Position.Bottom} id="thermal-source" />
+			<Handle
+				type="target"
+				position={rotPos(Position.Left, rotation)}
+				id="flow-target"
+			/>
+			<Handle
+				type="source"
+				position={rotPos(Position.Right, rotation)}
+				id="flow-source"
+			/>
+			<Handle
+				type="target"
+				position={rotPos(Position.Top, rotation)}
+				id="thermal-target"
+			/>
+			<Handle
+				type="source"
+				position={rotPos(Position.Bottom, rotation)}
+				id="thermal-source"
+			/>
 		</div>
 	);
 };

--- a/gui/frontend/src/components/nodes/MomentumChamberNode.tsx
+++ b/gui/frontend/src/components/nodes/MomentumChamberNode.tsx
@@ -6,7 +6,7 @@ import {
 	Position,
 	useUpdateNodeInternals,
 } from "reactflow";
-import { rotPos } from "../../utils/nodeUtils";
+import { HANDLE_CSS, rotPos } from "../../utils/nodeUtils";
 import { NodeDiagRows } from "../NodeDiagRows";
 
 const MomentumChamberNode = ({ id, data, selected }: NodeProps) => {
@@ -79,21 +79,25 @@ const MomentumChamberNode = ({ id, data, selected }: NodeProps) => {
 			<Handle
 				type="target"
 				position={rotPos(Position.Left, rotation)}
+				style={HANDLE_CSS[Position.Left]}
 				id="flow-target"
 			/>
 			<Handle
 				type="source"
 				position={rotPos(Position.Right, rotation)}
+				style={HANDLE_CSS[Position.Right]}
 				id="flow-source"
 			/>
 			<Handle
 				type="target"
 				position={rotPos(Position.Top, rotation)}
+				style={HANDLE_CSS[Position.Top]}
 				id="thermal-target"
 			/>
 			<Handle
 				type="source"
 				position={rotPos(Position.Bottom, rotation)}
+				style={HANDLE_CSS[Position.Bottom]}
 				id="thermal-source"
 			/>
 		</div>

--- a/gui/frontend/src/components/nodes/OrificeNode.tsx
+++ b/gui/frontend/src/components/nodes/OrificeNode.tsx
@@ -6,7 +6,7 @@ import {
 	Position,
 	useUpdateNodeInternals,
 } from "reactflow";
-import { HANDLE_CSS, rotPos } from "../../utils/nodeUtils";
+import { handleStyle, rotPos } from "../../utils/nodeUtils";
 import { NodeDiagRows } from "../NodeDiagRows";
 
 const OrificeNode = ({ id, data, selected }: NodeProps) => {
@@ -81,25 +81,25 @@ const OrificeNode = ({ id, data, selected }: NodeProps) => {
 			<Handle
 				type="target"
 				position={rotPos(Position.Left, rotation)}
-				style={HANDLE_CSS[Position.Left]}
+				style={handleStyle(Position.Left, rotation)}
 				id="flow-target"
 			/>
 			<Handle
 				type="source"
 				position={rotPos(Position.Right, rotation)}
-				style={HANDLE_CSS[Position.Right]}
+				style={handleStyle(Position.Right, rotation)}
 				id="flow-source"
 			/>
 			<Handle
 				type="target"
 				position={rotPos(Position.Top, rotation)}
-				style={HANDLE_CSS[Position.Top]}
+				style={handleStyle(Position.Top, rotation)}
 				id="thermal-target"
 			/>
 			<Handle
 				type="source"
 				position={rotPos(Position.Bottom, rotation)}
-				style={HANDLE_CSS[Position.Bottom]}
+				style={handleStyle(Position.Bottom, rotation)}
 				id="thermal-source"
 			/>
 		</div>

--- a/gui/frontend/src/components/nodes/OrificeNode.tsx
+++ b/gui/frontend/src/components/nodes/OrificeNode.tsx
@@ -6,6 +6,7 @@ import {
 	Position,
 	useUpdateNodeInternals,
 } from "reactflow";
+import { rotPos } from "../../utils/nodeUtils";
 import { NodeDiagRows } from "../NodeDiagRows";
 
 const OrificeNode = ({ id, data, selected }: NodeProps) => {
@@ -77,10 +78,26 @@ const OrificeNode = ({ id, data, selected }: NodeProps) => {
 				q
 			</div>
 
-			<Handle type="target" position={Position.Left} id="flow-target" />
-			<Handle type="source" position={Position.Right} id="flow-source" />
-			<Handle type="target" position={Position.Top} id="thermal-target" />
-			<Handle type="source" position={Position.Bottom} id="thermal-source" />
+			<Handle
+				type="target"
+				position={rotPos(Position.Left, rotation)}
+				id="flow-target"
+			/>
+			<Handle
+				type="source"
+				position={rotPos(Position.Right, rotation)}
+				id="flow-source"
+			/>
+			<Handle
+				type="target"
+				position={rotPos(Position.Top, rotation)}
+				id="thermal-target"
+			/>
+			<Handle
+				type="source"
+				position={rotPos(Position.Bottom, rotation)}
+				id="thermal-source"
+			/>
 		</div>
 	);
 };

--- a/gui/frontend/src/components/nodes/OrificeNode.tsx
+++ b/gui/frontend/src/components/nodes/OrificeNode.tsx
@@ -6,7 +6,7 @@ import {
 	Position,
 	useUpdateNodeInternals,
 } from "reactflow";
-import { rotPos } from "../../utils/nodeUtils";
+import { HANDLE_CSS, rotPos } from "../../utils/nodeUtils";
 import { NodeDiagRows } from "../NodeDiagRows";
 
 const OrificeNode = ({ id, data, selected }: NodeProps) => {
@@ -81,21 +81,25 @@ const OrificeNode = ({ id, data, selected }: NodeProps) => {
 			<Handle
 				type="target"
 				position={rotPos(Position.Left, rotation)}
+				style={HANDLE_CSS[Position.Left]}
 				id="flow-target"
 			/>
 			<Handle
 				type="source"
 				position={rotPos(Position.Right, rotation)}
+				style={HANDLE_CSS[Position.Right]}
 				id="flow-source"
 			/>
 			<Handle
 				type="target"
 				position={rotPos(Position.Top, rotation)}
+				style={HANDLE_CSS[Position.Top]}
 				id="thermal-target"
 			/>
 			<Handle
 				type="source"
 				position={rotPos(Position.Bottom, rotation)}
+				style={HANDLE_CSS[Position.Bottom]}
 				id="thermal-source"
 			/>
 		</div>

--- a/gui/frontend/src/components/nodes/PlenumNode.tsx
+++ b/gui/frontend/src/components/nodes/PlenumNode.tsx
@@ -6,6 +6,7 @@ import {
 	Position,
 	useUpdateNodeInternals,
 } from "reactflow";
+import { rotPos } from "../../utils/nodeUtils";
 import { NodeDiagRows } from "../NodeDiagRows";
 
 const PlenumNode = ({ id, data, selected }: NodeProps) => {
@@ -76,10 +77,26 @@ const PlenumNode = ({ id, data, selected }: NodeProps) => {
 			</div>
 
 			{/* Flow Handles: L/T = target (inlet), R/B = source (outlet) */}
-			<Handle type="target" position={Position.Left} id="flow-left" />
-			<Handle type="source" position={Position.Right} id="flow-right" />
-			<Handle type="target" position={Position.Top} id="flow-top" />
-			<Handle type="source" position={Position.Bottom} id="flow-bottom" />
+			<Handle
+				type="target"
+				position={rotPos(Position.Left, rotation)}
+				id="flow-left"
+			/>
+			<Handle
+				type="source"
+				position={rotPos(Position.Right, rotation)}
+				id="flow-right"
+			/>
+			<Handle
+				type="target"
+				position={rotPos(Position.Top, rotation)}
+				id="flow-top"
+			/>
+			<Handle
+				type="source"
+				position={rotPos(Position.Bottom, rotation)}
+				id="flow-bottom"
+			/>
 		</div>
 	);
 };

--- a/gui/frontend/src/components/nodes/PlenumNode.tsx
+++ b/gui/frontend/src/components/nodes/PlenumNode.tsx
@@ -6,7 +6,7 @@ import {
 	Position,
 	useUpdateNodeInternals,
 } from "reactflow";
-import { rotPos } from "../../utils/nodeUtils";
+import { HANDLE_CSS, rotPos } from "../../utils/nodeUtils";
 import { NodeDiagRows } from "../NodeDiagRows";
 
 const PlenumNode = ({ id, data, selected }: NodeProps) => {
@@ -80,21 +80,25 @@ const PlenumNode = ({ id, data, selected }: NodeProps) => {
 			<Handle
 				type="target"
 				position={rotPos(Position.Left, rotation)}
+				style={HANDLE_CSS[Position.Left]}
 				id="flow-left"
 			/>
 			<Handle
 				type="source"
 				position={rotPos(Position.Right, rotation)}
+				style={HANDLE_CSS[Position.Right]}
 				id="flow-right"
 			/>
 			<Handle
 				type="target"
 				position={rotPos(Position.Top, rotation)}
+				style={HANDLE_CSS[Position.Top]}
 				id="flow-top"
 			/>
 			<Handle
 				type="source"
 				position={rotPos(Position.Bottom, rotation)}
+				style={HANDLE_CSS[Position.Bottom]}
 				id="flow-bottom"
 			/>
 		</div>

--- a/gui/frontend/src/components/nodes/PlenumNode.tsx
+++ b/gui/frontend/src/components/nodes/PlenumNode.tsx
@@ -6,7 +6,7 @@ import {
 	Position,
 	useUpdateNodeInternals,
 } from "reactflow";
-import { HANDLE_CSS, rotPos } from "../../utils/nodeUtils";
+import { handleStyle, rotPos } from "../../utils/nodeUtils";
 import { NodeDiagRows } from "../NodeDiagRows";
 
 const PlenumNode = ({ id, data, selected }: NodeProps) => {
@@ -80,25 +80,25 @@ const PlenumNode = ({ id, data, selected }: NodeProps) => {
 			<Handle
 				type="target"
 				position={rotPos(Position.Left, rotation)}
-				style={HANDLE_CSS[Position.Left]}
+				style={handleStyle(Position.Left, rotation)}
 				id="flow-left"
 			/>
 			<Handle
 				type="source"
 				position={rotPos(Position.Right, rotation)}
-				style={HANDLE_CSS[Position.Right]}
+				style={handleStyle(Position.Right, rotation)}
 				id="flow-right"
 			/>
 			<Handle
 				type="target"
 				position={rotPos(Position.Top, rotation)}
-				style={HANDLE_CSS[Position.Top]}
+				style={handleStyle(Position.Top, rotation)}
 				id="flow-top"
 			/>
 			<Handle
 				type="source"
 				position={rotPos(Position.Bottom, rotation)}
-				style={HANDLE_CSS[Position.Bottom]}
+				style={handleStyle(Position.Bottom, rotation)}
 				id="flow-bottom"
 			/>
 		</div>

--- a/gui/frontend/src/components/nodes/PressureBoundaryNode.tsx
+++ b/gui/frontend/src/components/nodes/PressureBoundaryNode.tsx
@@ -6,6 +6,7 @@ import {
 	Position,
 	useUpdateNodeInternals,
 } from "reactflow";
+import { rotPos } from "../../utils/nodeUtils";
 
 const PressureBoundaryNode = ({ id, data, selected }: NodeProps) => {
 	const rotation = data.rotation || 0;
@@ -45,8 +46,16 @@ const PressureBoundaryNode = ({ id, data, selected }: NodeProps) => {
 				</div>
 			</div>
 
-			<Handle type="source" position={Position.Right} id="flow-source" />
-			<Handle type="target" position={Position.Left} id="flow-target" />
+			<Handle
+				type="source"
+				position={rotPos(Position.Right, rotation)}
+				id="flow-source"
+			/>
+			<Handle
+				type="target"
+				position={rotPos(Position.Left, rotation)}
+				id="flow-target"
+			/>
 		</div>
 	);
 };

--- a/gui/frontend/src/components/nodes/PressureBoundaryNode.tsx
+++ b/gui/frontend/src/components/nodes/PressureBoundaryNode.tsx
@@ -6,7 +6,7 @@ import {
 	Position,
 	useUpdateNodeInternals,
 } from "reactflow";
-import { rotPos } from "../../utils/nodeUtils";
+import { HANDLE_CSS, rotPos } from "../../utils/nodeUtils";
 
 const PressureBoundaryNode = ({ id, data, selected }: NodeProps) => {
 	const rotation = data.rotation || 0;
@@ -49,11 +49,13 @@ const PressureBoundaryNode = ({ id, data, selected }: NodeProps) => {
 			<Handle
 				type="source"
 				position={rotPos(Position.Right, rotation)}
+				style={HANDLE_CSS[Position.Right]}
 				id="flow-source"
 			/>
 			<Handle
 				type="target"
 				position={rotPos(Position.Left, rotation)}
+				style={HANDLE_CSS[Position.Left]}
 				id="flow-target"
 			/>
 		</div>

--- a/gui/frontend/src/components/nodes/PressureBoundaryNode.tsx
+++ b/gui/frontend/src/components/nodes/PressureBoundaryNode.tsx
@@ -6,7 +6,7 @@ import {
 	Position,
 	useUpdateNodeInternals,
 } from "reactflow";
-import { HANDLE_CSS, rotPos } from "../../utils/nodeUtils";
+import { handleStyle, rotPos } from "../../utils/nodeUtils";
 
 const PressureBoundaryNode = ({ id, data, selected }: NodeProps) => {
 	const rotation = data.rotation || 0;
@@ -49,13 +49,13 @@ const PressureBoundaryNode = ({ id, data, selected }: NodeProps) => {
 			<Handle
 				type="source"
 				position={rotPos(Position.Right, rotation)}
-				style={HANDLE_CSS[Position.Right]}
+				style={handleStyle(Position.Right, rotation)}
 				id="flow-source"
 			/>
 			<Handle
 				type="target"
 				position={rotPos(Position.Left, rotation)}
-				style={HANDLE_CSS[Position.Left]}
+				style={handleStyle(Position.Left, rotation)}
 				id="flow-target"
 			/>
 		</div>

--- a/gui/frontend/src/components/nodes/TeeJunctionNode.tsx
+++ b/gui/frontend/src/components/nodes/TeeJunctionNode.tsx
@@ -6,6 +6,7 @@ import {
 	Position,
 	useUpdateNodeInternals,
 } from "reactflow";
+import { rotPos } from "../../utils/nodeUtils";
 import { NodeDiagRows } from "../NodeDiagRows";
 
 // Port colours: blue = input arm, green = output arm (matches handle triangle colours).
@@ -23,8 +24,15 @@ const TeeJunctionNode = ({ id, data, selected }: NodeProps) => {
 	// Merging:  S(left, in) + B(bottom, in)  → C(right, out)
 	// Branching: C(left, in) → S(right, out) + B(bottom, out)
 	// Swap the left/right positions of S and C when the type changes.
-	const straightPos = isMerging ? Position.Left : Position.Right;
-	const commonPos = isMerging ? Position.Right : Position.Left;
+	const straightPos = rotPos(
+		isMerging ? Position.Left : Position.Right,
+		rotation,
+	);
+	const commonPos = rotPos(
+		isMerging ? Position.Right : Position.Left,
+		rotation,
+	);
+	const branchPos = rotPos(Position.Bottom, rotation);
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: rotation and tee_type both trigger handle re-measurement
 	useEffect(() => {
@@ -118,17 +126,9 @@ const TeeJunctionNode = ({ id, data, selected }: NodeProps) => {
 			<Handle type="target" position={commonPos} id="port-common-target" />
 			<Handle type="source" position={commonPos} id="port-common-source" />
 
-			{/* Branch arm — always bottom */}
-			<Handle
-				type="target"
-				position={Position.Bottom}
-				id="port-branch-target"
-			/>
-			<Handle
-				type="source"
-				position={Position.Bottom}
-				id="port-branch-source"
-			/>
+			{/* Branch arm — bottom at 0°, rotates with node */}
+			<Handle type="target" position={branchPos} id="port-branch-target" />
+			<Handle type="source" position={branchPos} id="port-branch-source" />
 		</div>
 	);
 };

--- a/gui/frontend/src/components/nodes/TeeJunctionNode.tsx
+++ b/gui/frontend/src/components/nodes/TeeJunctionNode.tsx
@@ -6,7 +6,7 @@ import {
 	Position,
 	useUpdateNodeInternals,
 } from "reactflow";
-import { rotPos } from "../../utils/nodeUtils";
+import { HANDLE_CSS, rotPos } from "../../utils/nodeUtils";
 import { NodeDiagRows } from "../NodeDiagRows";
 
 // Port colours: blue = input arm, green = output arm (matches handle triangle colours).
@@ -24,15 +24,12 @@ const TeeJunctionNode = ({ id, data, selected }: NodeProps) => {
 	// Merging:  S(left, in) + B(bottom, in)  → C(right, out)
 	// Branching: C(left, in) → S(right, out) + B(bottom, out)
 	// Swap the left/right positions of S and C when the type changes.
-	const straightPos = rotPos(
-		isMerging ? Position.Left : Position.Right,
-		rotation,
-	);
-	const commonPos = rotPos(
-		isMerging ? Position.Right : Position.Left,
-		rotation,
-	);
-	const branchPos = rotPos(Position.Bottom, rotation);
+	const straightBase = isMerging ? Position.Left : Position.Right;
+	const commonBase = isMerging ? Position.Right : Position.Left;
+	const branchBase = Position.Bottom;
+	const straightPos = rotPos(straightBase, rotation);
+	const commonPos = rotPos(commonBase, rotation);
+	const branchPos = rotPos(branchBase, rotation);
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: rotation and tee_type both trigger handle re-measurement
 	useEffect(() => {
@@ -119,16 +116,46 @@ const TeeJunctionNode = ({ id, data, selected }: NodeProps) => {
 			</div>
 
 			{/* Straight arm — left for merging, right for branching */}
-			<Handle type="target" position={straightPos} id="port-straight-target" />
-			<Handle type="source" position={straightPos} id="port-straight-source" />
+			<Handle
+				type="target"
+				position={straightPos}
+				style={HANDLE_CSS[straightBase]}
+				id="port-straight-target"
+			/>
+			<Handle
+				type="source"
+				position={straightPos}
+				style={HANDLE_CSS[straightBase]}
+				id="port-straight-source"
+			/>
 
 			{/* Common arm — right for merging, left for branching */}
-			<Handle type="target" position={commonPos} id="port-common-target" />
-			<Handle type="source" position={commonPos} id="port-common-source" />
+			<Handle
+				type="target"
+				position={commonPos}
+				style={HANDLE_CSS[commonBase]}
+				id="port-common-target"
+			/>
+			<Handle
+				type="source"
+				position={commonPos}
+				style={HANDLE_CSS[commonBase]}
+				id="port-common-source"
+			/>
 
 			{/* Branch arm — bottom at 0°, rotates with node */}
-			<Handle type="target" position={branchPos} id="port-branch-target" />
-			<Handle type="source" position={branchPos} id="port-branch-source" />
+			<Handle
+				type="target"
+				position={branchPos}
+				style={HANDLE_CSS[branchBase]}
+				id="port-branch-target"
+			/>
+			<Handle
+				type="source"
+				position={branchPos}
+				style={HANDLE_CSS[branchBase]}
+				id="port-branch-source"
+			/>
 		</div>
 	);
 };

--- a/gui/frontend/src/components/nodes/TeeJunctionNode.tsx
+++ b/gui/frontend/src/components/nodes/TeeJunctionNode.tsx
@@ -6,7 +6,7 @@ import {
 	Position,
 	useUpdateNodeInternals,
 } from "reactflow";
-import { HANDLE_CSS, rotPos } from "../../utils/nodeUtils";
+import { handleStyle, rotPos } from "../../utils/nodeUtils";
 import { NodeDiagRows } from "../NodeDiagRows";
 
 // Port colours: blue = input arm, green = output arm (matches handle triangle colours).
@@ -119,13 +119,13 @@ const TeeJunctionNode = ({ id, data, selected }: NodeProps) => {
 			<Handle
 				type="target"
 				position={straightPos}
-				style={HANDLE_CSS[straightBase]}
+				style={handleStyle(straightBase, rotation)}
 				id="port-straight-target"
 			/>
 			<Handle
 				type="source"
 				position={straightPos}
-				style={HANDLE_CSS[straightBase]}
+				style={handleStyle(straightBase, rotation)}
 				id="port-straight-source"
 			/>
 
@@ -133,13 +133,13 @@ const TeeJunctionNode = ({ id, data, selected }: NodeProps) => {
 			<Handle
 				type="target"
 				position={commonPos}
-				style={HANDLE_CSS[commonBase]}
+				style={handleStyle(commonBase, rotation)}
 				id="port-common-target"
 			/>
 			<Handle
 				type="source"
 				position={commonPos}
-				style={HANDLE_CSS[commonBase]}
+				style={handleStyle(commonBase, rotation)}
 				id="port-common-source"
 			/>
 
@@ -147,13 +147,13 @@ const TeeJunctionNode = ({ id, data, selected }: NodeProps) => {
 			<Handle
 				type="target"
 				position={branchPos}
-				style={HANDLE_CSS[branchBase]}
+				style={handleStyle(branchBase, rotation)}
 				id="port-branch-target"
 			/>
 			<Handle
 				type="source"
 				position={branchPos}
-				style={HANDLE_CSS[branchBase]}
+				style={handleStyle(branchBase, rotation)}
 				id="port-branch-source"
 			/>
 		</div>

--- a/gui/frontend/src/components/nodes/WallNode.tsx
+++ b/gui/frontend/src/components/nodes/WallNode.tsx
@@ -6,6 +6,7 @@ import {
 	Position,
 	useUpdateNodeInternals,
 } from "reactflow";
+import { rotPos } from "../../utils/nodeUtils";
 
 const WallNode = ({ id, data, selected }: NodeProps) => {
 	const rotation = data.rotation || 0;
@@ -45,7 +46,11 @@ const WallNode = ({ id, data, selected }: NodeProps) => {
 				</div>
 			</div>
 
-			<Handle type="target" position={Position.Left} id="flow-target" />
+			<Handle
+				type="target"
+				position={rotPos(Position.Left, rotation)}
+				id="flow-target"
+			/>
 		</div>
 	);
 };

--- a/gui/frontend/src/components/nodes/WallNode.tsx
+++ b/gui/frontend/src/components/nodes/WallNode.tsx
@@ -6,7 +6,7 @@ import {
 	Position,
 	useUpdateNodeInternals,
 } from "reactflow";
-import { HANDLE_CSS, rotPos } from "../../utils/nodeUtils";
+import { handleStyle, rotPos } from "../../utils/nodeUtils";
 
 const WallNode = ({ id, data, selected }: NodeProps) => {
 	const rotation = data.rotation || 0;
@@ -49,7 +49,7 @@ const WallNode = ({ id, data, selected }: NodeProps) => {
 			<Handle
 				type="target"
 				position={rotPos(Position.Left, rotation)}
-				style={HANDLE_CSS[Position.Left]}
+				style={handleStyle(Position.Left, rotation)}
 				id="flow-target"
 			/>
 		</div>

--- a/gui/frontend/src/components/nodes/WallNode.tsx
+++ b/gui/frontend/src/components/nodes/WallNode.tsx
@@ -6,7 +6,7 @@ import {
 	Position,
 	useUpdateNodeInternals,
 } from "reactflow";
-import { rotPos } from "../../utils/nodeUtils";
+import { HANDLE_CSS, rotPos } from "../../utils/nodeUtils";
 
 const WallNode = ({ id, data, selected }: NodeProps) => {
 	const rotation = data.rotation || 0;
@@ -49,6 +49,7 @@ const WallNode = ({ id, data, selected }: NodeProps) => {
 			<Handle
 				type="target"
 				position={rotPos(Position.Left, rotation)}
+				style={HANDLE_CSS[Position.Left]}
 				id="flow-target"
 			/>
 		</div>

--- a/gui/frontend/src/utils/nodeUtils.ts
+++ b/gui/frontend/src/utils/nodeUtils.ts
@@ -20,60 +20,58 @@ export const rotPos = (pos: Position, rotation: number): Position => {
 	return CYCLE[(idx + steps + 4) % 4];
 };
 
-// Base positioning for each handle edge. Used by handleStyle below.
-// The left/top/right/bottom values pin the handle to the correct physical
-// edge within the node div's local (pre-rotation) coordinate system.
+// Half the flow-handle size (12 px) so we can center without translate.
+// Using calc() in top/left instead of transform:translate avoids the
+// "translate in rotated axes" pitfall: if the transform only contains
+// rotate(), rotating around 50%/50% is a pure in-place spin and
+// getBoundingClientRect() returns the correct screen center both before
+// and after rotation.
+const H = "6px";
+
 const HANDLE_BASE: Record<Position, React.CSSProperties> = {
 	[Position.Left]: {
 		left: "-4px",
 		right: "auto",
-		top: "50%",
+		top: `calc(50% - ${H})`,
 		bottom: "auto",
 	},
 	[Position.Right]: {
 		left: "auto",
 		right: "-4px",
-		top: "50%",
+		top: `calc(50% - ${H})`,
 		bottom: "auto",
 	},
 	[Position.Top]: {
-		left: "50%",
+		left: `calc(50% - ${H})`,
 		right: "auto",
 		top: "-4px",
 		bottom: "auto",
 	},
 	[Position.Bottom]: {
-		left: "50%",
+		left: `calc(50% - ${H})`,
 		right: "auto",
 		top: "auto",
 		bottom: "-4px",
 	},
 };
 
-// Centering offset for left/right vs top/bottom handles.
-const HANDLE_CENTER: Record<Position, string> = {
-	[Position.Left]: "translate(0, -50%)",
-	[Position.Right]: "translate(0, -50%)",
-	[Position.Top]: "translate(-50%, 0)",
-	[Position.Bottom]: "translate(-50%, 0)",
-};
-
 /**
- * Returns the inline style for a Handle based on its pre-rotation base
- * position and the node's current rotation.
+ * Inline style for a Handle.
  *
- * Two effects:
- *  1. Overrides ReactFlow's position CSS classes (which would otherwise
- *     place the handle in the rotated coordinate system, landing it on the
- *     wrong visual edge).
- *  2. Counter-rotates the handle div by −rotation so that the ::after
- *     triangle drawn by index.css stays perpendicular to the edge it sits on,
- *     rather than inheriting the node's CSS rotation.
+ * 1. Pins it to the correct physical edge (overriding ReactFlow's position
+ *    CSS classes, which apply in the rotated coordinate system and would
+ *    land the handle on the wrong visual edge).
+ * 2. Counter-rotates the handle div by −rotation.  Because the node div has
+ *    transform:rotate(+rotation), the net rotation of the handle and its
+ *    ::after triangle is 0° relative to the screen — keeping the triangle
+ *    perpendicular to the edge it sits on.
+ *    The rotation is a pure spin (no translate), so getBoundingClientRect()
+ *    returns the correct screen center at every rotation step.
  */
 export const handleStyle = (
 	basePos: Position,
 	rotation: number,
 ): React.CSSProperties => ({
 	...HANDLE_BASE[basePos],
-	transform: `${HANDLE_CENTER[basePos]} rotate(${-rotation}deg)`,
+	transform: `rotate(${-rotation}deg)`,
 });

--- a/gui/frontend/src/utils/nodeUtils.ts
+++ b/gui/frontend/src/utils/nodeUtils.ts
@@ -1,11 +1,20 @@
+import { Position } from "reactflow";
+
+// Clockwise rotation cycle matching CSS transform: rotate(Ndeg).
+// Left→Top→Right→Bottom→Left for each 90° clockwise step.
+const CYCLE = [Position.Left, Position.Top, Position.Right, Position.Bottom];
+
 /**
- * Node rotation utility.
+ * Maps a handle's logical Position through a CSS clockwise rotation so the
+ * edge tangent direction matches the handle's visual location on the node.
  *
- * With the current approach, the entire node div is CSS-rotated via
- * `transform: rotate(Ndeg)`. Handles use FIXED Position values
- * (Left, Right, Top, Bottom) and React Flow re-measures their
- * screen coordinates via useUpdateNodeInternals(). No handle position
- * mapping is needed.
- *
- * This file is kept for future utilities.
+ * Without this, ReactFlow re-measures the handle's screen coordinates via
+ * updateNodeInternals (so the connection point is correct) but still uses
+ * the original position prop for the spline tangent, causing edges to leave
+ * at the wrong angle on rotated nodes.
  */
+export const rotPos = (pos: Position, rotation: number): Position => {
+	const steps = Math.round(rotation / 90) % 4;
+	const idx = CYCLE.indexOf(pos);
+	return CYCLE[(idx + steps + 4) % 4];
+};

--- a/gui/frontend/src/utils/nodeUtils.ts
+++ b/gui/frontend/src/utils/nodeUtils.ts
@@ -20,39 +20,60 @@ export const rotPos = (pos: Position, rotation: number): Position => {
 	return CYCLE[(idx + steps + 4) % 4];
 };
 
-// Inline styles that pin each Handle to its correct physical edge within the
-// rotated node div. ReactFlow positions handles via CSS classes
-// (.react-flow__handle-left etc.) but since the node div has a CSS transform
-// those classes apply in the rotated coordinate system — causing the handle
-// to appear on the wrong visual edge. Inline styles (higher specificity) keep
-// the handle at the intended pre-rotation location regardless of rotation.
-export const HANDLE_CSS: Record<Position, React.CSSProperties> = {
+// Base positioning for each handle edge. Used by handleStyle below.
+// The left/top/right/bottom values pin the handle to the correct physical
+// edge within the node div's local (pre-rotation) coordinate system.
+const HANDLE_BASE: Record<Position, React.CSSProperties> = {
 	[Position.Left]: {
 		left: "-4px",
 		right: "auto",
 		top: "50%",
 		bottom: "auto",
-		transform: "translate(0, -50%)",
 	},
 	[Position.Right]: {
 		left: "auto",
 		right: "-4px",
 		top: "50%",
 		bottom: "auto",
-		transform: "translate(0, -50%)",
 	},
 	[Position.Top]: {
 		left: "50%",
 		right: "auto",
 		top: "-4px",
 		bottom: "auto",
-		transform: "translate(-50%, 0)",
 	},
 	[Position.Bottom]: {
 		left: "50%",
 		right: "auto",
 		top: "auto",
 		bottom: "-4px",
-		transform: "translate(-50%, 0)",
 	},
 };
+
+// Centering offset for left/right vs top/bottom handles.
+const HANDLE_CENTER: Record<Position, string> = {
+	[Position.Left]: "translate(0, -50%)",
+	[Position.Right]: "translate(0, -50%)",
+	[Position.Top]: "translate(-50%, 0)",
+	[Position.Bottom]: "translate(-50%, 0)",
+};
+
+/**
+ * Returns the inline style for a Handle based on its pre-rotation base
+ * position and the node's current rotation.
+ *
+ * Two effects:
+ *  1. Overrides ReactFlow's position CSS classes (which would otherwise
+ *     place the handle in the rotated coordinate system, landing it on the
+ *     wrong visual edge).
+ *  2. Counter-rotates the handle div by −rotation so that the ::after
+ *     triangle drawn by index.css stays perpendicular to the edge it sits on,
+ *     rather than inheriting the node's CSS rotation.
+ */
+export const handleStyle = (
+	basePos: Position,
+	rotation: number,
+): React.CSSProperties => ({
+	...HANDLE_BASE[basePos],
+	transform: `${HANDLE_CENTER[basePos]} rotate(${-rotation}deg)`,
+});

--- a/gui/frontend/src/utils/nodeUtils.ts
+++ b/gui/frontend/src/utils/nodeUtils.ts
@@ -1,3 +1,4 @@
+import type React from "react";
 import { Position } from "reactflow";
 
 // Clockwise rotation cycle matching CSS transform: rotate(Ndeg).
@@ -17,4 +18,41 @@ export const rotPos = (pos: Position, rotation: number): Position => {
 	const steps = Math.round(rotation / 90) % 4;
 	const idx = CYCLE.indexOf(pos);
 	return CYCLE[(idx + steps + 4) % 4];
+};
+
+// Inline styles that pin each Handle to its correct physical edge within the
+// rotated node div. ReactFlow positions handles via CSS classes
+// (.react-flow__handle-left etc.) but since the node div has a CSS transform
+// those classes apply in the rotated coordinate system — causing the handle
+// to appear on the wrong visual edge. Inline styles (higher specificity) keep
+// the handle at the intended pre-rotation location regardless of rotation.
+export const HANDLE_CSS: Record<Position, React.CSSProperties> = {
+	[Position.Left]: {
+		left: "-4px",
+		right: "auto",
+		top: "50%",
+		bottom: "auto",
+		transform: "translate(0, -50%)",
+	},
+	[Position.Right]: {
+		left: "auto",
+		right: "-4px",
+		top: "50%",
+		bottom: "auto",
+		transform: "translate(0, -50%)",
+	},
+	[Position.Top]: {
+		left: "50%",
+		right: "auto",
+		top: "-4px",
+		bottom: "auto",
+		transform: "translate(-50%, 0)",
+	},
+	[Position.Bottom]: {
+		left: "50%",
+		right: "auto",
+		top: "auto",
+		bottom: "-4px",
+		transform: "translate(-50%, 0)",
+	},
 };


### PR DESCRIPTION
## Summary

Fixes three layered bugs that together prevented rotated nodes from displaying correct handle positions, triangle indicators, and edge spline directions.

- **Handle position** (`handleStyle` in `nodeUtils.ts`): ReactFlow's position-class CSS applies in the node's rotated coordinate system, landing handles on the wrong visual edge. Inline `left/top/right/bottom` CSS (via `handleStyle`) overrides those classes and pins each handle to its correct edge. Centering uses `calc(50% - 6px)` rather than `transform:translate` so `getBoundingClientRect()` stays correct.

- **Triangle orientation**: The `::after` triangles (defined in `index.css`) are children of the node div and inherit its CSS rotation. `handleStyle` adds `rotate(-rotation)` to each handle div so the net triangle rotation is 0 relative to the screen — always perpendicular to the edge.

- **Edge spline tangent** (`FlowEdge`, `ThermalEdge`): Both edge components had a local `rotatePosition()` that applied a second rotation to `sourcePosition`/`targetPosition`. Since Handle `position` is already set to `rotPos(base, rotation)`, the edge components were composing two 90 steps, producing 180 of error. Removing the redundant rotation makes the Handle `position` prop the sole source of truth for bezier tangent direction.

## Test plan

- [ ] Rotate channel node 90/180/270 CW: triangle on inlet handle points into node perpendicular to that edge; flow spline exits perpendicular
- [ ] TeeJunction rotation: S/C/B port triangles and splines all stay perpendicular
- [ ] PlenumNode 4-port rotation: all four handles correct
- [ ] Thermal edges: dashed orange splines also exit perpendicular after rotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)