### PR TITLE
perf(junction): flip MPCE-v2 Jacobian default to sympy (1.14x speedup, identical conv)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **MPCE-v2 default Jacobian method flipped from ``"fd"`` to ``"sympy"``**
+  (``MPCEv2Element.jacobian_method``). The sympy analytical Jacobian for
+  the canonical 3-port separating T has been wired since the prototype
+  PR but was kept disabled because the iteration-4 commit message
+  noted FD's tiny truncation acting as regularization on some hard
+  low-q mfb_two_pb cases. After the soft-barrier iteration and PR #197
+  joining-side calibration shipped, that empirical concern no longer
+  shows up: a focused audit comparing both methods across the full
+  separating measured grid (Bassett K6 + K5, 105 points x 3 topologies)
+  shows IDENTICAL convergence counts (94/32/11 of 105 across imposed_q
+  / three_pb / mfb_two_pb) and IDENTICAL mean/max K errors, with
+  ~1.14x wall-time speedup from cutting 4 Mynard evaluations to 1 per
+  Newton step on the canonical case. Joining flow and non-canonical
+  geometries (theta != 0 on straight, N != 3, port 0 not supplier)
+  auto-fall-back to FD via the existing canonical-check, so the flip
+  only affects separating canonical cases. Set ``MPCEv2Element.jacobian_method = "fd"``
+  on a per-instance basis to revert.
+
 ### Added
 - **K diagnostics for MPCE-v2 tee element**. ``MPCEv2Element.diagnostics``
   re-evaluates Mynard at the converged state and emits per-port K values

--- a/python/combaero/network/mpce_v2_element.py
+++ b/python/combaero/network/mpce_v2_element.py
@@ -56,14 +56,20 @@ class MPCEv2Element(MultiPortChamberElement):
 
     The ``jacobian_method`` attribute controls how the K*q_dyn term's
     Jacobian is computed:
-      - ``"fd"`` (default): numerical finite-difference on Mynard. Costs N+1
-        Mynard evaluations per residual call. Empirically slightly more
-        robust on mfb_two_pb due to FD's tiny truncation acting as
-        regularization for Newton's step.
-      - ``"sympy"``: analytical sympy-derived Jacobian for the canonical
-        3-port separating T. Faster (no Mynard perturbations) but the
-        exact derivative leads to more aggressive Newton steps that can
-        overshoot in some low-q mfb_two_pb cases.
+      - ``"sympy"`` (default): analytical sympy-derived Jacobian for the
+        canonical 3-port separating T (1 supplier on port 0, straight at
+        0 deg, branch at theta_branch). Uses 1 Mynard evaluation per
+        residual call. Non-canonical topologies (joining, theta != 0 on
+        the straight arm, N != 3) auto-fall-back to FD because the
+        sympy derivation is specific to the canonical case. Validated on
+        the separating K6 / K5 audit: identical convergence + accuracy
+        vs FD with ~1.14x wall-time speedup.
+      - ``"fd"``: numerical finite-difference on Mynard. Costs N+1
+        Mynard evaluations per residual call. Always available across
+        all topologies. The previous default; flipped to sympy in PR
+        adding GUI solver tweaks once the empirical "fd is more robust
+        on mfb_two_pb low-q" concern was found to no longer apply at
+        the post-soft-barrier audit point.
 
     ``flow_direction`` constrains which physical flow regime this element
     represents:
@@ -74,7 +80,7 @@ class MPCEv2Element(MultiPortChamberElement):
         on observed joining flow.
     """
 
-    jacobian_method: str = "fd"
+    jacobian_method: str = "sympy"
 
     # Soft-barrier penalty scale used when ``strict=False`` and the observed
     # flow direction disagrees with the declared one. Wraps the


### PR DESCRIPTION
## Summary

Flips `MPCEv2Element.jacobian_method` default `"fd"` → `"sympy"` for the canonical 3-port separating-T case. Cuts the Jacobian cost from N+1=4 Mynard evaluations per Newton step down to 1 — the analytical sympy-derived Jacobian has been wired since PR #192 iteration 4 but was kept disabled out of caution.

## Why now

The original iteration-4 commit kept FD as the default with a docstring note that sympy's exact derivative could overshoot on some low-q mfb_two_pb cases. After the soft-barrier + post-solve filter (iteration 7, PR #192) and the joining-side calibration (PR #197) shipped, that empirical concern doesn't materialise. Focused audit across the full separating measured grid (Bassett K6 + K5, 105 points × 3 topologies):

| Topology | Mode | Conv | Mean err | Max err |
|---|---|---|---|---|
| imposed_q | FD | 94/105 | 0.173 | 0.955 |
| imposed_q | **sympy** | 94/105 | 0.173 | 0.955 |
| three_pb | FD | 32/105 | 0.056 | 0.221 |
| three_pb | **sympy** | 32/105 | 0.056 | 0.221 |
| mfb_two_pb | FD | 11/105 | 0.148 | 0.319 |
| mfb_two_pb | **sympy** | 11/105 | 0.148 | 0.319 |

**Identical conv counts, identical errors. Wall time fd=6.6s → sympy=5.8s (1.14× speedup).**

Speedup is modest on the audit since solver wall time is partially dominated by channel / orifice iteration. Larger gains are expected on Mynard-dense networks typical of the GUI use case (which is why this is bundled with the GUI work).

## Scope

- **Affects only the canonical 3-port separating T**: 1 supplier on port 0, straight at 0°, branch at `theta_branch`. Joining flow and any non-canonical geometries auto-fall-back to FD via the existing `is_canonical_separating_T` check in `residuals()`. Sympy hasn't been derived for joining; FD remains the only path there.
- **Per-instance override**: set `MPCEv2Element.jacobian_method = "fd"` on an individual element to revert.

## Validation

- [x] All 1511 Python tests pass (no regressions)
- [x] `test_mpce_v2_jacobian.py` (10 cases at θ∈[30,120], ψ∈[1,3], q∈[0.2,0.8]) validates sympy matches FD at 1e-3 relative — the new default is already exercised across the parameter range
- [x] Audit script `tmp/audit_jacobian_method.py` (not shipped) confirms identical conv + error
- [x] Docstring updated to reflect new default + reasoning

🤖 Generated with [Claude Code](https://claude.com/claude-code)
