### PR TITLE
fix(tee): symmetric blended turning-loss closure for branching split direction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,14 +32,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in `docs/junction/junction_model.tex` exactly. Tee port nodes in the GUI backend
   are now `MomentumChamberNode` so static pressure P can differ from Pt at junction
   ports, allowing R_sp to be satisfied at non-zero velocity.
-  Known limitation: the dividing (branching) tee reaches a physical all-forward root
-  only when the branch outlet is pulled below the straight outlet; at equal or
-  straight-adverse splits the current parallel closure has no forward root, and a
-  `MomentumChamberNode`-bounded cascade additionally leaks the node dynamic head
-  through the channel coupling. Both defects, and a validated blended turning-loss
-  closure that fixes the split direction, are documented in
-  `docs/junction/junction_model_v3_addendum.md` (Findings 4-5) and tracked as
-  follow-up work. The merging tee is unaffected.
+  Branching split closure: both collector legs now use one consistent blended
+  turning-loss closure `Pt_com - Pt_leg - K_turn(theta)*q_leg - beta*x_leg*K_bc*q_ref`
+  (straight leg: `theta = 0` so the turning term vanishes, leaving the Borda-Carnot
+  extraction term). This removes the prior over-charge of a near-closed branch
+  (`K -> 1`) and lets a low-Mach `MomentumChamberNode`-bounded branching cascade reach
+  a physical all-forward, mass-conserving root. Known envelope limit: the straight run
+  is a low-loss through-leg whose effective loss coefficient is capped near
+  `beta*4/27 ~ 0.30` of the common dynamic head, so a large imposed straight-run
+  stagnation drop (and ejector/reverse behaviour generally) is outside this closure -
+  a momentum-CV junction is the sanctioned successor (see
+  `docs/junction/junction_model_v3_addendum.md` Finding 6 and
+  `docs/junction/momentum cv implementation guide.pdf`). The merging tee is unaffected.
 
 ### Fixed
 - **Channel-to-MomentumChamberNode face convention**: `ChannelElement.residuals` coupled

--- a/include/tee_junction.h
+++ b/include/tee_junction.h
@@ -410,6 +410,28 @@ T K_dat_j_closed(T x_j, T phi_j, T M_dat2) {
     return K_inc * (T{1.0} + kappa * M_dat2);
 }
 
+// Dividing-tee branch turning-loss model (blended closure; see Finding 5 of
+// docs/junction/junction_model_v3_addendum.md). The committed parallel closure
+//   R_branch = Pt_com - Pt_bra - K_bc * q_ref
+// charges both collector legs the common dynamic head q_ref, forcing K_str = K_bra
+// at equal outlets, which has no forward-octant root for an angled branch. The
+// blended closure replaces the branch leg with
+//   R_branch = Pt_com - Pt_bra - K_turn(theta) * q_bra - BETA_EXTRACT * x_bra * K_bc * q_ref
+// where q_bra is the branch-local dynamic head (the genuine turning loss) and the
+// x_bra prefactor makes the Borda-Carnot extraction term vanish as the branch
+// closes. K_turn(theta) follows the perpendicular-momentum-loss principle: the
+// incoming axial stream's component normal to the branch axis (u*sin(theta)) is
+// destroyed, so the lost stagnation head scales as sin^2(theta). K_TURN_90 (the
+// 90-deg value) and BETA_EXTRACT were FD-validated on the plenum cascade across
+// equal, branch-low, and straight-low regimes.
+inline constexpr double K_TURN_90    = 1.3;
+inline constexpr double BETA_EXTRACT = 2.0;
+
+inline double K_turn_div(double theta) {
+    const double s = std::sin(theta);
+    return K_TURN_90 * s * s;
+}
+
 // Machine-precision derivative of K_dat_j_closed (or any compatible kernel)
 // w.r.t. one of its three arguments, evaluated at a real point.
 //   which: 0 = d/dx, 1 = d/dphi, 2 = d/dM2

--- a/python/combaero/network/components.py
+++ b/python/combaero/network/components.py
@@ -2931,6 +2931,8 @@ class TeeJunctionElement(NetworkElement):
                     f"{self.common_node}.P": res.dR1_dP_com,
                     f"{self.common_node}.T": res.dR1_dT_com,
                     f"{self.branch_node}.Pt": res.dR1_dPt_bra,
+                    f"{self.branch_node}.P": res.dR1_dP_bra,
+                    f"{self.branch_node}.T": res.dR1_dT_bra,
                 },
             }
 

--- a/python/tests/test_tee_network.py
+++ b/python/tests/test_tee_network.py
@@ -79,12 +79,25 @@ def _merging_net(
 
 def _branching_net(
     Pt_common: float = 2.1e5,
-    Pt_straight: float = 2.06e5,
-    Pt_branch: float = 2.0e5,
+    Pt_straight: float = 2.098e5,
+    Pt_branch: float = 2.06e5,
     theta: float = _THETA_90,
     psi: float = 1.0,
 ) -> FlowNetwork:
-    """Three-node branching tee: one inlet (common) into two outlets (straight, branch)."""
+    """Three-node branching tee: one inlet (common) into two outlets (straight, branch).
+
+    Default boundary pressures sit inside the unified0D closure's physical envelope.
+    The straight run is a low-loss through-leg: its blended extraction term tops out at
+    an effective loss coefficient of beta*4/27 ~ 0.30 of the common dynamic head (the
+    Borda-Carnot diversion maximum). A large imposed straight-run stagnation drop is
+    therefore unreachable - the earlier 4.0e3 Pa straight drop (str 2.06 bar) only ever
+    "solved" because the pre-#9 closure over-charged the run with a full Borda-Carnot
+    K ~ 1, the bug Finding 5 removes. With a small straight drop the solver reaches a
+    clean all-forward exact root; the split is branch-dominated because the low-loss run
+    cannot carry much flow without downstream loading (see addendum Finding 6). See
+    docs/junction/'momentum cv implementation guide.pdf' for the momentum-CV successor
+    that removes this envelope limit entirely.
+    """
     net = FlowNetwork()
     Y = _DRY_AIR_Y
     net.add_node(PressureBoundary("pb_common", Pt=Pt_common, Tt=400.0, Y=Y))
@@ -234,14 +247,17 @@ def test_branching_tee_residuals_near_zero():
 
 def test_branching_tee_forward_flow_root():
     """Single dividing tee on direct pressure boundaries converges to a PHYSICAL
-    (all-forward) split when the branch outlet is pulled below the straight outlet.
+    (all-forward) exact root.
 
-    This is the honest positive baseline: a clean fixture (no MomentumChamberNode
-    coupling, see addendum Finding 4) where the committed parallel closure does reach
-    a forward exact zero (|F| ~ 5e-11).  At equal or straight-adverse outlet pressures
-    the same closure has no forward root (addendum Finding 5, task #9), so this test
-    deliberately uses the branch-low default of _branching_net (str 2.06, bra 2.0 bar)
-    rather than asserting direction for the symmetric case.
+    Honest positive baseline for the unified0D blended closure (task #9, addendum
+    Finding 6): a clean fixture (no MomentumChamberNode coupling, see Finding 4) with a
+    single source (common) and two sinks (straight, branch), so the BCs unambiguously
+    force all-outward flow - which the solver must then reproduce. The split is
+    branch-dominated because the straight run is a low-loss through-leg (its loss
+    coefficient is capped near 0.30 of the common dynamic head); a large straight drop
+    is outside the closure envelope. Direction here is a consequence of the BCs, not an
+    intrinsic property: with a single source and two sinks the physical answer is
+    all-forward, and that is what we assert.
     """
     net = _branching_net()
     solver = NetworkSolver(net)
@@ -638,23 +654,19 @@ def _gentle_branching_cascade() -> FlowNetwork:
     return net
 
 
-# Two known defects keep the MCN-bounded branching cascade from reaching a
-# physical (all-forward) root; both are documented in
-# docs/junction/junction_model_v3_addendum.md (Findings 4 and 5):
-#   * Defect 1 (task #7): ChannelElement couples upstream Pt to downstream P, which
-#     leaks an inline MomentumChamberNode's dynamic head as a free pressure gain.
-#   * Defect 2 (task #9): the parallel branch closure has no forward root at equal
-#     or straight-adverse outlets; the validated blended turning-loss closure is not
-#     yet ported to C++.
-# The cascade does reach a mass-conserving "__success__" root, but it is REVERSED
-# (tee straight arms run backward), so these tests assert flow DIRECTION and are
-# xfailed - we do not let a green test stand on an unphysical root.
-@pytest.mark.xfail(
-    reason="branching cascade converges only to a reversed split (addendum Findings 4-5; tasks #7, #9)",
-    strict=False,
-)
+# The gentle (low-Mach) MCN-bounded branching cascade now reaches a physical
+# (all-forward) mass-conserving root. Two defects previously blocked it, both fixed:
+#   * Defect 1 (task #7): ChannelElement coupled upstream Pt to downstream P, leaking an
+#     inline MomentumChamberNode's dynamic head as a free pressure gain. Landed.
+#   * Defect 2 (task #9): the parallel branch closure over-charged a near-closed branch
+#     (Borda-Carnot K -> 1) and forced K_str = K_bra at equal outlets. The unified0D
+#     blended turning-loss closure (both legs: extraction + branch turning loss) removes
+#     this. Landed in compressible_branching_tee_rj.
+# With both fixed, the gentle cascade is a single source feeding sinks, so the physical
+# answer is all-outward; the solver reproduces it (addendum Finding 6). The full
+# near-choke manifold below stays xfail - it is outside the closure envelope.
 def test_gentle_branching_cascade_forward_root():
-    """Two-tee MCN-bounded manifold should reach an all-forward, mass-conserving root."""
+    """Two-tee MCN-bounded manifold reaches an all-forward, mass-conserving root."""
     net = _gentle_branching_cascade()
     solver = NetworkSolver(net)
     sol = solver.solve()

--- a/src/solver_interface.cpp
+++ b/src/solver_interface.cpp
@@ -2108,9 +2108,6 @@ CompressibleTeeResult compressible_branching_tee_rj(
     const BranchInput& str,
     const BranchInput& bra)
 {
-    using combaero::K_dat_j_closed;
-    using combaero::cstep_deriv;
-
     constexpr double eps_m = 1e-10;
 
     // Pseudodatum = common branch (single supplier for branching)
@@ -2120,12 +2117,10 @@ CompressibleTeeResult compressible_branching_tee_rj(
     const double Pc    = com.P_static;
     const double Tc    = com.T;
     const double Rc    = com.R_gas;
-    const double gc    = com.gamma_eff;
     const double Ac    = com.A;
 
     const double m_com_sq_safe = m_com * m_com + eps_m * eps_m;
     const double u_dat  = m_com * Rc * Tc / (Pc * Ac);
-    const double M2_dat = u_dat * u_dat / (gc * Rc * Tc);
     const double q_ref  = 0.5 * (Pc / (Rc * Tc)) * u_dat * u_dat;
     // A_dat = Ac (derived: m_com / (rho_dat * u_dat) = m_com * Rc * Tc / (Pc * u_dat) = Ac)
 
@@ -2140,28 +2135,37 @@ CompressibleTeeResult compressible_branching_tee_rj(
     const double phi_str = 0.75 * std::abs(str.theta - com.theta);
     const double phi_bra = 0.75 * std::abs(bra.theta - com.theta);
 
-    const double K_str = K_dat_j_closed(x_str, phi_str, M2_dat);
-    const double K_bra = K_dat_j_closed(x_bra, phi_bra, M2_dat);
+    // Both collector legs use one consistent blended turning-loss closure (Finding 5):
+    //   R = Pt_com - Pt_leg - K_turn(theta)*q_leg - BETA_EXTRACT*x_leg*K_bc_leg*q_ref
+    // where q_leg is the leg-local dynamic head (turning loss, vanishes at theta=0) and
+    // K_bc_leg = 1 + x^2 - 2*x*cos(phi) is the incompressible Borda-Carnot kernel
+    // (faithful to the FD prototype; phi is constant w.r.t. the unknowns, so its
+    // x-derivative is the trivial 2x - 2cos(phi)). The straight leg has theta_str = 0,
+    // so K_turn(0) = 0 and its closure collapses to the pure extraction term.
+    const double BE = combaero::BETA_EXTRACT;
 
-    // Residuals: R = Pt_dat - Pt_j - K_j * q_ref  (p0_dat = Pt_com)
-    const double R_0 = com.Pt - str.Pt - K_str * q_ref;
-    const double R_1 = com.Pt - bra.Pt - K_bra * q_ref;
+    // Straight collector (theta_str = 0 -> no turning loss).
+    const double cos_phi_str = std::cos(phi_str);
+    const double K_bc_str    = 1.0 + x_str * x_str - 2.0 * x_str * cos_phi_str;
+    const double dKbc_str_dx = 2.0 * x_str - 2.0 * cos_phi_str;
 
-    // K kernel derivatives via complex-step
-    auto K_fn = [](auto x, auto phi, auto M2) {
-        return K_dat_j_closed(x, phi, M2);
-    };
-    const double dKs_dx  = cstep_deriv(K_fn, 0, x_str, phi_str, M2_dat);
-    const double dKs_dM2 = cstep_deriv(K_fn, 2, x_str, phi_str, M2_dat);
-    const double dKb_dx  = cstep_deriv(K_fn, 0, x_bra, phi_bra, M2_dat);
-    const double dKb_dM2 = cstep_deriv(K_fn, 2, x_bra, phi_bra, M2_dat);
+    const double R_0 = com.Pt - str.Pt - BE * x_str * K_bc_str * q_ref;
 
-    // Pseudodatum derivatives (M2_dat = m_com^2 * Rc * Tc / (gc * Pc^2 * Ac^2),
-    //                          q_ref  = 0.5 * m_com^2 * Rc * Tc / (Pc * Ac^2))
-    const double dM2_dPc    = -2.0 * M2_dat / Pc;
-    const double dM2_dTc    = M2_dat / Tc;
-    const double dM2_dm_com = 2.0 * m_com * Rc * Tc / (gc * Pc * Pc * Ac * Ac);
+    // Branch collector (theta_bra != 0 -> turning loss present).
+    const double cos_phi_bra = std::cos(phi_bra);
+    const double K_bc        = 1.0 + x_bra * x_bra - 2.0 * x_bra * cos_phi_bra;
+    const double dKbc_dx     = 2.0 * x_bra - 2.0 * cos_phi_bra;
+    const double K_turn      = combaero::K_turn_div(bra.theta);
 
+    const double Pb    = bra.P_static;
+    const double Tb    = bra.T;
+    const double Rb    = bra.R_gas;
+    const double Ab    = bra.A;
+    const double q_bra = 0.5 * Rb * Tb * m_bra * m_bra / (Pb * Ab * Ab);
+
+    const double R_1 = com.Pt - bra.Pt - K_turn * q_bra - BE * x_bra * K_bc * q_ref;
+
+    // Pseudodatum derivatives (q_ref = 0.5 * m_com^2 * Rc * Tc / (Pc * Ac^2)).
     const double dq_dPc    = -q_ref / Pc;
     const double dq_dTc    = q_ref / Tc;
     const double dq_dm_com = m_com * Rc * Tc / (Pc * Ac * Ac);
@@ -2181,25 +2185,40 @@ CompressibleTeeResult compressible_branching_tee_rj(
     res.R_0 = R_0;
     res.R_1 = R_1;
 
-    // R_0 Jacobians (dR0 = d(Pt_com - Pt_str - K_str * q_ref))
+    // R_0 Jacobians: R_0 = Pt_com - Pt_str - BETA_EXTRACT*x_str*K_bc_str*q_ref.
+    // Pure extraction term (straight leg, no turning loss); phi_str is constant w.r.t.
+    // the unknowns. d(x_str*K_bc_str)/dx_str = K_bc_str + x_str*dKbc_str_dx.
+    const double d_xKbc_str_dx = K_bc_str + x_str * dKbc_str_dx;
     res.dR0_dPt_com    = 1.0;
     res.dR0_dPt_str    = -1.0;
-    res.dR0_dP_com     = -(dKs_dM2 * dM2_dPc    * q_ref + K_str * dq_dPc);
-    res.dR0_dT_com     = -(dKs_dM2 * dM2_dTc    * q_ref + K_str * dq_dTc);
-    res.dR0_dmdot_com  = -(dKs_dx  * dx_str_dm_com * q_ref + dKs_dM2 * dM2_dm_com * q_ref + K_str * dq_dm_com);
-    res.dR0_dmdot_branch = -(dKs_dx * dx_str_dm_branch * q_ref);
-    // R_0 has no bra node dependence for branching
+    res.dR0_dP_com     = -BE * x_str * K_bc_str * dq_dPc;
+    res.dR0_dT_com     = -BE * x_str * K_bc_str * dq_dTc;
+    res.dR0_dmdot_com  = -BE * (q_ref * d_xKbc_str_dx * dx_str_dm_com + x_str * K_bc_str * dq_dm_com);
+    res.dR0_dmdot_branch = -BE * q_ref * d_xKbc_str_dx * dx_str_dm_branch;
+    // R_0 has no bra node dependence for branching.
     res.dR0_dP_str = 0.0;
+    res.dR0_dT_str = 0.0;
     res.dR0_dP_bra = 0.0;
 
-    // R_1 Jacobians (dR1 = d(Pt_com - Pt_bra - K_bra * q_ref))
+    // R_1 Jacobians: R_1 = Pt_com - Pt_bra - K_turn*q_bra - BETA_EXTRACT*x_bra*K_bc*q_ref.
+    // K_turn and phi_bra (hence K_bc's cos term) are constant w.r.t. the unknowns.
+    // Extraction term E = BETA_EXTRACT*x_bra*K_bc*q_ref; d(x_bra*K_bc)/dx_bra = K_bc + x_bra*dKbc_dx.
+    const double d_xKbc_dx      = K_bc + x_bra * dKbc_dx;
+    const double dq_bra_dm_bra  = Rb * Tb * m_bra / (Pb * Ab * Ab);  // d(q_bra)/d(m_branch)
+
     res.dR1_dPt_com    = 1.0;
     res.dR1_dPt_bra    = -1.0;
-    res.dR1_dP_com     = -(dKb_dM2 * dM2_dPc    * q_ref + K_bra * dq_dPc);
-    res.dR1_dT_com     = -(dKb_dM2 * dM2_dTc    * q_ref + K_bra * dq_dTc);
-    res.dR1_dmdot_com  = -(dKb_dx  * dx_bra_dm_com * q_ref + dKb_dM2 * dM2_dm_com * q_ref + K_bra * dq_dm_com);
-    res.dR1_dmdot_branch = -(dKb_dx * dx_bra_dm_branch * q_ref);
-    // R_1 has no str node dependence for branching
+    // Branch-local q_bra (q_bra ~ 1/P_bra, ~ T_bra); turning-loss term only.
+    res.dR1_dP_bra     = K_turn * q_bra / Pb;
+    res.dR1_dT_bra     = -K_turn * q_bra / Tb;
+    // Common datum enters only through q_ref in the extraction term (K_bc is incompressible).
+    res.dR1_dP_com     = -BE * x_bra * K_bc * dq_dPc;
+    res.dR1_dT_com     = -BE * x_bra * K_bc * dq_dTc;
+    // Flows: q_bra depends on m_branch only; x_bra and q_ref depend on m_com; x_bra on m_branch.
+    res.dR1_dmdot_com  = -BE * (q_ref * d_xKbc_dx * dx_bra_dm_com + x_bra * K_bc * dq_dm_com);
+    res.dR1_dmdot_branch = -K_turn * dq_bra_dm_bra
+                           - BE * q_ref * d_xKbc_dx * dx_bra_dm_branch;
+    // R_1 has no straight-node dependence for branching.
     res.dR1_dP_str = 0.0;
     res.dR1_dT_str = 0.0;
     res.dR1_dPt_str = 0.0;


### PR DESCRIPTION
## Summary
- Reform the branching-tee straight-leg residual (`R_0`) to use the same blended Borda-Carnot extraction closure as the branch leg, so both collectors share one consistent physics form. The straight leg (theta=0) collapses to the pure extraction term `beta*x*(1-x)^2*q_ref`; the branch leg keeps its turning loss `K_turn(theta)=K_TURN_90*sin^2(theta)`.
- Add `K_TURN_90`, `BETA_EXTRACT` constexprs and `K_turn_div()` to `tee_junction.h`; expose the `dR1_dP_bra`/`dR1_dT_bra` Jacobian entries in the Python residual assembly. Full analytic Jacobian FD-verified.
- Re-ground the branching-tee test fixtures to within-envelope boundary conditions. The model's straight-run extraction is capped at `beta*4/27 ~ 0.30` (Borda-Carnot diversion maximum), so the prior fixture's 4000 Pa straight-leg drop was unreachable without the over-charged pre-fix `K~1`.

## Notes
- The gentle two-tee cascade now reaches an all-forward, mass-conserving root (xfail removed). The near-choke manifold cases remain xfail (genuinely non-convergent, |F|~1.0e4).
- No API/units_data.h sync needed: no public signatures changed (the `CompressibleTeeResult` struct already carried all Jacobian fields).
- Correctness gate is convergence + mass conservation (BC-agnostic); split direction is a boundary-condition consequence, not an intrinsic property of the model.

## Test plan
- [x] `uv run pytest python/tests/test_tee_network.py -q` -> 22 passed, 2 xfailed
- [x] Full suite green; both style checks pass
- [x] Analytic Jacobian FD-verified (all 9 branching entries)

Generated with [Claude Code](https://claude.com/claude-code)