### PR TITLE
chore(docs): correct CLAUDE.md sandbox note for git/gh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ uv run scripts/generate_units_md.py         # regenerate docs/UNITS.md
 
 ## Git Workflow
 - **Branch protection on `main`:** never push directly to `main`. Always work on a feature/fix branch and open a PR (`feature-branch → main`).
-- **Opening PRs:** `gh pr create` requires `dangerouslyDisableSandbox: true` — the sandbox intercepts TLS and `gh` cannot reach the GitHub API without it.
+- **Opening PRs:** `git` and `gh` are allowlisted in `.claude/settings.local.json` and run inside the sandbox without approval — including `git push`, `gh pr view/checks/merge`, and (verified) most network operations to `github.com`. `dangerouslyDisableSandbox: true` is only needed when a command writes to a denied path (e.g., `git rebase` that touches `uv.lock`).
 - **CI is required to merge:** GitHub Actions checks must pass before a PR can be merged. If main was updated after the PR was opened, re-run checks against the updated base before merging.
 
 ## Version Sync Checklist


### PR DESCRIPTION
## Summary

Replaces the inaccurate claim that \`gh pr create requires dangerouslyDisableSandbox: true\` (because the sandbox supposedly intercepts TLS) with a verified statement of what's actually true.

With the allowlist in \`.claude/settings.local.json\` (\`Bash(git *)\`, \`Bash(gh *)\`), both git and gh network operations to github.com work inside the sandbox without per-command approval. The TLS-interception claim was inaccurate; the actual constraint had always been per-command approval, which is now resolved by the allowlist.

The note now correctly identifies the remaining sandbox-disable case: when a command writes to a denied path (e.g., \`git rebase\` touching \`uv.lock\`).

## Test plan
- [x] Verified \`git fetch\`, \`git push\`, \`gh pr view\` all run sandboxed in current session
- [x] Confirmed \`uv.lock\` write still requires \`dangerouslyDisableSandbox: true\` (hit it twice while preparing this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)