### PR TITLE
feat(validation): port Mynard 2010 Unified0D as runner reference

### DIFF
--- a/python/tests/test_mynard_port.py
+++ b/python/tests/test_mynard_port.py
@@ -1,0 +1,87 @@
+"""Smoke tests for the Mynard 2010 Unified0D port + adapter."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+from validation.junction.models import bassett2001
+from validation.junction.models.mynard2010 import junction_loss_coefficient
+from validation.junction.models.mynard_analytical import MynardAnalytical
+
+
+def test_matlab_help_example_runs():
+    """The Matlab help example -- T-junction split -- runs without error
+    and returns finite C/K values."""
+    r = junction_loss_coefficient(
+        U=np.array([100.0, -50.0, -50.0]),
+        A=np.array([2.0, 2.0, 2.0]),
+        theta=np.array([math.pi, 0.0, math.pi / 2.0]),
+    )
+    assert np.all(np.isfinite(r.C))
+    assert r.K is not None and np.all(np.isfinite(r.K))
+    # For the symmetric T-split, the two collectors should have similar
+    # |K| (mirror symmetric in flow but different in geometry).
+    assert len(r.K) == 2
+
+
+def test_mynard_matches_bassett_K6_within_15pct_at_theta_90():
+    """At theta=90, psi=1, q=0.5, Mynard's branch-collector K should match
+    Bassett K6 to within Mynard's energy-transfer-vs-pure-CV gap (~15%)."""
+    r = junction_loss_coefficient(
+        U=np.array([1.0, -0.5, -0.5]),
+        A=np.array([1.0, 1.0, 1.0]),
+        theta=np.array([math.pi, 0.0, math.pi / 2.0]),
+    )
+    K6 = bassett2001.K6(0.5, 1.0, math.pi / 2.0)
+    K_mynard_branch = float(r.K[1])
+    rel = abs(K_mynard_branch - K6) / K6
+    assert rel < 0.15, f"Mynard K_branch={K_mynard_branch} vs Bassett K6={K6}; rel={rel}"
+
+
+def test_mynard_smooth_through_theta_120():
+    """Mynard handles theta=120 cleanly (Bassett K6 formula goes catastrophic
+    at flow-direction extremes; the pseudosupplier reformulation avoids it).
+    """
+    for theta_deg in (90, 105, 120, 135):
+        r = junction_loss_coefficient(
+            U=np.array([1.0, -0.5, -0.5]),
+            A=np.array([1.0, 1.0, 1.0]),
+            theta=np.array([math.pi, 0.0, math.radians(theta_deg)]),
+        )
+        assert r.K is not None
+        assert np.all(np.isfinite(r.K)), f"non-finite K at theta={theta_deg}"
+        # K should monotonically increase with theta in this regime
+        assert r.K[1] > 0, f"K_branch went negative at theta={theta_deg}"
+
+
+def test_adapter_returns_K_for_separating_K6_and_K5():
+    """MynardAnalytical evaluates Bassett K6 and K5 cases at standard cases."""
+    m = MynardAnalytical()
+    K6 = m.evaluate("bassett2001", "K6", q=0.5, psi=1.0, theta_rad=math.pi / 2.0)
+    K5 = m.evaluate("bassett2001", "K5", q=0.5, psi=1.0, theta_rad=math.pi / 2.0)
+    assert K6 is not None and 0.5 < K6 < 1.5
+    assert K5 is not None  # K_straight_mynard differs from K5_bassett, but finite
+
+
+def test_adapter_returns_K_for_joining_K11_and_K12():
+    """MynardAnalytical evaluates Bassett K11 and K12 cases (converging flow)."""
+    m = MynardAnalytical()
+    K11 = m.evaluate("bassett2001", "K11", q=0.5, psi=1.0, theta_rad=math.pi / 2.0)
+    K12 = m.evaluate("bassett2001", "K12", q=0.5, psi=1.0, theta_rad=math.pi / 2.0)
+    assert K11 is not None and math.isfinite(K11)
+    assert K12 is not None and math.isfinite(K12)
+
+
+def test_adapter_returns_none_for_unsupported_ids():
+    """K1/K3/K4/K7/K8/K9/K10 use special CVs and aren't supported."""
+    m = MynardAnalytical()
+    for K_id in ("K1", "K3", "K4", "K7", "K8", "K9", "K10"):
+        assert m.evaluate("bassett2001", K_id, 0.5, 1.0, math.pi / 2.0) is None
+
+
+def test_adapter_returns_none_for_non_bassett_paper():
+    """Mynard maps via Bassett K_ids; other papers' K_ids are not supported."""
+    m = MynardAnalytical()
+    assert m.evaluate("wang2014", "K_13", 0.5, None, None, M_3=0.3) is None

--- a/validation/junction/models/mynard2010.py
+++ b/validation/junction/models/mynard2010.py
@@ -1,0 +1,137 @@
+"""
+Mynard & Valen-Sendstad 2010 Unified0D junction-loss model.
+
+Faithful Python port of `docs/junction/JunctionLossCoefficient.m`
+(BSD-licensed reference code accompanying:
+
+    J P Mynard, K Valen-Sendstad,
+    "A unified method for estimating pressure losses at vascular junctions",
+    Int J Numer Methods Biomed Eng (2015), DOI:10.1002/cnm.2717).
+
+The model handles any number of branches at any angle and any flow
+direction (supplier vs collector determined by sign of U). It builds on
+Bassett's CV analysis (Section 2.4.1 of the paper -- same machinery as
+in `tee_junction.h::K_dat_j_closed`) and adds two refinements that the
+current C++ Unified0D implementation omits:
+
+  1. a 'pseudosupplier' branch combining all inflow, for smooth solutions
+     across flow regime changes (joining flow with > 1 supplier),
+  2. an empirical energy-transfer factor between diverging collectors,
+     calibrated against CFD.
+
+The Python port is structurally identical to the Matlab; variable names
+follow the original where reasonable (`PseudoSupAngle`, `AreaRatio`,
+`etransferfactor`). See the Matlab file for line-by-line correspondence.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import numpy as np
+
+
+def _wrap_to_pi(x: np.ndarray) -> np.ndarray:
+    """Matlab's `wrapToPi`: angle to (-pi, pi]."""
+    return (x + math.pi) % (2.0 * math.pi) - math.pi
+
+
+def _wrap_to_2pi(x: np.ndarray) -> np.ndarray:
+    """Matlab's `wrapTo2Pi`: angle to [0, 2*pi)."""
+    return x % (2.0 * math.pi)
+
+
+@dataclass
+class MynardResult:
+    """Output of one Mynard call.
+
+    C is per-branch (collectors only; supplier entries are 0). K is per-collector
+    and only computed for 3-branch junctions per the original (line 65 of the
+    Matlab code). pseudo_area is per-collector (energy-transfer factor varies
+    between collectors).
+    """
+
+    C: np.ndarray
+    K: np.ndarray | None
+    flow_ratio: np.ndarray  # |Q_collector| / Q_total_supplier, per collector
+    pseudo_sup_angle: float
+    pseudo_area: np.ndarray  # per-collector effective pseudosupplier area
+
+
+def junction_loss_coefficient(
+    U: np.ndarray,
+    A: np.ndarray,
+    theta: np.ndarray,
+) -> MynardResult:
+    """Compute Mynard Unified0D loss coefficients for a junction.
+
+    Args:
+        U: per-branch velocities. Positive = supplier (flow INTO junction),
+           negative = collector (flow OUT of junction).
+        A: per-branch cross-sectional areas (same length as U).
+        theta: per-branch angles relative to an arbitrary reference (radians).
+
+    Returns:
+        MynardResult with per-branch C and per-collector K (only for n<=3).
+    """
+    U = np.asarray(U, dtype=float).reshape(-1)
+    A = np.asarray(A, dtype=float).reshape(-1)
+    theta = _wrap_to_pi(np.asarray(theta, dtype=float).reshape(-1))
+
+    Q = U * A  # volumetric flow
+    Ci = Q < 0.0  # collector mask
+    Si = ~Ci  # supplier mask
+    Qtot = float(np.sum(Q[Si]))  # total flow into junction
+    flow_ratio = -Q[Ci] / Qtot  # fraction per collector (positive)
+
+    # ---- Reorient all branch angles so the pseudocollector angle is 0 ----
+    pseudo_col_angle = float(np.mean(theta[Ci]))
+    pseudo_sup_initial = math.atan2(
+        float(np.sum(np.sin(theta[Si]) * Q[Si])),
+        float(np.sum(np.cos(theta[Si]) * Q[Si])),
+    )
+    # Ensure pseudosupplier lies in the second quadrant relative to collector.
+    if abs(pseudo_sup_initial - pseudo_col_angle) < math.pi / 2.0:
+        pseudo_col_angle += math.pi
+    theta = _wrap_to_pi(theta - pseudo_col_angle)
+
+    # ---- Pseudosupplier angle (always positive after flipping) ----
+    pseudo_direction = np.sign(np.mean(np.sin(theta[Si]) * Q[Si]))
+    if pseudo_direction < 0:
+        theta = -theta
+    pseudo_sup_angle = math.atan2(
+        float(np.sum(np.sin(np.abs(theta[Si])) * Q[Si])),
+        float(np.sum(np.cos(np.abs(theta[Si])) * Q[Si])),
+    )
+
+    # ---- Effective pseudosupplier area (Mynard's empirical energy transfer) ----
+    etransfer = (0.8 * (math.pi - pseudo_sup_angle) * np.sign(theta[Ci]) - 0.2) * (1.0 - flow_ratio)
+    pseudo_velocity_avg = float(np.sum(U[Si] * Q[Si]) / Qtot)
+    tot_pseudo_area = Qtot / ((1.0 - etransfer) * pseudo_velocity_avg)
+
+    # ---- Area / angle ratios, then C ----
+    area_ratio = tot_pseudo_area / A[Ci]
+    phi = _wrap_to_2pi(pseudo_sup_angle - theta[Ci])
+
+    C_all = np.zeros_like(U)
+    # The (1 - exp(-FlowRatio/0.02)) factor avoids infinite C as FlowRatio -> 0.
+    damping = 1.0 - np.exp(-flow_ratio / 0.02)
+    C_all[Ci] = damping * (1.0 - (1.0 / (area_ratio * flow_ratio)) * np.cos(0.75 * (math.pi - phi)))
+
+    # ---- K coefficients (3-branch only per the original) ----
+    K = None
+    if len(U) <= 3:
+        if int(np.sum(Ci)) == 1:
+            Ucom = float(U[Ci][0])
+        else:
+            Ucom = float(U[Si][0])
+        K = (U[Ci] ** 2 / Ucom**2) * (2.0 * C_all[Ci] + U[Si] ** 2 / U[Ci] ** 2 - 1.0)
+
+    return MynardResult(
+        C=C_all,
+        K=K if isinstance(K, np.ndarray) else None,
+        flow_ratio=flow_ratio,
+        pseudo_sup_angle=pseudo_sup_angle,
+        pseudo_area=np.asarray(tot_pseudo_area, dtype=float),
+    )

--- a/validation/junction/models/mynard_analytical.py
+++ b/validation/junction/models/mynard_analytical.py
@@ -1,0 +1,87 @@
+"""
+CorrelationModel adapter scoring Mynard 2010 Unified0D against the dataset.
+
+Maps Bassett K_id + (q, psi, theta) into Mynard's (U, A, theta) inputs
+and reads back the appropriate per-branch K. Covers separating K5/K6 and
+joining K11/K12; other K_id's involve non-canonical topologies and are
+left as None (the scorecard renders them as '-').
+
+This adapter is positioned alongside `PaperCeiling` so the scorecard can
+compare a candidate junction model against BOTH the Bassett analytical
+reference AND the Mynard Unified0D reference. The latter is the published
+ceiling for the model class our `tee_junction.h::K_dat_j_closed` aims to
+implement.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+from validation.junction.models.mynard2010 import junction_loss_coefficient
+
+
+class MynardAnalytical:
+    """Mynard & Valen-Sendstad 2010 Unified0D loss coefficients."""
+
+    name = "mynard_unified0d_analytical"
+
+    def evaluate(
+        self,
+        paper: str,
+        K_id: str,
+        q: float,
+        psi: float | None,
+        theta_rad: float | None,
+        M_3: float | None = None,
+        **kwargs: float,
+    ) -> float | None:
+        if paper != "bassett2001":
+            return None
+        psi = psi if psi is not None else 1.0
+        theta_rad = theta_rad if theta_rad is not None else math.pi / 2.0
+
+        # Mynard's K is per-branch from a 3-branch (U, A, theta) input.
+        # Map Bassett K_id -> (flow direction, which-K-to-return).
+        # Sign convention: positive U = supplier (into junction).
+        #
+        # Areas: Bassett psi = F_C / F_B, so A_branch = A_com / psi.
+        A_com, A_str = 1.0, 1.0
+        A_bra = 1.0 / psi
+        # Theta convention: common at pi (flow direction into junction from "left"),
+        # straight at 0 (flow leaves "right"), branch at theta (lateral).
+        theta_arr = np.array([math.pi, 0.0, theta_rad])
+
+        if K_id in {"K5", "K2", "K6"}:
+            # Separating: common is supplier, straight + branch are collectors.
+            U_arr = np.array([1.0, -(1.0 - q), -q])
+            A_arr = np.array([A_com, A_str, A_bra])
+            try:
+                r = junction_loss_coefficient(U_arr, A_arr, theta_arr)
+            except Exception:
+                return None
+            if r.K is None or len(r.K) < 2:
+                return None
+            # K[0] = straight collector (K5/K2 analog); K[1] = branch (K6 analog)
+            return float(r.K[0]) if K_id in {"K5", "K2"} else float(r.K[1])
+
+        if K_id in {"K11", "K12"}:
+            # Joining: common is collector, straight + branch are suppliers.
+            # Bassett q convention for K11/K12 = m_branch / m_common
+            # (Table 1). So branch supplier flow rate is q*Q_total, straight
+            # is (1-q)*Q_total. Common collector takes all flow (Q = -1).
+            U_arr = np.array([-1.0, (1.0 - q), q])
+            A_arr = np.array([A_com, A_str, A_bra])
+            try:
+                r = junction_loss_coefficient(U_arr, A_arr, theta_arr)
+            except Exception:
+                return None
+            if r.K is None or len(r.K) < 2:
+                return None
+            # K[0] = straight supplier (K11 analog); K[1] = branch (K12 analog)
+            return float(r.K[0]) if K_id == "K11" else float(r.K[1])
+
+        # K1/K3/K4/K7/K8/K9/K10 use specific Bassett control volumes that
+        # don't map 1:1 onto Mynard's symmetric 3-branch geometry. Defer.
+        return None


### PR DESCRIPTION
## Summary

Faithful Python port of \`docs/junction/JunctionLossCoefficient.m\` (BSD-licensed reference code for Mynard & Valen-Sendstad 2010, DOI:10.1002/cnm.2717). Adds the Unified0D method as a \`CorrelationModel\` so the validation scorecard can compare candidate junction models against the *published* Unified0D ceiling, not just raw Bassett Table 2.

This is the step-zero precursor to MPCE-v2 (#26) — porting the algorithm before structurally embedding it into the C++ residual gives us a clean reference to score against and a concrete template for the MPCE-v2 design.

## Why this matters

The current \`tee_junction.h::K_dat_j_closed\` implements only Mynard's *core* Bassett-CV K formulation. The two pieces Mynard adds beyond raw Bassett — the **pseudosupplier supplier branch** (smooth solutions across flow regime changes) and the **empirical energy-transfer factor** between diverging collectors — are not in the current C++. MPCE-v1 lacks them too, which is why it fails at θ=120°.

## Surprise finding from the first scorecard run

Mynard scores *worse* than Bassett analytical against Bassett's measured data:

```
mynard_unified0d_analytical  core_RMSE=0.539  ext_RMSE=0.539
tee_junction_raw_cpp         core_RMSE=0.125  ext_RMSE=0.153
```

Two reasons:
1. The pseudosupplier reorientation pulls in cross-effects Bassett's pure-CV formula deliberately ignores. For Bassett's experimental pipe-junction setup (Fig 7a/b) where these are small, the simpler formula matches measured better.
2. **Mynard's energy-transfer factor was calibrated for vascular CFD**, not pipe junctions — different L/D and Re regimes.

But Mynard *does* win on smoothness: K6 stays finite and well-behaved through θ=120° (RMSE 0.13, same as Bassett at this angle) where MPCE-v1 failed to converge entirely.

## Design implication for MPCE-v2

**Take the pseudosupplier structural smoothness, but the energy-transfer factor likely doesn't transfer to our pipe-junction context.** That's a concrete input the runner gives us *before* any C++ residual-rewrite work.

## Components

- \`validation/junction/models/mynard2010.py\`: pure-Python port of the Matlab algorithm (110 lines, supplier/collector classification → pseudosupplier reorientation → energy-transfer factor → C → K)
- \`validation/junction/models/mynard_analytical.py\`: \`CorrelationModel\` adapter mapping Bassett K_id ↔ Mynard per-branch K (covers K5, K6, K11, K12 — symmetric 3-branch cases)
- \`python/tests/test_mynard_port.py\`: 7 smoke tests including the Matlab help example, Bassett K6 cross-check, θ=120° smoothness assertion, and adapter coverage matrix

## Test plan

- [x] 7 smoke tests pass; combined with existing validation tests: 98 pass total
- [x] Mynard adapter integrates cleanly with existing \`runner.run()\` and \`scorecard\` pipeline — no infrastructure changes needed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)