### PR TITLE
feat(diagnostics): convergence history chart + worst-residual breakdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Solver convergence chart**: after every solve a "View convergence" link appears in
+  the solver status badge (both success and failure). Clicking opens a modal with a
+  log-scale `||F||` vs. time chart (no new dependency — pure SVG). The hybr phase is
+  shown in orange; the LM fallback phase (if triggered) in blue with a dashed boundary
+  line. A "Worst residuals" table below the chart shows the top-5 unknowns by absolute
+  residual value, helping identify which node or element is hardest to converge.
+- **Convergence history in API response**: `SolveResponse` now includes
+  `convergence_history` (list of `{eval, t, norm}` sampled at every `||F||` improvement
+  and at most every 0.1 s, capped at 1 000 points), `worst_residuals` (top 10 per-unknown
+  residuals at the final iterate), `solver_settings_used`, and `lm_started_at_eval`.
+  Useful for LLM-assisted diagnostics: the response is self-contained with full solver
+  context.
+
 ### Fixed
 - **Levenberg-Marquardt fallback for hybr oscillation** on compressible networks: when
   `hybr` (Powell's method) fails to converge on a compressible network — typically because

--- a/gui/backend/main.py
+++ b/gui/backend/main.py
@@ -128,7 +128,8 @@ def _solve_sync(schema: NetworkGraphSchema):
         }
 
     node_results, element_results, edge_results = _build_result_objects(result, net)
-    return result, node_results, element_results, edge_results, net
+    diag = getattr(solver, "_diagnostic_data", {})
+    return result, node_results, element_results, edge_results, net, diag
 
 
 @app.post("/solve", response_model=SolveResponse)
@@ -140,7 +141,7 @@ async def solve(schema: NetworkGraphSchema):
     hard_timeout = soft_timeout + 10.0
     try:
         # Offload CPU-bound C++ solver to a worker thread
-        result, node_results, element_results, edge_results, _ = await asyncio.wait_for(
+        result, node_results, element_results, edge_results, _, diag = await asyncio.wait_for(
             asyncio.to_thread(_solve_sync, schema),
             timeout=hard_timeout,
         )
@@ -152,6 +153,10 @@ async def solve(schema: NetworkGraphSchema):
             node_results=node_results,
             element_results=element_results,
             edge_results=edge_results,
+            convergence_history=diag.get("convergence_history", []),
+            worst_residuals=diag.get("worst_residuals", []),
+            solver_settings_used=diag.get("solver_settings_used", {}),
+            lm_started_at_eval=diag.get("lm_started_at_eval"),
         )
     except TimeoutError:
         raise HTTPException(

--- a/gui/backend/schemas.py
+++ b/gui/backend/schemas.py
@@ -385,6 +385,17 @@ class ElementResult(BaseModel):
     success: bool = True
 
 
+class ConvergencePoint(BaseModel):
+    eval: int
+    t: float
+    norm: float
+
+
+class WorstResidual(BaseModel):
+    name: str
+    residual: float
+
+
 class SolveResponse(BaseModel):
     success: bool
     message: str = ""
@@ -392,3 +403,7 @@ class SolveResponse(BaseModel):
     node_results: dict[str, NodeResult] = {}
     element_results: dict[str, ElementResult] = {}
     edge_results: dict[str, dict] = {}
+    convergence_history: list[ConvergencePoint] = []
+    worst_residuals: list[WorstResidual] = []
+    solver_settings_used: dict = {}
+    lm_started_at_eval: int | None = None

--- a/gui/frontend/src/api.ts
+++ b/gui/frontend/src/api.ts
@@ -15,10 +15,27 @@ export interface NodeResult {
 	success: boolean;
 }
 
+export interface ConvergencePoint {
+	eval: number;
+	t: number;
+	norm: number;
+}
+
+export interface WorstResidual {
+	name: string;
+	residual: number;
+}
+
 export interface SolveResponse {
 	success: boolean;
 	message: string;
+	final_norm?: number;
 	node_results: Record<string, NodeResult>;
+	element_results?: Record<string, any>;
+	convergence_history?: ConvergencePoint[];
+	worst_residuals?: WorstResidual[];
+	solver_settings_used?: Record<string, unknown>;
+	lm_started_at_eval?: number | null;
 }
 
 export const solveNetwork = async (

--- a/gui/frontend/src/components/ConvergenceChart.tsx
+++ b/gui/frontend/src/components/ConvergenceChart.tsx
@@ -1,0 +1,245 @@
+import { X } from "lucide-react";
+import type React from "react";
+
+export interface ConvergencePoint {
+	eval: number;
+	t: number;
+	norm: number;
+}
+
+export interface WorstResidual {
+	name: string;
+	residual: number;
+}
+
+interface Props {
+	history: ConvergencePoint[];
+	worstResiduals?: WorstResidual[];
+	lmStartedAt?: number | null;
+	onClose: () => void;
+}
+
+const W = 480;
+const H = 200;
+const PAD = { top: 12, right: 16, bottom: 36, left: 56 };
+const CHART_W = W - PAD.left - PAD.right;
+const CHART_H = H - PAD.top - PAD.bottom;
+
+function toLog(v: number): number {
+	return v > 0 ? Math.log10(v) : -20;
+}
+
+const ConvergenceChart: React.FC<Props> = ({
+	history,
+	worstResiduals,
+	lmStartedAt,
+	onClose,
+}) => {
+	if (!history || history.length === 0) return null;
+
+	const norms = history.map((p) => p.norm).filter((n) => n > 0);
+	const logMin = Math.floor(Math.min(...norms.map(toLog)));
+	const logMax = Math.ceil(Math.max(...norms.map(toLog)));
+	const logRange = logMax - logMin || 1;
+
+	const tMax = history[history.length - 1].t || 1;
+	const lmT =
+		lmStartedAt != null
+			? (history.find((p) => p.eval >= lmStartedAt)?.t ?? null)
+			: null;
+
+	const px = (t: number) => PAD.left + (t / tMax) * CHART_W;
+	const py = (norm: number) =>
+		PAD.top + CHART_H - ((toLog(norm) - logMin) / logRange) * CHART_H;
+
+	const makePolyline = (pts: ConvergencePoint[]) =>
+		pts
+			.filter((p) => p.norm > 0)
+			.map((p) => `${px(p.t).toFixed(1)},${py(p.norm).toFixed(1)}`)
+			.join(" ");
+
+	const hybrPts = lmT != null ? history.filter((p) => p.t <= lmT) : history;
+	const lmPts = lmT != null ? history.filter((p) => p.t >= lmT) : [];
+
+	const decades: number[] = [];
+	for (let d = logMin; d <= logMax; d++) decades.push(d);
+
+	const top5 = (worstResiduals ?? []).slice(0, 5);
+
+	return (
+		<div className="fixed inset-0 z-[200] flex items-center justify-center bg-black/40">
+			<div
+				role="dialog"
+				aria-modal="true"
+				aria-label="Convergence history"
+				className="bg-white rounded-lg shadow-xl border border-gray-200 p-4 w-[540px] max-w-[95vw]"
+				onKeyDown={(e) => e.key === "Escape" && onClose()}
+			>
+				<div className="flex items-center justify-between mb-3">
+					<span className="font-semibold text-sm text-gray-700">
+						Convergence history
+					</span>
+					<button
+						type="button"
+						onClick={onClose}
+						className="hover:bg-gray-100 p-1 rounded-full transition-colors"
+						aria-label="Close"
+					>
+						<X size={15} />
+					</button>
+				</div>
+
+				<svg
+					width={W}
+					height={H}
+					style={{ display: "block", overflow: "visible" }}
+				>
+					<title>Convergence history</title>
+					{decades.map((d) => {
+						const y = py(10 ** d);
+						return (
+							<g key={d}>
+								<line
+									x1={PAD.left}
+									x2={PAD.left + CHART_W}
+									y1={y}
+									y2={y}
+									stroke="#e5e7eb"
+									strokeWidth={1}
+								/>
+								<text
+									x={PAD.left - 4}
+									y={y}
+									textAnchor="end"
+									dominantBaseline="middle"
+									fontSize={9}
+									fill="#9ca3af"
+								>
+									{d === 0 ? "1" : `1e${d}`}
+								</text>
+							</g>
+						);
+					})}
+
+					{lmT != null && (
+						<line
+							x1={px(lmT)}
+							x2={px(lmT)}
+							y1={PAD.top}
+							y2={PAD.top + CHART_H}
+							stroke="#6366f1"
+							strokeWidth={1}
+							strokeDasharray="3 2"
+						/>
+					)}
+
+					{hybrPts.length > 1 && (
+						<polyline
+							points={makePolyline(hybrPts)}
+							fill="none"
+							stroke="#f97316"
+							strokeWidth={1.5}
+							strokeLinejoin="round"
+						/>
+					)}
+					{lmPts.length > 1 && (
+						<polyline
+							points={makePolyline(lmPts)}
+							fill="none"
+							stroke="#3b82f6"
+							strokeWidth={1.5}
+							strokeLinejoin="round"
+						/>
+					)}
+
+					<text
+						x={PAD.left + CHART_W / 2}
+						y={H - 4}
+						textAnchor="middle"
+						fontSize={9}
+						fill="#9ca3af"
+					>
+						t (s)
+					</text>
+					{[0, 0.25, 0.5, 0.75, 1.0].map((f) => (
+						<text
+							key={f}
+							x={px(f * tMax)}
+							y={PAD.top + CHART_H + 10}
+							textAnchor="middle"
+							fontSize={9}
+							fill="#9ca3af"
+						>
+							{(f * tMax).toFixed(f === 0 ? 0 : 1)}
+						</text>
+					))}
+
+					<text
+						x={PAD.left - 44}
+						y={PAD.top + CHART_H / 2}
+						textAnchor="middle"
+						fontSize={9}
+						fill="#9ca3af"
+						transform={`rotate(-90, ${PAD.left - 44}, ${PAD.top + CHART_H / 2})`}
+					>
+						||F||
+					</text>
+				</svg>
+
+				<div className="flex items-center gap-4 mt-1 mb-3 text-[10px] text-gray-500">
+					<span className="flex items-center gap-1">
+						<span
+							style={{
+								display: "inline-block",
+								width: 20,
+								height: 2,
+								background: "#f97316",
+							}}
+						/>
+						hybr
+					</span>
+					{lmT != null && (
+						<span className="flex items-center gap-1">
+							<span
+								style={{
+									display: "inline-block",
+									width: 20,
+									height: 2,
+									background: "#3b82f6",
+								}}
+							/>
+							LM fallback
+						</span>
+					)}
+					<span className="ml-auto text-gray-400">
+						{history.length} samples
+					</span>
+				</div>
+
+				{top5.length > 0 && (
+					<div>
+						<div className="text-[10px] font-semibold text-gray-500 uppercase tracking-wider mb-1">
+							Worst residuals
+						</div>
+						<table className="w-full text-[10px] font-mono">
+							<tbody>
+								{top5.map((r) => (
+									<tr key={r.name} className="border-t border-gray-100">
+										<td className="py-0.5 pr-3 text-gray-600 truncate max-w-[320px]">
+											{r.name}
+										</td>
+										<td className="py-0.5 text-right text-gray-800">
+											{r.residual.toExponential(2)}
+										</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</div>
+				)}
+			</div>
+		</div>
+	);
+};
+
+export default ConvergenceChart;

--- a/gui/frontend/src/components/SolverStatusBadge.tsx
+++ b/gui/frontend/src/components/SolverStatusBadge.tsx
@@ -1,9 +1,12 @@
 import { CheckCircle, X, XCircle } from "lucide-react";
 import type React from "react";
+import { useState } from "react";
 import useStore from "../store/useStore";
+import ConvergenceChart from "./ConvergenceChart";
 
 const SolverStatusBadge: React.FC = () => {
 	const { solveResults, dismissSolveStatus } = useStore();
+	const [showChart, setShowChart] = useState(false);
 
 	if (!solveResults) return null;
 
@@ -12,59 +15,100 @@ const SolverStatusBadge: React.FC = () => {
 		solveResults.message ||
 		(isSuccess ? "Solve completed" : "Failed to converge");
 	const finalNorm = solveResults.final_norm;
+	const hasHistory = (solveResults.convergence_history?.length ?? 0) > 0;
 
 	if (isSuccess) {
 		return (
-			<div className="absolute top-4 left-1/2 -translate-x-1/2 z-50 flex items-center gap-3 px-4 py-2 rounded shadow-md border bg-green-50 border-green-200 text-green-800">
-				<div className="flex items-center gap-2">
-					<CheckCircle size={20} />
-					<span className="font-semibold text-sm">Solver: Success</span>
+			<>
+				<div className="absolute top-4 left-1/2 -translate-x-1/2 z-50 flex items-center gap-3 px-4 py-2 rounded shadow-md border bg-green-50 border-green-200 text-green-800">
+					<div className="flex items-center gap-2">
+						<CheckCircle size={20} />
+						<span className="font-semibold text-sm">Solver: Success</span>
+					</div>
+					<div className="flex flex-col border-l pl-3 ml-1 border-green-300">
+						{finalNorm !== undefined && finalNorm !== null && (
+							<span className="text-xs font-mono">
+								||F|| = {finalNorm.toExponential(3)}
+							</span>
+						)}
+						<span className="text-xs opacity-80">{message}</span>
+						{hasHistory && (
+							<button
+								type="button"
+								onClick={() => setShowChart(true)}
+								className="text-[10px] text-green-600 underline hover:text-green-800 text-left mt-0.5"
+							>
+								View convergence
+							</button>
+						)}
+					</div>
+					<button
+						type="button"
+						onClick={dismissSolveStatus}
+						className="ml-2 hover:bg-black/5 p-1 rounded-full transition-colors"
+						aria-label="Dismiss"
+					>
+						<X size={16} />
+					</button>
 				</div>
-				<div className="flex flex-col border-l pl-3 ml-1 border-green-300">
-					{finalNorm !== undefined && finalNorm !== null && (
-						<span className="text-xs font-mono">
-							||F|| = {finalNorm.toExponential(3)}
-						</span>
-					)}
-					<span className="text-xs opacity-80">{message}</span>
-				</div>
-				<button
-					type="button"
-					onClick={dismissSolveStatus}
-					className="ml-2 hover:bg-black/5 p-1 rounded-full transition-colors"
-					aria-label="Dismiss"
-				>
-					<X size={16} />
-				</button>
-			</div>
+				{showChart && (
+					<ConvergenceChart
+						history={solveResults.convergence_history ?? []}
+						worstResiduals={solveResults.worst_residuals}
+						lmStartedAt={solveResults.lm_started_at_eval}
+						onClose={() => setShowChart(false)}
+					/>
+				)}
+			</>
 		);
 	}
 
 	return (
-		<div className="absolute top-4 left-1/2 -translate-x-1/2 z-50 w-[480px] max-w-[90vw] rounded shadow-lg border bg-red-50 border-red-200 text-red-800">
-			<div className="flex items-center gap-2 px-4 py-2 border-b border-red-200">
-				<XCircle size={20} className="shrink-0" />
-				<span className="font-semibold text-sm flex-1">Solver: Failed</span>
-				{finalNorm !== undefined && finalNorm !== null && (
-					<span className="text-xs font-mono opacity-70 mr-2">
-						||F|| = {finalNorm.toExponential(3)}
-					</span>
+		<>
+			<div className="absolute top-4 left-1/2 -translate-x-1/2 z-50 w-[480px] max-w-[90vw] rounded shadow-lg border bg-red-50 border-red-200 text-red-800">
+				<div className="flex items-center gap-2 px-4 py-2 border-b border-red-200">
+					<XCircle size={20} className="shrink-0" />
+					<span className="font-semibold text-sm flex-1">Solver: Failed</span>
+					{finalNorm !== undefined && finalNorm !== null && (
+						<span className="text-xs font-mono opacity-70 mr-2">
+							||F|| = {finalNorm.toExponential(3)}
+						</span>
+					)}
+					<button
+						type="button"
+						onClick={dismissSolveStatus}
+						className="hover:bg-red-100 p-1 rounded-full transition-colors shrink-0"
+						aria-label="Dismiss"
+					>
+						<X size={16} />
+					</button>
+				</div>
+				<div className="px-4 py-2 max-h-40 overflow-y-auto">
+					<pre className="text-xs font-mono whitespace-pre-wrap break-words">
+						{message}
+					</pre>
+				</div>
+				{hasHistory && (
+					<div className="px-4 pb-2">
+						<button
+							type="button"
+							onClick={() => setShowChart(true)}
+							className="text-[10px] text-red-500 underline hover:text-red-700"
+						>
+							View convergence
+						</button>
+					</div>
 				)}
-				<button
-					type="button"
-					onClick={dismissSolveStatus}
-					className="hover:bg-red-100 p-1 rounded-full transition-colors shrink-0"
-					aria-label="Dismiss"
-				>
-					<X size={16} />
-				</button>
 			</div>
-			<div className="px-4 py-2 max-h-40 overflow-y-auto">
-				<pre className="text-xs font-mono whitespace-pre-wrap break-words">
-					{message}
-				</pre>
-			</div>
-		</div>
+			{showChart && (
+				<ConvergenceChart
+					history={solveResults.convergence_history ?? []}
+					worstResiduals={solveResults.worst_residuals}
+					lmStartedAt={solveResults.lm_started_at_eval}
+					onClose={() => setShowChart(false)}
+				/>
+			)}
+		</>
 	);
 };
 

--- a/python/combaero/network/solver.py
+++ b/python/combaero/network/solver.py
@@ -1463,6 +1463,15 @@ class NetworkSolver:
         # Mutable so the LM fallback block can extend the effective limit.
         _timeout_eff: list[float | None] = [_hybr_budget]
 
+        # Convergence history: record on every ||F|| improvement and at most
+        # once per 0.1 s to show oscillation without excessive overhead.
+        # Cap at 1 000 entries (~50 KB JSON) regardless of problem size.
+        _history: list[dict] = []
+        _last_record_t: list[float] = [0.0]
+        _RECORD_INTERVAL = 0.1
+        _eval_count: list[int] = [0]
+        _lm_started_at_eval: list[int | None] = [None]
+
         # State for timeout and best iterate tracking (in real space)
         start_time = time.perf_counter()
         best_x = x0_use.copy()
@@ -1485,9 +1494,19 @@ class NetworkSolver:
 
                 # Track best iterate (in real space, unscaled residual)
                 res_norm = np.linalg.norm(res)
-                if res_norm < best_res_norm:
+                _improved = res_norm < best_res_norm
+                if _improved:
                     best_res_norm = res_norm
                     best_x = x_real.copy()
+
+                # Record convergence history point
+                _t = time.perf_counter() - start_time
+                if (_improved or _t - _last_record_t[0] >= _RECORD_INTERVAL) and len(
+                    _history
+                ) < 1000:
+                    _history.append({"eval": _eval_count[0], "t": round(_t, 3), "norm": res_norm})
+                    _last_record_t[0] = _t
+                _eval_count[0] += 1
 
                 # Scale residuals
                 res_scaled = res * inv_D_f
@@ -1585,6 +1604,7 @@ class NetworkSolver:
             _elapsed = time.perf_counter() - start_time
             _remaining = (timeout - _elapsed) if timeout is not None else None
             if _remaining is None or _remaining > 2.0:
+                _lm_started_at_eval[0] = _eval_count[0]
                 _timeout_eff[0] = timeout
                 try:
                     root(
@@ -1619,6 +1639,20 @@ class NetworkSolver:
         # Store solution for warm-start reuse
         self._last_x = final_x.copy()
 
+        # Decompose final residual vector into per-unknown contributions.
+        # One extra _residuals() call; same cost as a single Newton step.
+        # Guard with try-except: mocked or patched _residuals_and_jacobian in
+        # tests may raise, and diagnostic collection must never break the caller.
+        try:
+            _res_final = self._residuals(final_x)
+            _breakdown = {
+                name: float(abs(r)) for name, r in zip(self.unknown_names, _res_final, strict=False)
+            }
+            _worst = sorted(_breakdown.items(), key=lambda kv: kv[1], reverse=True)[:10]
+        except Exception:
+            _breakdown = {}
+            _worst = []
+
         # Store diagnostic data
         self._diagnostic_data = {
             "x0": x0_use.copy(),
@@ -1630,6 +1664,16 @@ class NetworkSolver:
             "solver_method": method,
             "solver_options": options.copy() if options else {},
             "wall_time": getattr(self, "_wall_time", None),
+            "convergence_history": _history,
+            "residual_breakdown": _breakdown,
+            "worst_residuals": [{"name": n, "residual": v} for n, v in _worst],
+            "lm_started_at_eval": _lm_started_at_eval[0],
+            "solver_settings_used": {
+                "method": method,
+                "init_strategy": init_strategy,
+                "timeout": timeout,
+                **options,
+            },
         }
 
         sol_dict = dict(zip(self.unknown_names, final_x, strict=False))


### PR DESCRIPTION
## Summary

- **Solver**: records `(eval, t, norm)` on every `||F||` improvement and at most every 0.1 s (capped at 1 000 points). One post-solve `_residuals()` call decomposes the final residual vector into per-unknown contributions. LM fallback start is timestamped for phase-boundary rendering.
- **Backend**: `SolveResponse` extended with `convergence_history`, `worst_residuals` (top 10), `solver_settings_used`, `lm_started_at_eval`. Self-contained for LLM-assisted diagnostics.
- **Frontend**: new `ConvergenceChart.tsx` — pure SVG, no new dependency. hybr phase in orange, LM fallback in blue with dashed boundary. Worst-residuals table (top 5). Opened via "View convergence" link in `SolverStatusBadge` for both success and failure results.

## Overhead

| Item | Cost |
|---|---|
| Per-eval history append | ~100 ns (only on improvement or every 0.1 s) |
| Post-solve residual breakdown | 1 × `_residuals()` ≈ one Newton step |
| HTTP response increase | ~50 KB |

## Test plan

- [ ] All 1365 existing tests pass
- [ ] Solve `manifold_basic.json` at m=0.19: click "View convergence", verify orange hybr plateau then blue LM drop
- [ ] Solve any simple network: verify chart shows monotone decrease, no LM phase shown
- [ ] Failed solve: verify "View convergence" link appears in red failure badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)