### PR TITLE
fix(gui): build mpce_tee junctions with strict=False

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   removed once the GUI drops the option.
 
 ### Fixed
+- **GUI ``mpce_tee`` junctions are now built with ``strict=False``.**
+  Strict mode raises whenever a Newton ITERATE (not the converged
+  answer) explores a wrong-sign port m_dot, killing GUI solves that
+  would otherwise converge with "Unexpected error during residual
+  evaluation: MPCEv2Element ... declared flow_direction=... but
+  observed wrong flow direction". Soft mode lets the solver explore
+  wrong-direction states transiently; the post-solve
+  ``verify_solution_consistent`` guard (see entry below) rejects any
+  wrong-direction artifact root at convergence, so this switch does
+  not admit silently wrong answers.
 - **Soft-barrier artifact roots are demoted to honest failures.**
   ``MPCEv2Element`` with ``strict=False`` replaces a wrong-direction
   port's physics row with Pt continuity plus a one-sided penalty

--- a/gui/backend/graph_builder.py
+++ b/gui/backend/graph_builder.py
@@ -586,6 +586,13 @@ def build_network_from_schema(schema: NetworkGraphSchema) -> FlowNetwork:
                 _outlet_angles = [0.0]
                 _port_areas = [_F_C, _A_branch, _F_C]
 
+            # strict=False: strict mode raises whenever a Newton ITERATE
+            # (not the converged answer) explores a wrong-sign port
+            # m_dot, killing GUI solves that would otherwise converge
+            # ("Unexpected error during residual evaluation"). Soft mode
+            # lets the solver explore; the post-solve
+            # verify_solution_consistent guard in NetworkSolver rejects
+            # any wrong-direction artifact root at convergence.
             _mpce = MPCEv2Element(
                 id=elem_id,
                 inlet_nodes=_inlets,
@@ -594,6 +601,7 @@ def build_network_from_schema(schema: NetworkGraphSchema) -> FlowNetwork:
                 outlet_angles_deg=_outlet_angles,
                 port_areas=_port_areas,
                 flow_direction=_md.flow_direction,
+                strict=False,
                 joining_etransfer_alpha=_md.joining_etransfer_alpha,
             )
             _mpce.initial_guess = _expand_initial_guess(_md.initial_guess, elem_id)

--- a/python/tests/test_gui_mpce_tee.py
+++ b/python/tests/test_gui_mpce_tee.py
@@ -100,6 +100,11 @@ def test_mpce_tee_branch_builds_separating_element():
     e = _get_element(net, "mpce")
     assert isinstance(e, MPCEv2Element)
     assert e.flow_direction == "branch"
+    assert e.strict is False, (
+        "GUI junctions must use soft mode: strict raises on transient "
+        "wrong-sign Newton iterates and kills solves that would converge; "
+        "the post-solve direction guard rejects artifact roots instead"
+    )
     assert len(e.inlet_nodes) == 1
     assert len(e.outlet_nodes) == 2
     assert e.port_angles_deg == [0.0, 0.0, 45.0]
@@ -111,6 +116,7 @@ def test_mpce_tee_merge_builds_joining_element():
     e = _get_element(net, "mpce")
     assert isinstance(e, MPCEv2Element)
     assert e.flow_direction == "merge"
+    assert e.strict is False
     assert len(e.inlet_nodes) == 2
     assert len(e.outlet_nodes) == 1
     assert e.port_angles_deg == [0.0, 45.0, 0.0]


### PR DESCRIPTION
## What

One functional line: GUI `mpce_tee` junctions are now built with `strict=False` (`graph_builder.py`), plus builder-test assertions and CHANGELOG.

## Why

Strict mode raises whenever a Newton **iterate** — not the converged answer — explores a wrong-sign port m_dot. On multi-tee GUI networks this killed solves that would otherwise converge, with:

```
Unexpected error during residual evaluation: MPCEv2Element 'node_...':
declared flow_direction='branch' but observed wrong flow direction at port(s) [2]
```

Whether a solve survived depended on whether the Newton path happened to cross a direction boundary — the "hit and miss depending on boundary conditions" behavior observed on a 5-tee network (2026-07-03). Downstream legs near m_dot = 0 are especially exposed.

Soft mode lets the solver explore wrong-direction states transiently. This is safe **only** because of #215: the post-solve `verify_solution_consistent` guard demotes any wrong-direction soft-barrier artifact root to an honest failure, so the switch cannot admit silently wrong answers.

## Tests

- `test_mpce_tee_branch_builds_separating_element` / `test_mpce_tee_merge_builds_joining_element` now assert `e.strict is False` (with the rationale in the assertion message).
- GUI-path suites green (test_gui_mpce_tee, test_gui_graph_builder, test_network_runner, test_junction_network_runner) plus the compressible network suite including the #215 artifact-root regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
