### PR TITLE
feat(junction): bind all 12 tee K functions + fix scorecard unsupported-cell metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Python bindings for all 12 Bassett K coefficients**: `cb._core.tee_K1`
+  through `tee_K12`. Previously only K5, K6, K11, K12 were exposed; the
+  rest required separate C++ tests. The new bindings let the
+  `validation/junction` scorecard evaluate all 12 K against measured
+  data in one pass (K1, K3, K4, K7, K8, K9, K10 now contribute real
+  numbers instead of being silently unsupported). `units_data.h` and
+  `docs/API_CPP.md` / `docs/API_PYTHON.md` updated to match.
 - **`MultiPortChamberElement` + `BorderCarnotLossElement`** (Phase 1 of the
   momentum-CV junction). Sanctioned successor to `TeeJunctionElement` for
   n-port manifolds, ejector / merge-split-reverse regimes, and high-Mach
@@ -63,6 +70,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `docs/junction/momentum cv implementation guide.pdf`). The merging tee is unaffected.
 
 ### Fixed
+- **Junction validation scorecard**: cells where the candidate model could
+  not evaluate any record (e.g. K not yet bound, paper not supported) now
+  display `-` instead of `0.000` and a misleading negative `Delta_vs_ceiling`.
+  Fully-unsupported cells are also excluded from the headline aggregates.
 - **`tee_junction.h` K8 transcription**: K8 (joining type 4, lateral path) had
   `c / psi` where Bassett Table 2 + Eq 34 angle correction call for `psi * c`.
   Invisible at `psi = 1` (the only point covered by the existing

--- a/docs/API_CPP.md
+++ b/docs/API_CPP.md
@@ -715,13 +715,30 @@ struct TeeInputStatus {
 };
 TeeInputStatus tee_check_inputs(double q, double psi, double theta);
 
-// Raw K-coefficient functions (Bassett 2001, Table 2) -- pure, no guards
-double K5(double q);                                   // straight arm, separating
-double K6(double q, double psi, double theta);         // branch arm, separating
-double K11(double q, double psi, double theta);        // straight arm, joining
-double K12(double q, double psi, double theta);        // branch arm, joining
+// Raw K-coefficient functions (Bassett 2001, Table 2 + Eq 33/34 angle corrections).
+// Pure math, no input guards. K2 and K5 are psi/theta-independent per Eq 15.
+double K1(double q, double psi, double theta);
+double K2(double q);                                   // = q^2 - 1.5*q + 0.5
+double K3(double q, double psi, double theta);
+double K4(double q, double psi, double theta);
+double K5(double q);                                   // same as K2; separating type 3
+double K6(double q, double psi, double theta);
+double K7(double q, double psi, double theta);
+double K8(double q, double psi, double theta);
+double K9(double q, double psi, double theta);
+double K10(double q, double psi, double theta);
+double K11(double q, double psi, double theta);
+double K12(double q, double psi, double theta);
+// Analytic q-derivatives for each.
+double dK1_dq(double q, double psi, double theta);
+double dK3_dq(double q, double psi, double theta);
+double dK4_dq(double q, double psi, double theta);
 double dK5_dq(double q);
 double dK6_dq(double q, double psi, double theta);
+double dK7_dq(double q, double psi, double theta);
+double dK8_dq(double q, double psi, double theta);
+double dK9_dq(double q, double psi, double theta);
+double dK10_dq(double q, double psi, double theta);
 double dK11_dq(double q, double psi, double theta);
 double dK12_dq(double q, double psi, double theta);
 

--- a/docs/API_PYTHON.md
+++ b/docs/API_PYTHON.md
@@ -588,9 +588,19 @@ Y[1] = 0.233  # O2
 status = _core.tee_check_inputs(q=0.5, psi=1.0, theta=math.pi/2)
 # status.valid, status.q_in_range, status.psi_valid, status.theta_valid
 
-# Raw K-coefficient functions (Bassett 2001)
+# Raw K-coefficient functions (Bassett 2001 Table 2 + Eq 33/34 angle corrections).
+# K2 and K5 take only q (psi/theta-independent per Eq 15); the rest take (q, psi, theta).
+# Provided for diagnostics and validation against measured data.
+k1  = _core.tee_K1(q, psi, theta)
+k2  = _core.tee_K2(q)
+k3  = _core.tee_K3(q, psi, theta)
+k4  = _core.tee_K4(q, psi, theta)
 k5  = _core.tee_K5(q)               # straight arm, separating tee
 k6  = _core.tee_K6(q, psi, theta)   # branch arm, separating tee
+k7  = _core.tee_K7(q, psi, theta)
+k8  = _core.tee_K8(q, psi, theta)
+k9  = _core.tee_K9(q, psi, theta)
+k10 = _core.tee_K10(q, psi, theta)
 k11 = _core.tee_K11(q, psi, theta)  # straight arm, joining tee
 k12 = _core.tee_K12(q, psi, theta)  # branch arm, joining tee
 

--- a/include/units_data.h
+++ b/include/units_data.h
@@ -304,6 +304,19 @@ inline constexpr Entry function_units[] = {
      "TeeJunctionResult (R_straight: Pa, R_branch: Pa, dR/dm_dot: Pa*s/kg, "
      "dR/dP: -, dR/dT: Pa/K, dR/dY: Pa, K_straight: -, K_branch: -, "
      "q: -, blend_w: -, topology_valid: bool, status: CorrelationValidity)"},
+    // Raw Bassett K coefficients (validation/diagnostic; no clamping).
+    {"tee_K1", "q: -, psi: -, theta: rad", "- (K)"},
+    {"tee_K2", "q: -", "- (K)"},
+    {"tee_K3", "q: -, psi: -, theta: rad", "- (K)"},
+    {"tee_K4", "q: -, psi: -, theta: rad", "- (K)"},
+    {"tee_K5", "q: -", "- (K)"},
+    {"tee_K6", "q: -, psi: -, theta: rad", "- (K)"},
+    {"tee_K7", "q: -, psi: -, theta: rad", "- (K)"},
+    {"tee_K8", "q: -, psi: -, theta: rad", "- (K)"},
+    {"tee_K9", "q: -, psi: -, theta: rad", "- (K)"},
+    {"tee_K10", "q: -, psi: -, theta: rad", "- (K)"},
+    {"tee_K11", "q: -, psi: -, theta: rad", "- (K)"},
+    {"tee_K12", "q: -, psi: -, theta: rad", "- (K)"},
 
     // -------------------------------------------------------------------------
     // multi_port_chamber.h + solver_interface.h - Momentum-CV junction

--- a/python/combaero/_core.cpp
+++ b/python/combaero/_core.cpp
@@ -483,10 +483,26 @@ PYBIND11_MODULE(_core, m) {
         "Returns: TeeJunctionResult");
 
   // Tee junction pure K functions and helpers (for testing and diagnostics)
+  m.def("tee_K1", &combaero::K1, py::arg("q"), py::arg("psi"), py::arg("theta"),
+        "Bassett K1: branch loss, separating flow type 1 (reverse of K6).");
+  m.def("tee_K2", &combaero::K5, py::arg("q"),
+        "Bassett K2: straight-through loss, separating flow types 1/2. Same expression as K5.");
+  m.def("tee_K3", &combaero::K3, py::arg("q"), py::arg("psi"), py::arg("theta"),
+        "Bassett K3: branch-to-downstream, separating flow type 2 (reverse of K4).");
+  m.def("tee_K4", &combaero::K4, py::arg("q"), py::arg("psi"), py::arg("theta"),
+        "Bassett K4: branch-to-downstream, separating flow type 2.");
   m.def("tee_K5", &combaero::K5, py::arg("q"),
         "Bassett K5: straight-through loss, separating flow. K5(q) = q^2-1.5q+0.5");
   m.def("tee_K6", &combaero::K6, py::arg("q"), py::arg("psi"), py::arg("theta"),
         "Bassett K6: branch loss, separating flow type 3.");
+  m.def("tee_K7", &combaero::K7, py::arg("q"), py::arg("psi"), py::arg("theta"),
+        "Bassett K7: straight path, joining flow type 4.");
+  m.def("tee_K8", &combaero::K8, py::arg("q"), py::arg("psi"), py::arg("theta"),
+        "Bassett K8: branch path, joining flow type 4.");
+  m.def("tee_K9", &combaero::K9, py::arg("q"), py::arg("psi"), py::arg("theta"),
+        "Bassett K9: branch A path, joining flow type 5.");
+  m.def("tee_K10", &combaero::K10, py::arg("q"), py::arg("psi"), py::arg("theta"),
+        "Bassett K10: branch C path, joining flow type 5.");
   m.def("tee_K11", &combaero::K11, py::arg("q"), py::arg("psi"), py::arg("theta"),
         "Bassett K11: straight-to-outlet, joining flow type 6.");
   m.def("tee_K12", &combaero::K12, py::arg("q"), py::arg("psi"), py::arg("theta"),

--- a/validation/junction/models/tee_junction_raw.py
+++ b/validation/junction/models/tee_junction_raw.py
@@ -22,15 +22,20 @@ class TeeJunctionRaw:
 
     name = "tee_junction_raw_cpp"
 
-    # Only 4 of 12 Bassett K's are currently bound to Python via cb._core:
-    #     tee_K5, tee_K6, tee_K11, tee_K12.
-    # K1, K3, K4, K7, K8, K9, K10 are inline-only in include/tee_junction.h
-    # and not exposed via pybind11. Adding those bindings is a separate
-    # follow-up; the bound 4 cover the K12 ψ² bug verdict (the headline
-    # case) so we proceed.
+    # All 12 Bassett K's are exposed via cb._core as tee_K1..tee_K12.
+    # K2 and K5 take only q (the formula is psi/theta-independent per Eq 15);
+    # the others take (q, psi, theta).
     _CORE_K_FNS = {
+        "K1": "tee_K1",
+        "K2": "tee_K2",
+        "K3": "tee_K3",
+        "K4": "tee_K4",
         "K5": "tee_K5",
         "K6": "tee_K6",
+        "K7": "tee_K7",
+        "K8": "tee_K8",
+        "K9": "tee_K9",
+        "K10": "tee_K10",
         "K11": "tee_K11",
         "K12": "tee_K12",
     }
@@ -57,7 +62,7 @@ class TeeJunctionRaw:
         fn = getattr(cb._core, self._CORE_K_FNS[K_id], None)
         if fn is None:
             return None
-        # K2/K5 take only q in the C++ API.
+        # K2 and K5 take only q in the C++ API (theta- and psi-independent).
         if K_id in {"K2", "K5"}:
             return float(fn(q))
         return float(fn(q, psi, theta_rad))

--- a/validation/junction/scorecard.py
+++ b/validation/junction/scorecard.py
@@ -29,7 +29,13 @@ CORE_K_IDS = {"K_straight_sep", "K_lateral_sep", "K_lateral_join", "K_straight_j
 
 @dataclass
 class Cell:
-    """One row of the scorecard."""
+    """One row of the scorecard.
+
+    A cell is "fully unsupported" when every record had K_model is None
+    (e.g. the model has no binding for that K). The metric fields are NaN
+    in that case; the renderer shows '-' rather than 0 to avoid the
+    misleading negative D_ceil it produced before.
+    """
 
     canonical_K: str
     psi_bin: str  # "1.0" or "all" if mixed
@@ -43,6 +49,11 @@ class Cell:
     delta_vs_ceiling: float = 0.0
     median_wall_time_s: float = 0.0
     n_unsupported: int = 0  # model returned None
+
+    @property
+    def fully_unsupported(self) -> bool:
+        """True if the model had no evaluable records in this cell."""
+        return self.N > 0 and self.n_unsupported >= self.N
 
 
 def _rmse(errs: list[float]) -> float:
@@ -82,19 +93,41 @@ def build_cells(records: list[Record], *, uncertainty_K: float = 0.05) -> list[C
         return (cK, psi if psi is not None else -1.0, theta if theta is not None else -1.0)
 
     cells: list[Cell] = []
+    nan = float("nan")
     for (cK, psi, theta), recs in sorted(groups.items(), key=_sort_key):
         N = len(recs)
         model_errs = [r.K_model - r.K_measured for r in recs if r.K_model is not None]
         ceil_errs = [r.K_ceiling - r.K_measured for r in recs if r.K_ceiling is not None]
         unsupported = sum(1 for r in recs if r.K_model is None)
-        rmse_m = _rmse(model_errs)
-        rmse_c = _rmse(ceil_errs)
-        mae = sum(abs(e) for e in model_errs) / len(model_errs) if model_errs else 0.0
-        bias = sum(model_errs) / len(model_errs) if model_errs else 0.0
-        max_err = max((abs(e) for e in model_errs), default=0.0)
-        within = sum(1 for e in model_errs if abs(e) <= uncertainty_K)
-        pct = within / len(model_errs) if model_errs else 0.0
         wt = _median([r.wall_time_s for r in recs])
+        if not model_errs:
+            # Model couldn't evaluate any record in this cell. Don't fabricate
+            # a 0 RMSE / negative D_ceil; mark metrics NaN so the renderer can
+            # show them as '-' and the headline can exclude them.
+            cells.append(
+                Cell(
+                    canonical_K=cK,
+                    psi_bin=f"{psi:g}" if psi is not None else "n/a",
+                    theta_bin=f"{theta:g}" if theta is not None else "n/a",
+                    N=N,
+                    rmse_meas=nan,
+                    mae_meas=nan,
+                    bias_meas=nan,
+                    max_err_meas=nan,
+                    pct_within_uncertainty=nan,
+                    delta_vs_ceiling=nan,
+                    median_wall_time_s=wt,
+                    n_unsupported=unsupported,
+                )
+            )
+            continue
+        rmse_m = _rmse(model_errs)
+        rmse_c = _rmse(ceil_errs) if ceil_errs else nan
+        mae = sum(abs(e) for e in model_errs) / len(model_errs)
+        bias = sum(model_errs) / len(model_errs)
+        max_err = max(abs(e) for e in model_errs)
+        within = sum(1 for e in model_errs if abs(e) <= uncertainty_K)
+        pct = within / len(model_errs)
         cells.append(
             Cell(
                 canonical_K=cK,
@@ -106,7 +139,7 @@ def build_cells(records: list[Record], *, uncertainty_K: float = 0.05) -> list[C
                 bias_meas=bias,
                 max_err_meas=max_err,
                 pct_within_uncertainty=pct,
-                delta_vs_ceiling=rmse_m - rmse_c,
+                delta_vs_ceiling=rmse_m - rmse_c if not math.isnan(rmse_c) else nan,
                 median_wall_time_s=wt,
                 n_unsupported=unsupported,
             )
@@ -125,9 +158,17 @@ class Headline:
 
 
 def headline(model_name: str, cells: list[Cell]) -> Headline:
-    core = [c.rmse_meas for c in cells if c.canonical_K in CORE_K_IDS and c.N > 0]
-    extended = [c.rmse_meas for c in cells if c.N > 0]
-    deltas = [c.delta_vs_ceiling for c in cells if c.N > 0]
+    """Aggregate cells into one-line headline. Fully-unsupported cells are
+    excluded; otherwise NaN cells (rare: model evaluated some records but
+    no ceiling) are also excluded for sanity."""
+
+    def _ok(c: Cell, attr: str) -> bool:
+        v = getattr(c, attr)
+        return c.N > 0 and not c.fully_unsupported and not math.isnan(v)
+
+    core = [c.rmse_meas for c in cells if _ok(c, "rmse_meas") and c.canonical_K in CORE_K_IDS]
+    extended = [c.rmse_meas for c in cells if _ok(c, "rmse_meas")]
+    deltas = [c.delta_vs_ceiling for c in cells if _ok(c, "delta_vs_ceiling")]
     n_sup = sum(c.N - c.n_unsupported for c in cells)
     n_unsup = sum(c.n_unsupported for c in cells)
     return Headline(
@@ -140,8 +181,17 @@ def headline(model_name: str, cells: list[Cell]) -> Headline:
     )
 
 
+def _fmt(v: float, spec: str, na: str = "-") -> str:
+    """Format a float, rendering NaN as `na` right-aligned to spec's width."""
+    if math.isnan(v):
+        # spec like '>7.3f' -> width is the number before the dot
+        width = int(spec.lstrip("+").lstrip(">").split(".")[0]) if "." in spec else 6
+        return f"{na:>{width}}"
+    return format(v, spec)
+
+
 def format_scorecard(model_name: str, cells: list[Cell], h: Headline) -> str:
-    """Render a human-readable scorecard."""
+    """Render a human-readable scorecard. NaN metrics render as '-'."""
     lines = []
     lines.append(f"=== Scorecard: {model_name} ===")
     lines.append(
@@ -151,11 +201,12 @@ def format_scorecard(model_name: str, cells: list[Cell], h: Headline) -> str:
     )
     lines.append("-" * 110)
     for c in sorted(cells, key=lambda c: (c.canonical_K, c.psi_bin, c.theta_bin)):
+        pct_str = "-" if math.isnan(c.pct_within_uncertainty) else f"{c.pct_within_uncertainty * 100:.0f}%"
         lines.append(
             f"{c.canonical_K:<20} {c.psi_bin:>6} {c.theta_bin:>6} {c.N:>4} "
-            f"{c.rmse_meas:>7.3f} {c.mae_meas:>7.3f} {c.bias_meas:>+8.3f} "
-            f"{c.max_err_meas:>7.3f} {c.pct_within_uncertainty * 100:>7.0f}% "
-            f"{c.delta_vs_ceiling:>+8.3f} {c.n_unsupported:>6}"
+            f"{_fmt(c.rmse_meas, '>7.3f')} {_fmt(c.mae_meas, '>7.3f')} "
+            f"{_fmt(c.bias_meas, '>+8.3f')} {_fmt(c.max_err_meas, '>7.3f')} "
+            f"{pct_str:>8} {_fmt(c.delta_vs_ceiling, '>+8.3f')} {c.n_unsupported:>6}"
         )
     lines.append("-" * 110)
     lines.append(


### PR DESCRIPTION
## Summary

Two small but high-value changes:

1. **Bind all 12 Bassett K coefficients to Python** (`tee_K1` … `tee_K12`). Previously only K5/K6/K11/K12 were exposed, so the validation scorecard silently marked K1/K3/K4/K7/K8/K9/K10 as unsupported. The `TeeJunctionRaw` adapter now covers all 12 → roughly +140 supported records in the scorecard.
2. **Fix the scorecard unsupported-cell metric.** Cells where the model returned `None` for every record were reporting `RMSE = 0.000` and `Delta_vs_ceiling = -<ceiling RMSE>` — making the model look like it was beating the ceiling when it actually wasn't tested. Now those cells store `NaN` and the renderer shows `-`; headline aggregates exclude them.

## Scorecard before / after (TeeJunctionRaw vs Bassett measured)

```
Before:  core_RMSE=0.109  extended_RMSE=0.069  avg_Delta_ceiling=-0.074
         250 supported, 385 unsupported. 7 K silently broken cells reported 0 RMSE.

After:   core_RMSE=0.125  extended_RMSE=0.153  avg_Delta_ceiling=+0.000
         390 supported, 245 unsupported. All 12 K reported, fully-unsupported
         cells render as '-' and don't pollute headline.
```

The `extended_RMSE` rose from 0.069 to 0.153 because the previously-hidden K4/K7/K8/K9 contributions are now counted — these are the moderate-fit Ks. `avg_Delta_ceiling = +0.000` is the correct answer since `TeeJunctionRaw` *is* the Bassett analytical reference (zero distance from itself).

## New per-K verdicts now visible

| K | psi=1 typical RMSE | Highest-psi RMSE | Paper's fit-tier |
|---|---|---|---|
| K4 (sep type 2) | 0.13–0.25 | n/a | very_good (now scored honestly) |
| K7 (join type 4) | 0.12 | 0.36 at psi=4 | moderate ✓ |
| K8 (join type 4, recently fixed) | 0.10–0.17 | 0.36 at psi=2 | moderate ✓ |
| K9 (join type 5) | 0.25 at theta=90 | n/a | poor — matches Bassett's own admission |

## Files

- `python/combaero/_core.cpp`: 7 new `m.def(\"tee_K…\", &combaero::K…)` bindings + tee_K2 alias of K5 for symmetry
- `validation/junction/models/tee_junction_raw.py`: extended `_CORE_K_FNS` dict to all 12
- `validation/junction/scorecard.py`: `Cell` gains `fully_unsupported` property, `build_cells` stores NaN for empty model_errs, `format_scorecard` renders NaN as `-`, `headline` excludes fully-unsupported cells
- `include/units_data.h`: 12 new `tee_K*` entries
- `docs/API_PYTHON.md` + `docs/API_CPP.md`: documented K1–K12 raw functions
- `CHANGELOG.md`: entries under \`[Unreleased]\` Added and Fixed

## Test plan

- [x] All 28 C++ tee_junction tests pass
- [x] Python: `pytest python/tests/test_units_sync.py test_junction_validation_runner.py test_junction_dataset_quality.py` → 82 pass, 28 skip
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)