### PR TITLE
fix(compressible): interpolate L_choke within the breaking march step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   when the solver supplies ``port_mdots``.
 
 ### Fixed
+- **``L_choke`` is interpolated within the breaking march step instead of
+  snapping to the RK4 grid.** ``fanno_channel`` / ``fanno_channel_rough``
+  reported the length-to-choking quantized to ``L / n_steps`` (the
+  position of the last completed step). The in-channel choke barrier
+  (see the barrier entry below) builds its ramp on ``L_choke``, so the
+  channel's dP(m_dot) closure was a staircase near choke onset: jumps of
+  ``kappa * P_in / n_steps`` (~1 kPa at 1 bar with the default 100-step
+  march) every ~0.008 kg/s. Any pressure-driven network whose residual
+  zero fell inside a staircase jump had NO root -- a single air channel
+  (L=1 m, D=0.05 m) between two pressure boundaries failed to converge
+  at EVERY Pt ratio from 1.2 to 10 under every method/init combination,
+  stalling at a tread edge (best |F| ~ 90 at ratio 1.2). The sonic
+  station is now interpolated: linearly in Mach between the last two
+  steps for the ``M >= kFannoChokeMach`` exit, and linearly in the
+  pressure probe for the ``P <= 0`` RK4-stage exits. The same
+  single-channel sweep now converges at all 13 sampled ratios (1.2-10),
+  landing on the monotone barrier ramp at the choke boundary as the
+  barrier design intended. The choke threshold Mach (0.999) is hoisted
+  to ``constexpr kFannoChokeMach`` in ``compressible.h``. NOTE: for BCs
+  beyond the subsonic envelope the converged ``m_dot`` sits on the
+  barrier ramp slightly above the physical choked flow -- check the
+  channel's ``choked`` flag when interpreting such solutions. This also
+  invalidates (again) the pre-fix LHS-32 audit numbers: the 2026-07-03
+  re-run showed 25/32 all-strategy failures, most of which trace to this
+  staircase because the audit's channel geometry leaves the subsonic
+  envelope at Pt ratio ~1.19.
 - **MultiPortChamberElement ports now report their real throughflow to the
   solver's state propagation.** ``flow_at_node`` returned 0 "for safety",
   so every port-MCN fed by the junction (all collector/outflow ports)

--- a/include/compressible.h
+++ b/include/compressible.h
@@ -215,6 +215,11 @@ NozzleSolution nozzle_cd(
 //
 // Integration via RK4 on p(x), solving for T from energy at each step.
 
+// Mach number at which the Fanno march declares in-channel choking.
+// Slightly below 1 so the RK4 step stays finite near the sonic
+// singularity (dP/dx -> -inf as M -> 1).
+constexpr double kFannoChokeMach = 0.999;
+
 // Result of Fanno flow calculation at a single station
 struct FannoStation {
     double x   = 0.0;    // Position along channel [m]

--- a/python/tests/test_compressible.py
+++ b/python/tests/test_compressible.py
@@ -230,6 +230,37 @@ def test_fanno_channel_rough_choked() -> None:
     assert sol.L_choke < 1000.0  # choking happened before the end
 
 
+def test_fanno_channel_rough_lchoke_interpolated() -> None:
+    """L_choke must vary continuously with inlet velocity, not snap to the
+    march grid.
+
+    L_choke used to be quantized to L / n_steps (the RK4 march step). Any
+    closure built on it -- e.g. the network choke barrier, which adds
+    kappa * P_in * (1 - L_choke / L) -- became a staircase in m_dot with
+    jumps of kappa * P_in / n_steps (~1 kPa at 1 bar). A pressure-driven
+    channel whose residual zero fell inside a jump had no root at all: a
+    single channel between two pressure boundaries at Pt ratio 1.2
+    stalled at |F| ~ 90 under every solver configuration. The sonic
+    station is now interpolated within the breaking march step.
+    """
+    X = cb.species.dry_air()
+    T_in, P_in = 300.0, 100000.0
+    L, D, roughness = 1.0, 0.05, 1e-5
+    grid_dx = L / 100.0  # default n_steps = 100
+
+    l_chokes = []
+    for u in np.arange(298.5, 320.0, 0.1):
+        sol = cb.fanno_channel_rough(T_in, P_in, float(u), L, D, roughness, X)
+        assert sol.choked
+        l_chokes.append(sol.L_choke)
+    diffs = np.abs(np.diff(l_chokes))
+    # Grid-snapped L_choke moves in whole-step jumps (grid_dx) separated
+    # by flat stretches; interpolated L_choke tracks the ~0.002 m per
+    # sample physical trend everywhere.
+    assert float(np.max(diffs)) < 0.5 * grid_dx
+    assert float(np.median(diffs)) > 1e-3
+
+
 def test_fanno_channel_rough_invalid_correlation() -> None:
     """Unknown correlation should raise ValueError."""
     import pytest

--- a/python/tests/test_network_compressible.py
+++ b/python/tests/test_network_compressible.py
@@ -100,6 +100,44 @@ def test_compressible_channel_network():
     assert dP > 0, "Pressure should drop across channel"
 
 
+def test_compressible_channel_beyond_subsonic_envelope_converges():
+    """A pressure-driven channel demanding more than the subsonic Fanno
+    envelope must converge onto the choke-barrier boundary state.
+
+    The L=1 m, D=0.05 m air channel leaves the subsonic envelope at a Pt
+    ratio of about 1.19. Before L_choke was interpolated within the march
+    step (it snapped to L/n_steps), the choke-barrier ramp was a
+    staircase in m_dot: when the residual zero fell inside a staircase
+    jump this network had no root, and every method/init combination
+    stalled at a tread edge (best |F| ~ 90 at Pt ratio 1.2).
+    """
+    mdots = []
+    for pr in (1.2, 3.0):
+        net = FlowNetwork()
+        net.add_node(PressureBoundary("inlet", Pt=100000.0 * pr, Tt=300.0))
+        net.add_node(PressureBoundary("outlet", Pt=100000.0, Tt=300.0))
+        net.add_element(
+            ChannelElement(
+                "channel",
+                "inlet",
+                "outlet",
+                length=1.0,
+                diameter=0.05,
+                regime="compressible",
+            )
+        )
+        solver = NetworkSolver(net)
+        sol = solver.solve(timeout=30.0)
+        assert sol["__success__"], (
+            f"pr={pr}: {sol.get('__message__')} (|F|={sol.get('__final_norm__')})"
+        )
+        assert sol["channel.m_dot"] > 0
+        mdots.append(sol["channel.m_dot"])
+    # Choked mass flow scales with inlet pressure: the barrier root must
+    # track the envelope boundary, not park at an arbitrary tread.
+    assert mdots[1] > 2.0 * mdots[0]
+
+
 def test_mixed_compressible_incompressible_network():
     """Test network mixing compressible and incompressible elements."""
     net = FlowNetwork()

--- a/src/compressible.cpp
+++ b/src/compressible.cpp
@@ -543,7 +543,12 @@ FannoSolution fanno_channel(
     double T = T_in;
     double rho = rho_in;
     double u = u_in;
+    double M_prev = M_in;
 
+    // L_choke is interpolated within the breaking step below. Snapping it
+    // to the march grid makes any closure built on it (e.g. the network
+    // choke barrier) a staircase in m_dot whose jumps can leave residuals
+    // rootless near choke onset.
     for (std::size_t step = 0; step < n_steps; ++step) {
         // RK4 integration of dp/dx
         // k1
@@ -551,21 +556,21 @@ FannoSolution fanno_channel(
 
         // k2: evaluate at x + dx/2, P + k1*dx/2
         double P2 = P + 0.5 * k1 * dx;
-        if (P2 <= 0.0) { sol.choked = true; sol.L_choke = x; break; }
+        if (P2 <= 0.0) { sol.choked = true; sol.L_choke = x + 0.5 * dx * P / (P - P2); break; }
         [[maybe_unused]] double T2, u2, rho2;
         T2 = solve_T_from_energy(P2, sol.h0, sol.mdot, A, X, mw_kg, T, u2, rho2);
         double k2 = dpdx_fanno(rho2, u2, f, D);
 
         // k3: evaluate at x + dx/2, P + k2*dx/2
         double P3 = P + 0.5 * k2 * dx;
-        if (P3 <= 0.0) { sol.choked = true; sol.L_choke = x; break; }
+        if (P3 <= 0.0) { sol.choked = true; sol.L_choke = x + 0.5 * dx * P / (P - P3); break; }
         [[maybe_unused]] double T3, u3, rho3;
         T3 = solve_T_from_energy(P3, sol.h0, sol.mdot, A, X, mw_kg, T, u3, rho3);
         double k3 = dpdx_fanno(rho3, u3, f, D);
 
         // k4: evaluate at x + dx, P + k3*dx
         double P4 = P + k3 * dx;
-        if (P4 <= 0.0) { sol.choked = true; sol.L_choke = x; break; }
+        if (P4 <= 0.0) { sol.choked = true; sol.L_choke = x + dx * P / (P - P4); break; }
         [[maybe_unused]] double T4, u4, rho4;
         T4 = solve_T_from_energy(P4, sol.h0, sol.mdot, A, X, mw_kg, T, u4, rho4);
         double k4 = dpdx_fanno(rho4, u4, f, D);
@@ -575,7 +580,7 @@ FannoSolution fanno_channel(
 
         if (P_new <= 0.0) {
             sol.choked = true;
-            sol.L_choke = x;
+            sol.L_choke = x + dx * P / (P - P_new);
             break;
         }
 
@@ -592,11 +597,16 @@ FannoSolution fanno_channel(
         double a = current.a();
         double M = u / a;
 
-        if (M >= 0.999) {
+        if (M >= kFannoChokeMach) {
             sol.choked = true;
-            sol.L_choke = x;
+            double frac = 1.0;
+            if (M - M_prev > 1e-12) {
+                frac = (kFannoChokeMach - M_prev) / (M - M_prev);
+            }
+            sol.L_choke = x - dx * (1.0 - std::clamp(frac, 0.0, 1.0));
             break;
         }
+        M_prev = M;
 
         // Store profile point
         if (store_profile) {
@@ -732,7 +742,10 @@ FannoSolution fanno_channel_rough(
     double rho = rho_in;
     double u   = u_in;
     double f_sum = f_in;  // accumulate for f_avg
+    double M_prev = M_in;
 
+    // L_choke is interpolated within the breaking step below (see the
+    // constant-f overload for why grid-snapped L_choke is harmful).
     for (std::size_t step = 0; step < n_steps; ++step) {
         // k1: local f at current state
         const double f1 = local_friction(T, P, u, D, roughness, X, correlation, f_multiplier);
@@ -740,7 +753,7 @@ FannoSolution fanno_channel_rough(
 
         // k2
         const double P2 = P + 0.5 * k1 * dx;
-        if (P2 <= 0.0) { sol.choked = true; sol.L_choke = x; break; }
+        if (P2 <= 0.0) { sol.choked = true; sol.L_choke = x + 0.5 * dx * P / (P - P2); break; }
         double T2, u2, rho2;
         T2 = solve_T_from_energy(P2, sol.h0, sol.mdot, A, X, mw_kg, T, u2, rho2);
         const double f2 = local_friction(T2, P2, u2, D, roughness, X, correlation, f_multiplier);
@@ -748,7 +761,7 @@ FannoSolution fanno_channel_rough(
 
         // k3
         const double P3 = P + 0.5 * k2 * dx;
-        if (P3 <= 0.0) { sol.choked = true; sol.L_choke = x; break; }
+        if (P3 <= 0.0) { sol.choked = true; sol.L_choke = x + 0.5 * dx * P / (P - P3); break; }
         double T3, u3, rho3;
         T3 = solve_T_from_energy(P3, sol.h0, sol.mdot, A, X, mw_kg, T, u3, rho3);
         const double f3 = local_friction(T3, P3, u3, D, roughness, X, correlation, f_multiplier);
@@ -756,14 +769,14 @@ FannoSolution fanno_channel_rough(
 
         // k4
         const double P4 = P + k3 * dx;
-        if (P4 <= 0.0) { sol.choked = true; sol.L_choke = x; break; }
+        if (P4 <= 0.0) { sol.choked = true; sol.L_choke = x + dx * P / (P - P4); break; }
         double T4, u4, rho4;
         T4 = solve_T_from_energy(P4, sol.h0, sol.mdot, A, X, mw_kg, T, u4, rho4);
         const double f4 = local_friction(T4, P4, u4, D, roughness, X, correlation, f_multiplier);
         const double k4 = dpdx_fanno(rho4, u4, f4, D);
 
         const double P_new = P + dx * (k1 + 2.0*k2 + 2.0*k3 + k4) / 6.0;
-        if (P_new <= 0.0) { sol.choked = true; sol.L_choke = x; break; }
+        if (P_new <= 0.0) { sol.choked = true; sol.L_choke = x + dx * P / (P - P_new); break; }
 
         x += dx;
         P = P_new;
@@ -778,7 +791,16 @@ FannoSolution fanno_channel_rough(
         const double a = current.a();
         const double M = u / a;
 
-        if (M >= 0.999) { sol.choked = true; sol.L_choke = x; break; }
+        if (M >= kFannoChokeMach) {
+            sol.choked = true;
+            double frac = 1.0;
+            if (M - M_prev > 1e-12) {
+                frac = (kFannoChokeMach - M_prev) / (M - M_prev);
+            }
+            sol.L_choke = x - dx * (1.0 - std::clamp(frac, 0.0, 1.0));
+            break;
+        }
+        M_prev = M;
 
         if (store_profile) {
             FannoStation st;


### PR DESCRIPTION
## Problem

`fanno_channel` / `fanno_channel_rough` report `L_choke` snapped to the RK4 march grid (`L / n_steps`). The in-channel choke barrier from #211 builds its ramp on `L_choke`, so near choke onset the channel `dP(m_dot)` closure is a **staircase**: jumps of `kappa * P_in / n_steps` (~1 kPa at 1 bar with the default 100-step march) every ~0.008 kg/s, with smooth treads in between.

When a pressure-driven network's residual zero falls inside one of those jumps, the system has **no root at all**. Concretely: a single air channel (L=1 m, D=0.05 m) between two pressure boundaries fails to converge at **every** Pt ratio from 1.2 to 10, under every method/init combination, stalling at a tread edge (best |F| ~ 90 at ratio 1.2, `tmp/channel_1d_scan.py`).

This staircase also accounts for most of the 25/32 all-strategy failures in the 2026-07-03 LHS-32 MPCE cold-start audit re-run (`tmp/mpce_cold_start_audit.py` + `tmp/mpce_audit_followup.py`): that fixture's channel geometry leaves the subsonic Fanno envelope at Pt ratio ~1.19, below the LHS design minimum of 1.2, so nearly every audit case lands on the barrier ramp.

## Fix

In both marches (constant-f and rough):

- **`M >= kFannoChokeMach` exit**: interpolate the sonic station linearly in Mach between the last two steps (`M_prev` tracked across steps).
- **`P <= 0` RK4-stage exits**: interpolate linearly in the pressure probe along the stage distance (half-step for k2/k3, full step for k4 and the update).
- The `0.999` choke threshold is hoisted to `constexpr kFannoChokeMach` in `compressible.h` (Define Once). No exported-API change (internal constant, same precedent as the #211 barrier constants).

## Result

The single-channel Pt-ratio sweep converges **13/13** (was 0/13), landing on the monotone barrier ramp at the choke boundary as the #211 design intended:

| pr | before | after (m_dot) |
|-----|--------|---------------|
| 1.2 | stall, \|F\|~91 | converged, 0.814 |
| 3.0 | stall | converged, 2.216 |
| 10.0 | stall | converged, 7.720 |

Note: for BCs beyond the subsonic envelope the converged `m_dot` sits on the barrier ramp slightly above the physical choked flow -- check the channel's `choked` flag when interpreting such solutions.

## Tests

- `test_fanno_channel_rough_lchoke_interpolated` (kernel): `L_choke(u)` continuity over a fine sweep across choke onset -- max adjacent step must stay under half a grid quantum (pre-fix: whole-quantum jumps separated by flat stretches).
- `test_compressible_channel_beyond_subsonic_envelope_converges` (network): the over-envelope single channel converges at Pt ratios 1.2 and 3.0 and the choked m_dot scales with inlet pressure.
- Full suite green: 1534 Python tests, 17/17 ctest (test_thermo_transport passes outside the sandbox; known gtest /tmp capture issue).
- Existing #211 barrier tests (supersonic barrier, monotone-through-choke, reverse antisymmetry) and the case-4 rescue regression all unchanged and passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
