### PR TITLE
fix(network): MPCE ports report real throughflow to state propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   when the solver supplies ``port_mdots``.
 
 ### Fixed
+- **MultiPortChamberElement ports now report their real throughflow to the
+  solver's state propagation.** ``flow_at_node`` returned 0 "for safety",
+  so every port-MCN fed by the junction (all collector/outflow ports)
+  received zero-mass upstream streams. Three consequences, all fixed:
+  (1) the collector-port MCN closure ``Pt = P + 0.5 rho v^2`` silently
+  degenerated to ``Pt = P`` -- the outflow dynamic head (~29 kPa for
+  0.4 kg/s through a 5 cm port at 1 bar) vanished from the bookkeeping,
+  and MPCE-v2's Mynard residual received a static pressure where its
+  design expects the port stagnation pressure; (2) merging streams with
+  unequal temperatures mixed with all-zero weights, so the outlet
+  temperature snapped to the FIRST inlet stream's value (a 0.3 kg/s @
+  400 K + 0.1 kg/s @ 300 K merge reported 400 K instead of the
+  enthalpy-weighted ~375 K) -- previously masked because all junction
+  tests are isothermal; (3) the degenerate closure made non-physical
+  network states exactly satisfiable (dead-branch / reversed-supply roots
+  at |F| ~ 1e-7). Ports now resolve their outer connecting elements'
+  ``m_dot`` unknowns via an index map stashed by ``NetworkSolver`` at
+  unknown-vector build time; supplier ports and single-supplier
+  collectors carry their own outer flow, multi-supplier collectors the
+  sum of the supplier feeds, with matching ``flow_jac_at_node`` entries
+  so the closure Jacobian stays consistent. Additionally,
+  ``MultiPortChamberElement.resolve_topology`` pushes inferred port areas
+  onto auto-sized port-MCNs (collector ports have no upstream channel to
+  inherit ``Dh`` from and previously kept the 0.1 m^2 fallback, hiding
+  the face velocity even when flows were known). Converged results for
+  MPCE networks shift by the collector dynamic head; junction loss
+  calibrations (e.g. MPCE-v2 ``joining_etransfer_alpha``) were fitted on
+  the degenerate plumbing and should be revisited against the validation
+  suite. Known consequence: with honest collector stagnation pressures,
+  the v1 impulse rows (``sin^2(theta)`` per-port form, Bassett
+  correspondence derived for separating flow) are energetically
+  inconsistent for JOINING flow -- a v1 merge junction can manufacture
+  flow work and may lose its all-forward root entirely.
+  ``test_step_4_adding_bypass`` migrated its junctions to
+  ``MPCEv2Element`` (the production model, joining-capable by design);
+  the v1 vs K-closure comparison test now seeds the forward basin
+  explicitly since v1's sign-symmetric residuals admit the mirrored
+  all-reverse root from a cold start.
 - **Merging/splitting MomentumChamberNode now refused at build time** (#174).
   MCN's scalar ``Pt = P + 0.5 rho v^2`` closure models a single bulk
   velocity and cannot represent merging or splitting streams within the

--- a/python/combaero/network/components.py
+++ b/python/combaero/network/components.py
@@ -3026,7 +3026,10 @@ class MultiPortChamberElement(NetworkElement):
       same flow with opposite sign).
     - Exactly one element (channel, loss element, etc.) must connect to each
       port-MCN on the outside. Its m_dot is the port's mass-flow source; the
-      junction reads it via the graph at residual-eval time.
+      junction reads it via the graph at residual-eval time, and reports it
+      back through ``flow_at_node`` so the state propagation gives every
+      port-MCN its real face flow (collector ports would otherwise see zero
+      and their Pt = P + 0.5*rho*v^2 closure would degenerate to Pt = P).
     - Sign convention per port is fixed by the inlet/outlet declaration in
       the constructor. ``inlet_nodes`` carry sign ``-1`` (canonical flow INTO
       junction); ``outlet_nodes`` carry sign ``+1`` (canonical flow OUT). The
@@ -3133,13 +3136,52 @@ class MultiPortChamberElement(NetworkElement):
         # Outlet ports = nodes the junction delivers flow TO.
         return list(self.outlet_nodes)
 
+    def _port_throughflow_terms(self, node_id: str) -> list[tuple[str, float]]:
+        """Outer-element terms whose weighted sum is the junction throughflow
+        at ``node_id`` (positive = canonical direction through the port).
+
+        Supplier (inlet) ports and collector ports of a single-supplier
+        junction carry exactly their own outer element's flow. A collector
+        of a multi-supplier junction (e.g. merge tee outlet) receives the
+        sum of the supplier feeds -- consistent with how the solver's state
+        propagation composes the collector's total flow from one stream per
+        supplier port.
+        """
+        if node_id not in self.port_nodes:
+            return []
+        i = self.port_nodes.index(node_id)
+        if self._port_signs[i] < 0 or len(self.inlet_nodes) == 1:
+            return [(self._port_element_ids[i], 1.0)]
+        return [(self._port_element_ids[j], 1.0) for j in range(self.N) if self._port_signs[j] < 0]
+
     def flow_at_node(self, node_id: str, x: Any, indices: list[int]) -> float:
-        # We never actually contribute to a port-MCN's mass row (solver skips
-        # it via _is_junction_port). Return 0 for safety if asked.
-        return 0.0
+        # Port-MCN mass rows are skipped by the solver (_is_junction_port);
+        # this is consumed by the state propagation instead, so collector-port
+        # MCNs see their real face flow in the Pt = P + 0.5*rho*v^2 closure
+        # and mix upstream streams with true mass weights. `indices` are this
+        # element's own unknowns (P_jct); the port flows live on the outer
+        # elements, resolved via the _port_outer_mdot_idx map the solver
+        # stashes when it builds the unknown vector.
+        idx_map = getattr(self, "_port_outer_mdot_idx", None)
+        if not idx_map:
+            return 0.0
+        total = 0.0
+        for outer_id, coeff in self._port_throughflow_terms(node_id):
+            global_idx = idx_map.get(outer_id)
+            if global_idx is not None:
+                total += coeff * float(x[global_idx])
+        return total
 
     def flow_jac_at_node(self, node_id: str, indices: list[int]) -> dict[int, float]:
-        return {}
+        idx_map = getattr(self, "_port_outer_mdot_idx", None)
+        if not idx_map:
+            return {}
+        jac: dict[int, float] = {}
+        for outer_id, coeff in self._port_throughflow_terms(node_id):
+            global_idx = idx_map.get(outer_id)
+            if global_idx is not None:
+                jac[global_idx] = jac.get(global_idx, 0.0) + coeff
+        return jac
 
     def resolve_topology(self, graph: "FlowNetwork") -> None:
         # 1. For each port: locate the (unique) connecting element on the
@@ -3220,6 +3262,21 @@ class MultiPortChamberElement(NetworkElement):
                     f"area at port '{port_id}'. Provide port_areas explicitly "
                     f"or attach a ChannelElement with diameter set."
                 )
+
+            # 3. Give auto-sized port-MCNs a real flow area. Nodes resolve
+            #    before elements (FlowNetwork.resolve_all_topology), and a
+            #    collector port has no upstream channel to inherit Dh from,
+            #    so it would otherwise keep MomentumChamberNode's 0.1 m^2
+            #    fallback and its Pt = P + 0.5*rho*v^2 closure would see a
+            #    near-zero face velocity. Mirrors the MCN auto path (Dh ->
+            #    area, surface.area) exactly so a later node-resolve pass is
+            #    idempotent and collector ports match what inlet ports
+            #    already get from upstream-channel Dh inheritance.
+            if port_node._auto_area and port_node.Dh is None:
+                area_i = float(self.port_areas[i])
+                port_node.Dh = 2.0 * math.sqrt(area_i / math.pi)
+                port_node.area = area_i
+                port_node.surface.area = area_i
 
     def residuals(
         self, states: list[NetworkMixtureState], P_jct: float, port_mdots: list[float]

--- a/python/combaero/network/solver.py
+++ b/python/combaero/network/solver.py
@@ -558,6 +558,22 @@ class NetworkSolver:
         # Build name to index mapping
         self._name_to_index = {name: i for i, name in enumerate(self.unknown_names)}
 
+        # MultiPortChamberElement ports carry their throughflow on the outer
+        # connecting elements' m_dot unknowns. Stash the resolved global
+        # indices on each junction so flow_at_node / flow_jac_at_node can
+        # report real port flows during state propagation: collector-port
+        # MCNs need them for the Pt = P + 0.5*rho*v^2 closure and for
+        # mass-weighted mixing of merging streams.
+        from .components import MultiPortChamberElement as _MPCElem
+
+        for element in self.network.elements.values():
+            if isinstance(element, _MPCElem):
+                element._port_outer_mdot_idx = {
+                    outer_id: self._name_to_index[f"{outer_id}.m_dot"]
+                    for outer_id in element._port_element_ids
+                    if f"{outer_id}.m_dot" in self._name_to_index
+                }
+
         # Pre-compute topological order for forward state propagation
         self._topological_order = self._compute_topological_order()
 

--- a/python/tests/test_momentum_cv_vs_tee.py
+++ b/python/tests/test_momentum_cv_vs_tee.py
@@ -154,7 +154,18 @@ def test_both_models_give_forward_dominant_inlet_flow():
     physically valid).
     """
     v3_sol = NetworkSolver(_v3_branching_net_direct()).solve()
-    mp_sol = NetworkSolver(_mpce_branching_net()).solve()
+
+    # MPCE's residual set is even in the mass flows apart from the linear
+    # mass row, so the network is symmetric under a global sign flip: the
+    # all-forward root and its mirrored all-reverse image are equally exact,
+    # and the default cold start may land either. Seed the forward basin
+    # explicitly -- this test compares the models' forward solutions, it
+    # does not test cold-start basin selection.
+    mp_net = _mpce_branching_net()
+    mp_net.elements["lc_com"].initial_guess = {"lc_com.m_dot": 0.4}
+    mp_net.elements["lc_str"].initial_guess = {"lc_str.m_dot": 0.25}
+    mp_net.elements["lc_bra"].initial_guess = {"lc_bra.m_dot": 0.15}
+    mp_sol = NetworkSolver(mp_net).solve()
 
     assert v3_sol["__success__"], f"v3 did not converge: {v3_sol.get('__message__')}"
     assert mp_sol["__success__"], f"MPCE did not converge: {mp_sol.get('__message__')}"

--- a/python/tests/test_network_compressible.py
+++ b/python/tests/test_network_compressible.py
@@ -624,6 +624,149 @@ def test_analytical_pt_prop_rescues_cold_stuck_case():
     )
 
 
+def _mpce_mfb_merge_network(theta_deg: float = 45.0) -> FlowNetwork:
+    """MFB-driven 3-port merge tee with unequal supply temperatures.
+
+    Mass-flow boundaries impose the flow direction, so the solve lands the
+    physical basin deterministically -- suitable for closure/mixing
+    regression tests independent of basin selection.
+    """
+    diameter = 0.05
+    A = math.pi * (diameter / 2.0) ** 2
+    net = FlowNetwork()
+    net.add_node(MassFlowBoundary("mfb_hot", m_dot=0.3, Tt=400.0))
+    net.add_node(MassFlowBoundary("mfb_cold", m_dot=0.1, Tt=300.0))
+    net.add_node(PressureBoundary("pb_out", Pt=100000.0, Tt=300.0))
+    net.add_node(MomentumChamberNode("mc_str", area=A))
+    net.add_node(MomentumChamberNode("mc_bra", area=A))
+    net.add_node(MomentumChamberNode("mc_com", area=A))
+    net.add_element(
+        ChannelElement(
+            "ch_hot", "mfb_hot", "mc_str", length=1.0, diameter=diameter, regime="compressible"
+        )
+    )
+    net.add_element(
+        ChannelElement(
+            "ch_cold", "mfb_cold", "mc_bra", length=1.0, diameter=diameter, regime="compressible"
+        )
+    )
+    net.add_element(
+        ChannelElement(
+            "ch_out", "mc_com", "pb_out", length=1.0, diameter=diameter, regime="compressible"
+        )
+    )
+    net.add_element(
+        MultiPortChamberElement(
+            id="jct",
+            inlet_nodes=["mc_str", "mc_bra"],
+            outlet_nodes=["mc_com"],
+            inlet_angles_deg=[0.0, theta_deg],
+            outlet_angles_deg=[0.0],
+            port_areas=[A, A, A],
+        )
+    )
+    return net
+
+
+def test_mpce_collector_port_carries_dynamic_head():
+    """Collector-port MCNs must see their real face flow in the
+    Pt = P + 0.5*rho*v^2 closure.
+
+    Before the throughflow fix, MultiPortChamberElement.flow_at_node
+    returned 0, so any port fed by the junction had _total_m_dot = 0 and
+    its closure silently degenerated to Pt = P -- the outflow dynamic head
+    (tens of kPa at these conditions) vanished from the bookkeeping.
+    """
+    net = _mpce_mfb_merge_network()
+    solver = NetworkSolver(net)
+    sol = solver.solve(timeout=120.0)
+    assert sol["__final_norm__"] < 1e-3
+
+    node = net.nodes["mc_com"]
+    m_out = sol["ch_out.m_dot"]
+    assert m_out == pytest.approx(0.4, abs=1e-4)
+    assert node._total_m_dot == pytest.approx(m_out, rel=1e-6)
+
+    T_com, _, _ = solver._derived_states["mc_com"]
+    rho = cb.density(T_com, sol["mc_com.P"], cb.species.dry_air())
+    A = node.area
+    q_expected = 0.5 * rho * (m_out / (rho * A)) ** 2
+    q_solved = sol["mc_com.Pt"] - sol["mc_com.P"]
+    assert q_solved > 1e3, "collector dynamic head must not degenerate to zero"
+    assert q_solved == pytest.approx(q_expected, rel=1e-4)
+
+
+def test_mpce_merge_outlet_temperature_mass_weighted():
+    """Merging streams with unequal temperatures must mix mass-weighted.
+
+    Before the throughflow fix, all streams through the junction carried
+    m_dot = 0, so the mixer fell back to the FIRST stream's temperature:
+    the outlet of a 0.3 kg/s @ 400 K + 0.1 kg/s @ 300 K merge reported
+    400 K instead of the enthalpy-weighted ~375 K.
+    """
+    net = _mpce_mfb_merge_network()
+    solver = NetworkSolver(net)
+    sol = solver.solve(timeout=120.0)
+    assert sol["__final_norm__"] < 1e-3
+
+    T_com, _, _ = solver._derived_states["mc_com"]
+    assert T_com == pytest.approx(375.1, abs=2.0)
+    assert abs(T_com - 400.0) > 20.0, "outlet T stuck at first-stream value"
+
+
+def test_mpce_collector_port_mcn_inherits_area():
+    """Auto-sized collector-port MCNs inherit the junction port area.
+
+    Nodes resolve before elements, and a collector port has no upstream
+    channel to inherit Dh from, so MomentumChamberNode.resolve_topology
+    leaves it at the 0.1 m^2 fallback; MultiPortChamberElement.resolve_
+    topology must then push the inferred port area onto it, otherwise the
+    Pt closure sees a near-zero face velocity.
+    """
+    D_main, D_bra = 0.05, 0.04
+    net = FlowNetwork()
+    net.add_node(PressureBoundary("pb_hi", Pt=150000.0, Tt=300.0))
+    net.add_node(PressureBoundary("pb_lo_str", Pt=100000.0, Tt=300.0))
+    net.add_node(PressureBoundary("pb_lo_bra", Pt=100000.0, Tt=300.0))
+    net.add_node(MomentumChamberNode("mc_com"))
+    net.add_node(MomentumChamberNode("mc_str"))
+    net.add_node(MomentumChamberNode("mc_bra"))
+    net.add_element(
+        ChannelElement(
+            "ch_in", "pb_hi", "mc_com", length=1.0, diameter=D_main, regime="compressible"
+        )
+    )
+    net.add_element(
+        ChannelElement(
+            "ch_str", "mc_str", "pb_lo_str", length=1.0, diameter=D_main, regime="compressible"
+        )
+    )
+    net.add_element(
+        ChannelElement(
+            "ch_bra", "mc_bra", "pb_lo_bra", length=1.0, diameter=D_bra, regime="compressible"
+        )
+    )
+    net.add_element(
+        MultiPortChamberElement(
+            id="jct",
+            inlet_nodes=["mc_com"],
+            outlet_nodes=["mc_str", "mc_bra"],
+            inlet_angles_deg=[0.0],
+            outlet_angles_deg=[0.0, 45.0],
+        )
+    )
+    net.resolve_all_topology()
+
+    A_main = math.pi * (D_main / 2.0) ** 2
+    A_bra = math.pi * (D_bra / 2.0) ** 2
+    # Inlet port: pre-existing inheritance via upstream channel Dh.
+    assert net.nodes["mc_com"].area == pytest.approx(A_main, rel=1e-12)
+    # Collector ports: inherited through the junction's port areas.
+    assert net.nodes["mc_str"].area == pytest.approx(A_main, rel=1e-12)
+    assert net.nodes["mc_bra"].area == pytest.approx(A_bra, rel=1e-12)
+    assert net.nodes["mc_bra"].Dh == pytest.approx(D_bra, rel=1e-12)
+
+
 def test_analytical_pt_prop_rejects_unknown_strategy_name():
     net = FlowNetwork()
     net.add_node(PressureBoundary("in", Pt=200000.0, Tt=300.0))

--- a/python/tests/test_network_scenarios.py
+++ b/python/tests/test_network_scenarios.py
@@ -6,7 +6,6 @@ from combaero.network import (
     ChannelElement,
     FlowNetwork,
     MomentumChamberNode,
-    MultiPortChamberElement,
     NetworkSolver,
     OrificeElement,
     PlenumNode,
@@ -126,14 +125,25 @@ def test_step_4_adding_bypass():
     """Bypass branch: splits at mc1, rejoins at mc2.
 
     mc1 (splitting) and mc2 (merging) are momentum-CV junctions built from
-    MultiPortChamberElement + MomentumChamberNode port faces. The earlier
-    incarnation of this test used bare MomentumChamberNode at both splits
-    and was xfailed against #174 because MCN's scalar Pt = P + 0.5 rho v^2
-    cannot represent merging or splitting streams in the chamber itself.
-    Migration onto the momentum-CV junction (closes #174) restores the
-    expected diameter-driven split: smaller-bore bypass < main branch.
+    MPCEv2Element + MomentumChamberNode port faces. The earlier incarnation
+    of this test used bare MomentumChamberNode at both splits and was
+    xfailed against #174 because MCN's scalar Pt = P + 0.5 rho v^2 cannot
+    represent merging or splitting streams in the chamber itself. Migration
+    onto the momentum-CV junction (closes #174) restores the expected
+    diameter-driven split: smaller-bore bypass < main branch.
+
+    The junctions are the Mynard-based MPCEv2Element rather than the v1
+    impulse MultiPortChamberElement: once collector ports carry their real
+    face flow (honest Pt = P + 0.5 rho v^2 closure), v1's per-port
+    sin^2(theta) impulse rows -- whose Bassett correspondence is derived
+    for separating flow -- create flow work out of nothing at a joining
+    junction, and the rejoin at mc2 has no energetically consistent
+    all-forward root. MPCEv2's stagnation-pressure residual handles
+    joining natively and converges from the default cold start.
     """
     import math
+
+    from combaero.network.mpce_v2_element import MPCEv2Element
 
     D_main = 0.1
     D_bypass = 0.08
@@ -162,13 +172,15 @@ def test_step_4_adding_bypass():
         delta_geom_deg=90.0,
         area=A_bypass,
     )
-    mpce_mc1 = MultiPortChamberElement(
+    mpce_mc1 = MPCEv2Element(
         id="mpce_mc1",
         inlet_nodes=["mc1_com"],
         outlet_nodes=["mc1_str", "mc1_bra"],
         inlet_angles_deg=[0.0],
         outlet_angles_deg=[0.0, 90.0],
         port_areas=[A_main, A_main, A_bypass],
+        flow_direction="branch",
+        strict=False,
     )
 
     # mc2: merging junction (2 inflows from p3 and o_bypass, 1 outflow to p4).
@@ -184,13 +196,15 @@ def test_step_4_adding_bypass():
         delta_geom_deg=90.0,
         area=A_bypass,
     )
-    mpce_mc2 = MultiPortChamberElement(
+    mpce_mc2 = MPCEv2Element(
         id="mpce_mc2",
         inlet_nodes=["mc2_str", "mc2_bra"],
         outlet_nodes=["mc2_com"],
         inlet_angles_deg=[0.0, 90.0],
         outlet_angles_deg=[0.0],
         port_areas=[A_main, A_bypass, A_main],
+        flow_direction="merge",
+        strict=False,
     )
 
     # Main series elements (now attach to port-face MCNs at mc1, mc2).
@@ -256,6 +270,10 @@ def test_step_4_adding_bypass():
     # Mass conservation: split at mc1, rejoin at mc2.
     assert abs(sol["p1.m_dot"] - (sol["p2.m_dot"] + sol["p_bypass.m_dot"])) < 1e-6
     assert abs((sol["p3.m_dot"] + sol["p_bypass.m_dot"]) - sol["p4.m_dot"]) < 1e-6
+
+    # Diameter-driven split: forward bypass flow, smaller than the main branch.
+    assert sol["p_bypass.m_dot"] > 0.0
+    assert sol["p2.m_dot"] > sol["p_bypass.m_dot"]
 
     assert all(sol[f"{e}.m_dot"] > 0 for e in ["p1", "p2", "p3", "p4", "p_bypass"])
 


### PR DESCRIPTION
## Summary

Fixes Finding 2 from the MPCE tee solver review: `MultiPortChamberElement.flow_at_node` returned 0 "for safety", so every port-MCN fed by the junction (all collector/outflow ports) received zero-mass upstream streams from the solver's state propagation. Three consequences, all fixed:

1. **Degenerate collector closure**: the collector-port MCN's `Pt = P + 0.5*rho*v^2` closure silently collapsed to `Pt = P` — the outflow dynamic head (~29 kPa for 0.4 kg/s through a 5 cm port at 1 bar) vanished from the bookkeeping. MPCE-v2's Mynard residual received a *static* pressure where its design expects the port *stagnation* pressure.
2. **Broken temperature mixing**: merging streams mixed with all-zero weights, so the outlet snapped to the FIRST inlet stream's temperature (0.3 kg/s @ 400 K + 0.1 kg/s @ 300 K reported 400 K instead of the enthalpy-weighted ~375 K). Masked until now because all junction tests are isothermal.
3. **Exact spurious roots**: the degenerate closure made non-physical states exactly satisfiable (dead-branch / reversed-supply roots at `|F| ~ 1e-7`; companion fix for the choked-channel side is #211).

## Fix

- `flow_at_node` / `flow_jac_at_node` resolve the outer connecting elements' `m_dot` unknowns via `_port_outer_mdot_idx`, stashed by `NetworkSolver._build_x0` once the name-to-index map exists. Supplier ports and single-supplier collectors carry their own outer flow; multi-supplier collectors the sum of the supplier feeds — matching how `_propagate_states` composes the collector's `_total_m_dot` from one stream per supplier, so residual and Jacobian stay consistent.
- `MultiPortChamberElement.resolve_topology` pushes inferred port areas (`Dh`, `area`, `surface.area`, mirroring the MCN auto path) onto auto-sized port-MCNs. Collector ports have no upstream channel to inherit `Dh` from and previously kept the 0.1 m² fallback — relevant for GUI-built networks, whose auto-inserted port MCNs carry no explicit area.

Verification on the MFB-driven merge fixture: collector `Pt − P = 28685.11 Pa` vs independently computed `0.5*rho*u^2 = 28685.11 Pa`; outlet T = 375.09 K.

## Known consequence (and why two tests changed)

With honest collector stagnations, the **v1 impulse rows** (`sin^2(theta)` per-port form, Bassett correspondence derived for *separating* flow) are energetically inconsistent for **joining** flow — a v1 merge junction can manufacture flow work, and the bypass rejoin network loses its all-forward root entirely. The degenerate closure was hiding this by zeroing the very dynamic head the inconsistency lives in.

- `test_step_4_adding_bypass`: junctions migrated to `MPCEv2Element` (the production model — the GUI builds v2 exclusively — and joining-capable by design). Converges from the default cold start with both `lm` and `hybr`, and now also asserts the forward diameter-driven split.
- `test_both_models_give_forward_dominant_inlet_flow`: seeds the forward basin explicitly. v1's residuals are even in the mass flows except the linear mass row, so the all-forward root and its mirrored all-reverse image are equally exact; cold-start basin selection is not what this model-comparison test is about.

Follow-up candidates (not this PR): revisit MPCE-v2 `joining_etransfer_alpha` calibration against the validation suite (it was fitted on the degenerate plumbing), and decide whether v1's joining mode should be guarded or deprecated in favour of v2.

## Test plan

- [x] `test_mpce_collector_port_carries_dynamic_head` — collector `Pt − P` equals `0.5*rho*u^2` from the solved outflow (rel 1e-4)
- [x] `test_mpce_merge_outlet_temperature_mass_weighted` — 400 K / 300 K merge mixes to ~375 K, not 400 K
- [x] `test_mpce_collector_port_mcn_inherits_area` — auto-sized collector port MCNs get the junction port area, not the 0.1 m² fallback
- [x] Full suite: 1528 passed, 28 skipped, 5 xfailed (includes the #210 `analytical_pt_prop` case-4 regression, still passing)
- [x] `./scripts/check-python-style.sh --fix` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
