### PR TITLE
fix(junction): K8 transcription — psi on wrong side in tee_junction.h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `docs/junction/momentum cv implementation guide.pdf`). The merging tee is unaffected.
 
 ### Fixed
+- **`tee_junction.h` K8 transcription**: K8 (joining type 4, lateral path) had
+  `c / psi` where Bassett Table 2 + Eq 34 angle correction call for `psi * c`.
+  Invisible at `psi = 1` (the only point covered by the existing
+  `K7-K8` complementary-identity test, since both forms reduce to the same
+  expression there); diverges at `psi != 1`. Verdict surfaced by the new
+  junction-validation runner (`#183`) on Bassett Fig 12b digitized data
+  (`psi in {1, 2, 4}` at theta=45 deg). Corrected K8 matches Bassett's own
+  published calc line in Fig 12b; the residual gap vs measured (~0.6 at
+  psi=4, q=0.5) is the paper's own acknowledged moderate fit, not a code
+  defect. Same fix applied to `dK8_dq`. K7-K8 identity test still passes
+  unchanged. New regression test pins K8 across psi=1, 2, 4 at theta=45
+  deg.
 - **Channel-to-MomentumChamberNode face convention**: `ChannelElement.residuals` coupled
   the upstream node's stagnation pressure to the downstream node's *static* pressure
   (`Pt_up - P_down - dP_friction = 0`). Across an inline `MomentumChamberNode` (where

--- a/include/tee_junction.h
+++ b/include/tee_junction.h
@@ -151,17 +151,18 @@ inline double dK11_dq(double q, double psi, double theta) {
     return (2.0 * psi / D) * dN + 2.0 * q;
 }
 
-// K8: branch path, type 4. Has 1/psi: protect psi before calling.
-// theta_corr = pi - (3/4)*(pi - theta).
+// K8: branch path, type 4 (Bassett Table 2 + Eq 34 angle correction).
+// theta_corr = pi - (3/4)*(pi - theta). Multiplied by psi (not 1/psi);
+// no protection needed.
 inline double K8(double q, double psi, double theta) {
     const double tc = M_PI - 0.75 * (M_PI - theta);
     const double c = std::cos(tc);
-    return 1.0 - q * q + 2.0 * (1.0 - q) * (1.0 - q) * c / psi;
+    return 1.0 - q * q + 2.0 * (1.0 - q) * (1.0 - q) * psi * c;
 }
 inline double dK8_dq(double q, double psi, double theta) {
     const double tc = M_PI - 0.75 * (M_PI - theta);
     const double c = std::cos(tc);
-    return -2.0 * q - 4.0 * (1.0 - q) * c / psi;
+    return -2.0 * q - 4.0 * (1.0 - q) * psi * c;
 }
 
 // K7: straight path, type 4. theta_corr = pi - (3/4)*(pi - theta).

--- a/tests/test_tee_junction.cpp
+++ b/tests/test_tee_junction.cpp
@@ -55,6 +55,36 @@ TEST(TeeJunctionKCoefficients, K6AtNinetyDegreeEqualArea) {
 }
 
 // -----------------------------------------------------------------------------
+// K8 psi-sweep test (Bassett Table 2 + Eq 34 angle correction).
+// Pins the fix to a prior transcription error that had c/psi instead of
+// psi*c. The (1-q)^2 form is correct per Table 2 and preserves the
+// K7-K8 identity at psi=1 (since the psi factor reduces to 1 there).
+// Reference values computed analytically from the corrected formula at
+// theta=45 deg; their disagreement with Fig 12b measured (1.73 at psi=4)
+// is the paper's own acknowledged moderate fit, not a code bug.
+// -----------------------------------------------------------------------------
+TEST(TeeJunctionKCoefficients, K8PsiSweepAtFortyFiveDeg) {
+    const double theta = M_PI / 4.0;
+    const double q = 0.5;
+    const double tc = M_PI - 0.75 * (M_PI - theta);
+    const double c = std::cos(tc);
+    for (double psi : {1.0, 2.0, 4.0}) {
+        const double expected = 1.0 - q * q + 2.0 * (1.0 - q) * (1.0 - q) * psi * c;
+        EXPECT_NEAR(K8(q, psi, theta), expected, 1e-10)
+            << "K8 at psi=" << psi << ", q=0.5, theta=45 deg should equal "
+            << expected << " per Bassett Table 2 + Eq 34";
+    }
+    // Specific reference values at q=0.5, theta=45 deg:
+    //   cos(theta') = cos(78.75 deg) ~ 0.195090
+    //   psi=1: 0.75 + 2 * 0.25 * 1 * 0.195 ~ 0.848
+    //   psi=2: 0.75 + 2 * 0.25 * 2 * 0.195 ~ 0.945
+    //   psi=4: 0.75 + 2 * 0.25 * 4 * 0.195 ~ 1.141
+    EXPECT_NEAR(K8(0.5, 1.0, theta), 0.848, 5e-3);
+    EXPECT_NEAR(K8(0.5, 2.0, theta), 0.945, 5e-3);
+    EXPECT_NEAR(K8(0.5, 4.0, theta), 1.141, 5e-3);
+}
+
+// -----------------------------------------------------------------------------
 // Test 3: K12 at theta=90deg, psi=1 (Bassett Fig. 10b reference ~0.35)
 // -----------------------------------------------------------------------------
 TEST(TeeJunctionKCoefficients, K12AtNinetyDegreeEqualArea) {

--- a/validation/junction/models/bassett2001.py
+++ b/validation/junction/models/bassett2001.py
@@ -97,14 +97,14 @@ def K7_corr(q: float, psi: float, theta: float) -> float:
 
 def K8_raw(q: float, psi: float, theta: float) -> float:
     """Joining type 4, lateral path (Table 2, no angle correction).
-    K8 = 1 - q^2 + 2*(1-q)*psi*cos(theta)."""
-    return 1.0 - q * q + 2.0 * (1.0 - q) * psi * math.cos(theta)
+    K8 = 1 - q^2 + 2 * (1-q)^2 * psi * cos(theta)."""
+    return 1.0 - q * q + 2.0 * (1.0 - q) * (1.0 - q) * psi * math.cos(theta)
 
 
 def K8_corr(q: float, psi: float, theta: float) -> float:
     """Joining type 4, lateral path with Eq 34 correction."""
     tc = math.pi - 0.75 * (math.pi - theta)
-    return 1.0 - q * q + 2.0 * (1.0 - q) * psi * math.cos(tc)
+    return 1.0 - q * q + 2.0 * (1.0 - q) * (1.0 - q) * psi * math.cos(tc)
 
 
 def K9_raw(q: float, psi: float, theta: float) -> float:


### PR DESCRIPTION
## Summary

The K8 (Bassett joining type 4, branch path) formula in \`include/tee_junction.h\` had \`c / psi\` where Bassett Table 2 + Eq 34 angle correction call for \`psi * c\`. The \`(1-q)^2\` factor and \`theta'\` angle correction were both correct; only psi was placed on the wrong side of the fraction.

## How the bug surfaced

Invisible at \`psi=1\` (the only point covered by the existing K7-K8 complementary-identity test, since both forms reduce to the same expression there). The new junction-validation runner (#183) compared C++ K8 against Bassett Fig 12b digitized data across \`psi in {1, 2, 4}\` at \`theta=45 deg\`:

| psi  | q   | C++ before | C++ after | Measured (Fig 12b) |
|------|-----|------------|-----------|--------------------|
| 1.0  | 0.5 | 0.847      | 0.847     | 0.835              |
| 2.0  | 0.5 | 0.799      | 0.945     | 1.148              |
| 4.0  | 0.5 | 0.774      | 1.141     | 1.731              |

The corrected formula matches Bassett's own published calc line in Fig 12b (cross-checked at \`q=0\`, \`psi=4\`: code 1.0, fix 2.56, paper curve ~2.5). The residual gap vs measured at \`psi=4\` (~0.6) is the paper's own acknowledged moderate fit, not a code defect; p. 874 explicitly says *"these results show some discrepancy between measured and predicted values, but the trends caused by altering the area ratio are predicted well"*.

## Phase A companion fix

\`validation/junction/models/bassett2001.py\` K8_raw and K8_corr had a complementary transcription error (missing the \`(1-q)^2\` factor) that I introduced in the original Phase A commit. Fixed here too. With both fixes, the C++ and Phase A modules now agree across all psi.

## What stays the same

- K7 unchanged (matched Table 2 correctly already)
- K7-K8 complementary identity test (\`K7(q,1,θ) - K8(1-q,1,θ) = 2q - 1\` at psi=1) still passes — psi=1 is unchanged by the fix
- All other K1..K12 unchanged
- No signature change → no API_CPP.md / units_data.h update needed

## Test plan

- [x] Full \`test_tee_junction\` suite: 28 tests, all pass
- [x] New \`K8PsiSweepAtFortyFiveDeg\` pins the corrected behavior across \`psi in {1, 2, 4}\` to within 5e-3 of the closed-form Bassett+Eq34 reference
- [x] Existing \`K7MinusK8ComplementIdentity\` still passes (identity preserved)
- [x] Python validation runner smoke tests: 4 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)