### PR TITLE
chore: sync biome version to 2.4.16 (schema + pre-commit pin)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,5 +63,5 @@ repos:
     rev: v0.6.1
     hooks:
       - id: biome-check
-        additional_dependencies: ["@biomejs/biome@2.4.9"]
+        additional_dependencies: ["@biomejs/biome@2.4.16"]
         files: ^gui/frontend/

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.9/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
 	"files": {
 		"ignoreUnknown": true,
 		"includes": ["gui/frontend/src/**"]


### PR DESCRIPTION
## Summary
- After #170 bumped `@biomejs/biome` to 2.4.16 in `gui/frontend/package.json`, the root `biome.json` `$schema` URL and the `.pre-commit-config.yaml` pin were still at 2.4.9. Dependabot can only touch `package.json`/lockfile, so these two were left behind.
- Bring both up to 2.4.16 so all three locations agree, per the frontend version-sync checklist in CLAUDE.md.

## Test plan
- [x] `./scripts/check-gui-style.sh` -> biome check passes (43 files)
- [ ] CI GUI lint + frontend validation green

Generated with [Claude Code](https://claude.com/claude-code)