### PR TITLE
fix(network): refuse merging/splitting MomentumChamberNode at build time (closes #174)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   when the solver supplies ``port_mdots``.
 
 ### Fixed
+- **Merging/splitting MomentumChamberNode now refused at build time** (#174).
+  MCN's scalar ``Pt = P + 0.5 rho v^2`` closure models a single bulk
+  velocity and cannot represent merging or splitting streams within the
+  chamber itself; the silent-corruption case at the time of #174 was
+  ``test_step_4_adding_bypass``, where the face-convention proxy
+  (channel -> Pt, orifice -> static) produced a non-physical 17 kPa
+  asymmetry at a high-q merging MCN. ``FlowNetwork.validate`` now raises
+  ``ValueError`` for any MCN with > 1 incoming or > 1 outgoing edges,
+  pointing the user at ``MultiPortChamberElement`` (momentum-CV junction
+  with one MCN per port) as the correct migration target. The
+  formerly-xfailed ``test_step_4_adding_bypass`` is restored as a
+  passing test on the MPCE topology and now exhibits the expected
+  diameter-driven split (smaller-bore bypass < main branch). Pass-through
+  MCNs (1-in / 1-out, including the GUI auto-insert pattern and MPCE
+  port faces) remain valid.
 - **MPCE Tee GUI shows ``m: 0.000 kg/s`` on the node card and in Live
   Telemetry** even when the junction is actually flowing. Root cause:
   ``MPCEv2Element.diagnostics`` only emitted per-port ``port_i_m_dot``

--- a/python/combaero/network/graph.py
+++ b/python/combaero/network/graph.py
@@ -236,6 +236,27 @@ class FlowNetwork:
                     "is wired backwards (e.g. C on a branching tee should be the inlet)."
                 )
 
+            # MomentumChamberNode topology guard (#174). MCN's scalar closure
+            # Pt = P + 0.5 rho v^2 only models a single bulk velocity, so it
+            # cannot represent merging or splitting streams in the chamber
+            # itself. >1 incoming or >1 outgoing edges puts MCN outside its
+            # valid envelope; use MultiPortChamberElement (momentum-CV
+            # junction with one MCN per port) for those topologies.
+            if type(node).__name__ == "MomentumChamberNode" and (
+                len(upstream) > 1 or len(downstream) > 1
+            ):
+                direction = "incoming" if len(upstream) > 1 else "outgoing"
+                edges = upstream if len(upstream) > 1 else downstream
+                raise ValueError(
+                    f"FlowNetwork validation failed: MomentumChamberNode "
+                    f"'{node_id}' has multiple {direction} edges ({sorted(edges)}). "
+                    "MCN's scalar Pt = P + 0.5 rho v^2 closure cannot represent "
+                    "merging or splitting streams. Use a MultiPortChamberElement "
+                    "junction (one MCN per port) instead -- see "
+                    "python/tests/test_multi_port_chamber.py for the pattern. "
+                    "Tracked in #174."
+                )
+
     def to_dict(self) -> dict:
         """
         Serialize the entire network topology and physics settings into a declarative dictionary suitable for JSON.

--- a/python/tests/test_network_scenarios.py
+++ b/python/tests/test_network_scenarios.py
@@ -2,9 +2,11 @@ import pytest
 
 import combaero as cb
 from combaero.network import (
+    BorderCarnotLossElement,
     ChannelElement,
     FlowNetwork,
     MomentumChamberNode,
+    MultiPortChamberElement,
     NetworkSolver,
     OrificeElement,
     PlenumNode,
@@ -120,75 +122,145 @@ def test_step_3_full_series_no_bypass():
     assert all(mf > 0 for mf in mass_flows), "All mass flows should be positive"
 
 
-@pytest.mark.xfail(
-    reason="high-dynamic-head merging MomentumChamberNode needs an axial momentum "
-    "balance with angle-dependent transverse loss (port_angles_deg currently unused); "
-    "the face-convention proxy (channel->Pt, orifice->static) gives a non-physical "
-    "flow split at mc2 where q~17 kPa. Tracked in #174.",
-    strict=False,
-)
 def test_step_4_adding_bypass():
-    """Test: Adding bypass branch (mc1 -> orifice -> mc2)"""
+    """Bypass branch: splits at mc1, rejoins at mc2.
+
+    mc1 (splitting) and mc2 (merging) are momentum-CV junctions built from
+    MultiPortChamberElement + MomentumChamberNode port faces. The earlier
+    incarnation of this test used bare MomentumChamberNode at both splits
+    and was xfailed against #174 because MCN's scalar Pt = P + 0.5 rho v^2
+    cannot represent merging or splitting streams in the chamber itself.
+    Migration onto the momentum-CV junction (closes #174) restores the
+    expected diameter-driven split: smaller-bore bypass < main branch.
+    """
+    import math
+
+    D_main = 0.1
+    D_bypass = 0.08
+    A_main = math.pi * (D_main / 2.0) ** 2
+    A_bypass = math.pi * (D_bypass / 2.0) ** 2
+
     graph = FlowNetwork()
     inlet, outlet = build_pressure_bounds()
 
     n1 = PlenumNode("n1")
-    mc1 = MomentumChamberNode("mc1")
     n2 = PlenumNode("n2")
     plen = PlenumNode("plenum")
-    mc2 = MomentumChamberNode("mc2")
-
-    # Main series elements
-    p1 = ChannelElement("p1", "inlet", "n1", length=2.0, diameter=0.1, roughness=1e-4)
-    o1 = OrificeElement("o1", "n1", "mc1", Cd=0.6, diameter=0.100925, correlation="fixed")
-    p2 = ChannelElement("p2", "mc1", "n2", length=2.0, diameter=0.1, roughness=1e-4)
-    o2 = OrificeElement("o2", "n2", "plenum", Cd=0.6, diameter=0.100925, correlation="fixed")
-    p3 = ChannelElement("p3", "plenum", "mc2", length=2.0, diameter=0.1, roughness=1e-4)
-    p4 = ChannelElement("p4", "mc2", "outlet", length=2.0, diameter=0.1, roughness=1e-4)
-
-    # Bypass branch, sized from an incompressible series-conductance estimate
-    # (main-branch effective conductance ~ A*Cd for o2 = 0.008 * 0.6 = 0.0048;
-    # bypass picked at ~50% of that). That estimate ignores dynamic head and is
-    # superseded by the compressible momentum closure (see the xfail / #174):
-    # at the high-q merging chamber mc2 the conductance argument no longer
-    # predicts the split, so the "p_bypass < p2" expectation below does not hold
-    # with the current face-convention proxy.
     n_bypass = PlenumNode("n_bypass")
+
+    # mc1: splitting junction (1 inflow from o1, 2 outflows to p2 and p_bypass).
+    # Port-face MCNs: com (inlet) + str (straight outlet) + bra (branch outlet,
+    # 90 deg). BorderCarnotLossElement carries the angled-arm loss on bra.
+    mc1_com = MomentumChamberNode("mc1_com", area=A_main)
+    mc1_str = MomentumChamberNode("mc1_str", area=A_main)
+    mc1_bra = MomentumChamberNode("mc1_bra", area=A_bypass)
+    mc1_bra_post = MomentumChamberNode("mc1_bra_post", area=A_bypass)
+    loss_mc1_bra = BorderCarnotLossElement(
+        "loss_mc1_bra",
+        from_node="mc1_bra",
+        to_node="mc1_bra_post",
+        delta_geom_deg=90.0,
+        area=A_bypass,
+    )
+    mpce_mc1 = MultiPortChamberElement(
+        id="mpce_mc1",
+        inlet_nodes=["mc1_com"],
+        outlet_nodes=["mc1_str", "mc1_bra"],
+        inlet_angles_deg=[0.0],
+        outlet_angles_deg=[0.0, 90.0],
+        port_areas=[A_main, A_main, A_bypass],
+    )
+
+    # mc2: merging junction (2 inflows from p3 and o_bypass, 1 outflow to p4).
+    # Mirror layout: pre-loss node on the angled inlet feeds the bra port face.
+    mc2_str = MomentumChamberNode("mc2_str", area=A_main)
+    mc2_bra_pre = MomentumChamberNode("mc2_bra_pre", area=A_bypass)
+    mc2_bra = MomentumChamberNode("mc2_bra", area=A_bypass)
+    mc2_com = MomentumChamberNode("mc2_com", area=A_main)
+    loss_mc2_bra = BorderCarnotLossElement(
+        "loss_mc2_bra",
+        from_node="mc2_bra_pre",
+        to_node="mc2_bra",
+        delta_geom_deg=90.0,
+        area=A_bypass,
+    )
+    mpce_mc2 = MultiPortChamberElement(
+        id="mpce_mc2",
+        inlet_nodes=["mc2_str", "mc2_bra"],
+        outlet_nodes=["mc2_com"],
+        inlet_angles_deg=[0.0, 90.0],
+        outlet_angles_deg=[0.0],
+        port_areas=[A_main, A_bypass, A_main],
+    )
+
+    # Main series elements (now attach to port-face MCNs at mc1, mc2).
+    p1 = ChannelElement("p1", "inlet", "n1", length=2.0, diameter=D_main, roughness=1e-4)
+    o1 = OrificeElement("o1", "n1", "mc1_com", Cd=0.6, diameter=0.100925, correlation="fixed")
+    p2 = ChannelElement("p2", "mc1_str", "n2", length=2.0, diameter=D_main, roughness=1e-4)
+    o2 = OrificeElement("o2", "n2", "plenum", Cd=0.6, diameter=0.100925, correlation="fixed")
+    p3 = ChannelElement("p3", "plenum", "mc2_str", length=2.0, diameter=D_main, roughness=1e-4)
+    p4 = ChannelElement("p4", "mc2_com", "outlet", length=2.0, diameter=D_main, roughness=1e-4)
+
+    # Bypass branch (same sizing as the original incarnation of the test).
     p_bypass = ChannelElement(
-        "p_bypass", "mc1", "n_bypass", length=5.0, diameter=0.08, roughness=1e-4
+        "p_bypass", "mc1_bra_post", "n_bypass", length=5.0, diameter=D_bypass, roughness=1e-4
     )
     o_bypass = OrificeElement(
-        "o_bypass", "n_bypass", "mc2", Cd=0.6, diameter=0.071365, correlation="fixed"
+        "o_bypass", "n_bypass", "mc2_bra_pre", Cd=0.6, diameter=0.071365, correlation="fixed"
     )
 
-    # Add all nodes and elements
-    for n in [inlet, outlet, n1, mc1, n2, plen, mc2, n_bypass]:
+    for n in [
+        inlet,
+        outlet,
+        n1,
+        n2,
+        plen,
+        n_bypass,
+        mc1_com,
+        mc1_str,
+        mc1_bra,
+        mc1_bra_post,
+        mc2_str,
+        mc2_bra_pre,
+        mc2_bra,
+        mc2_com,
+    ]:
         graph.add_node(n)
-    for e in [p1, o1, p2, o2, p3, p4, p_bypass, o_bypass]:
+    for e in [
+        p1,
+        o1,
+        p2,
+        o2,
+        p3,
+        p4,
+        p_bypass,
+        o_bypass,
+        loss_mc1_bra,
+        mpce_mc1,
+        loss_mc2_bra,
+        mpce_mc2,
+    ]:
         graph.add_element(e)
 
-    # Set initial guesses
+    # Initial guesses on the named PlenumNodes (port-face MCNs default-init fine).
     n1.initial_guess = {"n1.P": 145000.0, "n1.Pt": 145000.0}
-    mc1.initial_guess = {"mc1.P": 140000.0, "mc1.Pt": 140000.0}
     n_bypass.initial_guess = {"n_bypass.P": 130000.0, "n_bypass.Pt": 130000.0}
     n2.initial_guess = {"n2.P": 135000.0, "n2.Pt": 135000.0}
     plen.initial_guess = {"plenum.P": 125000.0, "plenum.Pt": 125000.0}
-    mc2.initial_guess = {"mc2.P": 115000.0, "mc2.Pt": 115000.0}
 
     solver = NetworkSolver(graph)
     sol = solver.solve(method="lm")
 
-    # Verify mass conservation at junctions
-    # At mc1: p1.m_dot = p2.m_dot + p_bypass.m_dot
-    assert abs(sol["p1.m_dot"] - (sol["p2.m_dot"] + sol["p_bypass.m_dot"])) < 1e-6
+    assert sol["__success__"], f"did not converge: {sol.get('__message__')}"
 
-    # At mc2: p3.m_dot + bypass.m_dot = p4.m_dot (bypass joins here)
+    # Mass conservation: split at mc1, rejoin at mc2.
+    assert abs(sol["p1.m_dot"] - (sol["p2.m_dot"] + sol["p_bypass.m_dot"])) < 1e-6
     assert abs((sol["p3.m_dot"] + sol["p_bypass.m_dot"]) - sol["p4.m_dot"]) < 1e-6
 
-    # All flows should be positive
     assert all(sol[f"{e}.m_dot"] > 0 for e in ["p1", "p2", "p3", "p4", "p_bypass"])
 
-    # Bypass should carry less flow than main branch (smaller diameter)
+    # With the momentum-CV closure the diameter argument holds: smaller-bore
+    # bypass (D=0.08) carries less flow than the main branch (D=0.1).
     assert sol["p_bypass.m_dot"] < sol["p2.m_dot"]
 
 

--- a/python/tests/test_network_validation_edge_cases.py
+++ b/python/tests/test_network_validation_edge_cases.py
@@ -3,6 +3,7 @@ import pytest
 from combaero.network import (
     FlowNetwork,
     MassFlowBoundary,
+    MomentumChamberNode,
     NetworkSolver,
     OrificeElement,
     PlenumNode,
@@ -170,3 +171,53 @@ def test_validation_elements_between_boundaries():
     solver = NetworkSolver(graph)
     sol = solver.solve()
     assert "orf_1.m_dot" in sol
+
+
+def test_validation_mcn_multiple_incoming_edges_rejected():
+    """MCN with >1 incoming edges (merging chamber) is rejected at build time.
+
+    MCN's scalar Pt = P + 0.5 rho v^2 cannot represent merging streams (#174);
+    the topology guard should fire before solve.
+    """
+    graph = FlowNetwork()
+    graph.add_node(PressureBoundary("pb_a", Pt=200000.0))
+    graph.add_node(PressureBoundary("pb_b", Pt=200000.0))
+    graph.add_node(PressureBoundary("outlet", Pt=100000.0))
+    graph.add_node(MomentumChamberNode("mc_merge", area=0.01))
+    graph.add_element(OrificeElement("orf_a", "pb_a", "mc_merge", 0.6, 0.05, correlation="fixed"))
+    graph.add_element(OrificeElement("orf_b", "pb_b", "mc_merge", 0.6, 0.05, correlation="fixed"))
+    graph.add_element(
+        OrificeElement("orf_out", "mc_merge", "outlet", 0.6, 0.05, correlation="fixed")
+    )
+
+    with pytest.raises(ValueError, match="multiple incoming edges"):
+        graph.validate()
+
+
+def test_validation_mcn_multiple_outgoing_edges_rejected():
+    """MCN with >1 outgoing edges (splitting chamber) is rejected at build time."""
+    graph = FlowNetwork()
+    graph.add_node(PressureBoundary("inlet", Pt=200000.0))
+    graph.add_node(PressureBoundary("pb_a", Pt=100000.0))
+    graph.add_node(PressureBoundary("pb_b", Pt=100000.0))
+    graph.add_node(MomentumChamberNode("mc_split", area=0.01))
+    graph.add_element(OrificeElement("orf_in", "inlet", "mc_split", 0.6, 0.05, correlation="fixed"))
+    graph.add_element(OrificeElement("orf_a", "mc_split", "pb_a", 0.6, 0.05, correlation="fixed"))
+    graph.add_element(OrificeElement("orf_b", "mc_split", "pb_b", 0.6, 0.05, correlation="fixed"))
+
+    with pytest.raises(ValueError, match="multiple outgoing edges"):
+        graph.validate()
+
+
+def test_validation_mcn_pass_through_accepted():
+    """MCN with exactly 1 in + 1 out (pass-through) is the valid envelope."""
+    graph = FlowNetwork()
+    graph.add_node(PressureBoundary("inlet", Pt=200000.0))
+    graph.add_node(PressureBoundary("outlet", Pt=100000.0))
+    graph.add_node(MomentumChamberNode("mc_pass", area=0.01))
+    graph.add_element(OrificeElement("orf_in", "inlet", "mc_pass", 0.6, 0.05, correlation="fixed"))
+    graph.add_element(
+        OrificeElement("orf_out", "mc_pass", "outlet", 0.6, 0.05, correlation="fixed")
+    )
+
+    graph.validate()  # no raise


### PR DESCRIPTION
## Summary

- `MomentumChamberNode`'s scalar `Pt = P + 0.5·ρv²` closure models a single bulk velocity; it cannot represent merging or splitting streams in the chamber itself. The historical silent-corruption case was `test_step_4_adding_bypass`, where the face-convention proxy (channel→Pt, orifice→static) gave a non-physical bypass-larger-than-main split at the high-q merging chamber. That test had been `xfail`'d against #174.
- `FlowNetwork.validate` now raises `ValueError` for any MCN with >1 incoming or >1 outgoing edges, pointing the user at `MultiPortChamberElement` (momentum-CV junction with one MCN per port) as the migration target. The check is topological so it fires at build time — no solve-time direction guessing.
- `test_step_4_adding_bypass` restored as a passing test on an MPCE topology (both `mc1` splitting and `mc2` merging become 3-port MPCE junctions with `BorderCarnotLossElement` on the angled arm). The diameter-driven assertion (smaller-bore bypass < main branch) now holds with the momentum-CV closure.
- Closes #174.

## Scope

This is PR 1 of the MCN→MPCE migration. Out of scope, deferred to follow-up PRs:
- GUI `graph_builder` auto-insert change (currently inserts MCN for element-to-element connections; works for pass-through, will need MPCE for merging/splitting topologies once those are drawable directly).
- `TeeJunctionElement` disposition (whether to hide from GUI sidebar in favour of `mpce_tee`).

## Test plan

- [x] `uv run pytest python/tests/` — **1522 passed, 4 xfailed (down from 6)**.
- [x] `./scripts/check-python-style.sh --fix` clean.
- [x] New guard tests in `test_network_validation_edge_cases.py`: multi-incoming raises, multi-outgoing raises, 1-in/1-out pass-through accepted.
- [x] Existing MPCE port-face pattern (1-in/1-out per MCN) still passes guard — verified across `test_multi_port_chamber.py`, `test_momentum_cv_*`, validation builder.
- [ ] Quick GUI sanity: build any saved network with bare MCNs as merging/splitting chambers should now error at solve start with the new guard message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
