### PR TITLE
feat(solver): MPCE networks default to analytical_pt_prop init; deprecate incompressible_warmstart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **MPCE networks now default to ``analytical_pt_prop`` initialization.**
+  ``NetworkSolver.solve(init_strategy="default")`` auto-upgrades to
+  ``analytical_pt_prop`` when the network contains a
+  ``MultiPortChamberElement``; passing any other strategy or an
+  explicit ``x0`` opts out, and the strategy actually used is recorded
+  in ``solver_settings_used``. Evidence: on the certified inverse-design
+  audit (``tmp/mpce_audit_v2_generator.py`` + ``_runner.py``, 32
+  feasible fixtures with stored ground-truth roots), analytical
+  converged 32/32 to the certified root and was the fastest strategy
+  overall (41 s total), vs 28/32 for the plain cold start and
+  homotopy. The GUI ``SolverSettings`` schema now accepts
+  ``analytical_pt_prop`` explicitly. NOTE: the earlier LHS-32 audit
+  numbers (complementary default/analytical partition) are void -- that
+  fixture family was later shown to be infeasible for any physical tee
+  closure (equal-Pt sinks + constant-area legs demand static recovery
+  the model set cannot represent).
+
+### Deprecated
+- **``init_strategy="incompressible_warmstart"``** now emits a
+  ``DeprecationWarning``. On the certified audit it converged 10/32 at
+  roughly 10x the wall time of ``analytical_pt_prop`` (409 s vs 41 s
+  total); on a real GUI tee network it needed 445 evaluations vs 31
+  for the cold start. The incompressible proxy seeds a low-residual but
+  poorly conditioned region for the compressible restart. Will be
+  removed once the GUI drops the option.
+
 ### Removed
 - **``tee_junction`` (Bassett K-closure) retired from the GUI** (#177).
   ``MPCE Tee`` (``mpce_tee``, momentum-CV closure) is now the sole

--- a/docs/API_PYTHON.md
+++ b/docs/API_PYTHON.md
@@ -389,7 +389,11 @@ graph = FlowNetwork()
 graph.add_element(OrificeElement("ori1", "nodeA", "nodeB", Cd=0.6, diameter=0.011284))
 
 solver = NetworkSolver(graph)
-# init_strategy options: "default", "incompressible_warmstart", "homotopy"
+# init_strategy options: "default", "analytical_pt_prop", "homotopy",
+# "continuation", "incompressible_warmstart" (deprecated).
+# "default" auto-upgrades to "analytical_pt_prop" for networks that
+# contain a MultiPortChamberElement; pass another strategy or an
+# explicit x0 to opt out.
 results = solver.solve(method="hybr", init_strategy="homotopy")
 ```
 

--- a/gui/backend/schemas.py
+++ b/gui/backend/schemas.py
@@ -298,9 +298,13 @@ class ThermalWallData(BaseModel):
 class SolverSettings(BaseModel):
     model_config = ConfigDict(extra="ignore")
     global_regime: Literal["incompressible", "compressible"] = "incompressible"
-    init_strategy: Literal["default", "incompressible_warmstart", "homotopy", "continuation"] = (
-        "default"
-    )
+    init_strategy: Literal[
+        "default",
+        "analytical_pt_prop",
+        "incompressible_warmstart",
+        "homotopy",
+        "continuation",
+    ] = "default"
     method: Literal[
         "hybr",
         "lm",

--- a/python/combaero/network/solver.py
+++ b/python/combaero/network/solver.py
@@ -1415,15 +1415,18 @@ class NetworkSolver:
                 previous solution's ``_last_x`` for warm-starting
                 parameter sweeps.
             init_strategy: Initialization strategy. ``default`` uses
-                direct x0 construction; ``incompressible_warmstart``
-                first solves an incompressible-regime proxy network and
-                uses that solution as x0; ``analytical_pt_prop`` seeds
-                topology-aware initial guesses (channel Bernoulli m_dot
-                + MPCE junction P_jct at the common port), targeting
-                MPCE compressible cold-start cases where the solver's
-                default per-element uniform dP fallback lands Newton in
-                a wrong basin (see LHS-32 audit
-                ``tmp/mpce_cold_start_audit.py``).
+                direct x0 construction; for networks containing a
+                ``MultiPortChamberElement`` it auto-upgrades to
+                ``analytical_pt_prop`` (32/32 vs 28/32 certified-root
+                convergence on the 2026-07 inverse-design audit,
+                ``tmp/mpce_audit_v2_runner.py``) -- pass another
+                strategy or an explicit ``x0`` to opt out.
+                ``analytical_pt_prop`` seeds topology-aware initial
+                guesses (channel Bernoulli m_dot + MPCE junction P_jct
+                at the common port). ``incompressible_warmstart``
+                (DEPRECATED: 10/32 on the same audit at ~10x the wall
+                time) first solves an incompressible-regime proxy
+                network and uses that solution as x0.
             warmstart_maxfev: Maximum function evaluations for the
                 incompressible proxy solve when
                 ``init_strategy='incompressible_warmstart'``.
@@ -1460,9 +1463,39 @@ class NetworkSolver:
         if method != "hybr" and "maxfev" in options:
             options.setdefault("maxiter", options.pop("maxfev"))
 
+        if init_strategy == "incompressible_warmstart":
+            warnings.warn(
+                "init_strategy='incompressible_warmstart' is deprecated. "
+                "On the certified MPCE cold-start audit (2026-07) it "
+                "converged 10/32 cases at ~10x the wall time of "
+                "'analytical_pt_prop' (32/32). Use 'analytical_pt_prop' "
+                "or leave init_strategy='default'.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         # Ensure topology is resolved before solving
         self.network.resolve_all_topology()
         self.network.validate()
+
+        # MPCE networks auto-upgrade the default initialization to the
+        # analytical Pt-propagation seeds: on the certified inverse-design
+        # audit (tmp/mpce_audit_v2_*, 2026-07-04) analytical_pt_prop
+        # converged 32/32 to the certified root vs 28/32 for the plain
+        # cold start, and was the fastest strategy overall. Explicitly
+        # passing any other init_strategy (or an x0) opts out.
+        # The incompressible_warmstart proxy solve passes "default" and
+        # must keep the legacy plain cold start (flag below), otherwise
+        # the deprecated strategy's behavior silently changes.
+        if (
+            x0 is None
+            and init_strategy == "default"
+            and not getattr(self, "_in_warmstart_proxy", False)
+        ):
+            from .components import MultiPortChamberElement as _MPCElem
+
+            if any(isinstance(e, _MPCElem) for e in self.network.elements.values()):
+                init_strategy = "analytical_pt_prop"
 
         # analytical_pt_prop seeds channel m_dot + MPCE P_jct through the
         # regular _build_x0 path via self._init_overrides. _build_x0 reads
@@ -1512,14 +1545,17 @@ class NetworkSolver:
                     self.network.resolve_all_topology()
 
                     warm_options = {"maxfev": int(warmstart_maxfev)}
-                    warm_sol = self.solve(
-                        method="hybr",
-                        timeout=timeout,
-                        options=warm_options,
-                        use_jac=use_jac,
-                        x0=None,
-                        init_strategy="default",
-                    )
+                    self._in_warmstart_proxy = True
+                    with warnings.catch_warnings():
+                        warnings.simplefilter("ignore", DeprecationWarning)
+                        warm_sol = self.solve(
+                            method="hybr",
+                            timeout=timeout,
+                            options=warm_options,
+                            use_jac=use_jac,
+                            x0=None,
+                            init_strategy="default",
+                        )
 
                     if bool(warm_sol.get("__success__", False)):
                         candidate = getattr(self, "_last_x", None)
@@ -1533,6 +1569,7 @@ class NetworkSolver:
                         stacklevel=2,
                     )
                 finally:
+                    self._in_warmstart_proxy = False
                     for elem_id, regime in original_regimes.items():
                         self.network.elements[elem_id].regime = regime
                     self.network.resolve_all_topology()

--- a/python/tests/test_network_compressible.py
+++ b/python/tests/test_network_compressible.py
@@ -854,6 +854,58 @@ def test_analytical_pt_prop_rejects_unknown_strategy_name():
         solver.solve(init_strategy="analytical_pt_property")  # type: ignore[arg-type]
 
 
+def test_mpce_network_default_init_auto_upgrades():
+    """MPCE networks silently upgrade init_strategy='default' to
+    'analytical_pt_prop' (32/32 vs 28/32 certified-root convergence on
+    the 2026-07 inverse-design audit)."""
+    net = _mpce_tee_network(
+        pt_ratio=1.5,
+        theta_deg=60.0,
+        psi=1.0,
+        flow_direction="branch",
+    )
+    solver = NetworkSolver(net)
+    _ = solver.solve(timeout=10.0, options={"maxfev": 5})
+    used = solver._diagnostic_data["solver_settings_used"]["init_strategy"]
+    assert used == "analytical_pt_prop"
+
+
+def test_non_mpce_network_default_init_unchanged():
+    """Networks without an MPCE keep the plain default initialization."""
+    net = FlowNetwork()
+    net.add_node(PressureBoundary("in", Pt=200000.0, Tt=300.0))
+    net.add_node(PressureBoundary("out", Pt=100000.0, Tt=300.0))
+    net.add_element(OrificeElement("orf", "in", "out", 0.6, 0.05, correlation="fixed"))
+    solver = NetworkSolver(net)
+    _ = solver.solve(timeout=10.0)
+    used = solver._diagnostic_data["solver_settings_used"]["init_strategy"]
+    assert used == "default"
+
+
+def test_mpce_explicit_strategy_opts_out_of_auto_upgrade():
+    """Passing a non-default init_strategy suppresses the MPCE upgrade."""
+    net = _mpce_tee_network(
+        pt_ratio=1.5,
+        theta_deg=60.0,
+        psi=1.0,
+        flow_direction="branch",
+    )
+    solver = NetworkSolver(net)
+    _ = solver.solve(init_strategy="homotopy", timeout=10.0, options={"maxfev": 5})
+    used = solver._diagnostic_data["solver_settings_used"]["init_strategy"]
+    assert used == "homotopy"
+
+
+def test_incompressible_warmstart_deprecated():
+    net = FlowNetwork()
+    net.add_node(PressureBoundary("in", Pt=200000.0, Tt=300.0))
+    net.add_node(PressureBoundary("out", Pt=100000.0, Tt=300.0))
+    net.add_element(OrificeElement("orf", "in", "out", 0.6, 0.05, correlation="fixed"))
+    solver = NetworkSolver(net)
+    with pytest.warns(DeprecationWarning, match="incompressible_warmstart"):
+        _ = solver.solve(init_strategy="incompressible_warmstart", timeout=10.0)
+
+
 def test_analytical_pt_prop_respects_user_initial_guess():
     """User-provided initial_guess on a channel wins over the analytical seed."""
     net = _mpce_tee_network(


### PR DESCRIPTION
## What

1. **MPCE networks now default to `analytical_pt_prop` initialization.** `NetworkSolver.solve(init_strategy="default")` auto-upgrades when the network contains a `MultiPortChamberElement`. Opting out: pass any other strategy or an explicit `x0`. The strategy actually used is recorded in `solver_settings_used` (visible in GUI diagnostics).
2. **`incompressible_warmstart` is deprecated** (DeprecationWarning; still functional). Its nested proxy solve is exempted from the auto-upgrade via an internal flag so the deprecated path keeps its legacy behavior bit-for-bit.
3. GUI `SolverSettings` schema accepts `"analytical_pt_prop"` explicitly.

## Why

Measured on the new certified inverse-design audit (`tmp/mpce_audit_v2_generator.py` + `tmp/mpce_audit_v2_runner.py`): 32 fixtures constructed to be exact roots of the production model (design floors ~1e-11, warm-solve certified, ground-truth solution stored per case). Success below = converged **and** matched the certified root (mirrors/artifact roots count as failures):

| strategy | converged to certified root | total wall |
|---|---|---|
| **analytical_pt_prop** | **32/32** | **41 s** |
| cold default | 28/32 | 49 s |
| homotopy | 28/32 | 49 s |
| incompressible_warmstart | 10/32 | 409 s |

The earlier LHS-32 audit's "complementary default/analytical partition" is void: that fixture family was shown to be infeasible for **any** physical tee closure (equal-Pt sinks + constant-area legs demand static recovery the model set cannot represent; forensics in `tmp/case31_*`).

`incompressible_warmstart` seeds a low-residual but poorly conditioned region for the compressible restart — on a real GUI tee network it needed 445 evals vs 31 for the plain cold start.

## Tests

- `test_mpce_network_default_init_auto_upgrades` — MPCE net + defaults records `analytical_pt_prop`.
- `test_non_mpce_network_default_init_unchanged` — orifice net stays `default`.
- `test_mpce_explicit_strategy_opts_out_of_auto_upgrade` — explicit `homotopy` wins.
- `test_incompressible_warmstart_deprecated` — warns.
- Full suite green: 1538 passed, 28 skipped, 5 xfailed (the xfail delta vs main is `test_mixing_plenum_convergence`, marked non-deterministic-in-suite; it xpasses in isolation).

## Follow-up (separate PR)

The audit's constant-K warm-start experiments exposed that `strict=False` soft-barrier mode can manufacture exact artifact roots (penalty term cancels the Pt-continuity mismatch at a slightly-reversed feed). Next PR adds automatic post-solve direction verification so such roots are demoted to honest failures — prerequisite for switching the GUI to `strict=False`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
