### PR TITLE
chore: add Practical Tips to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,9 @@
 # CombAero — Claude Code Instructions
 
+## Practical Tips
+- Avoid shell variable expansions and use literal paths or printenv/env instead. Run shell expansions once per session and use the abs path after. Shell variable expansions require user approval per open bugs (#29616, #18160). Allow list workarounds are not always reliable.
+- There are allow rules for sandboxed commands such as uv run, that are best executed in sandbox mode. Disabling sandbox requires user approval and should only be used when absolutely required.
+
 ## Hard Rules
 - **Virtual environment only:** use `uv run` and `uv pip`. Never install into system Python or use global `pip`.
 - **Never bypass pre-commit hooks** or CI checks. All code must pass cleanly before pushing.


### PR DESCRIPTION
## Summary
- Adds a `## Practical Tips` section to `CLAUDE.md` documenting two recurring workflow constraints:
  - Avoid per-command shell variable expansions (they require user approval per open bugs #29616/#18160; allowlist workarounds are unreliable) - resolve once per session and reuse the literal path.
  - Prefer running sandboxed commands in sandbox mode; disabling the sandbox requires user approval and should be reserved for cases that truly need it (e.g. `gh` API calls, which fail under TLS interception).

Docs-only change; no code, tests, or generated files affected.

## Test plan
- [x] pre-commit hooks pass (trailing whitespace, EOF, large files, merge conflicts)
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)