### PR TITLE
fix(solver): require >= 2 PressureBoundaries for the analytical init auto-upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   removed once the GUI drops the option.
 
 ### Fixed
+- **The MPCE ``analytical_pt_prop`` auto-upgrade now requires >= 2
+  ``PressureBoundary`` nodes.** The strategy's Pt propagation needs a
+  boundary pressure gradient to be meaningful. On MFB-driven networks
+  with a single PB (the common GUI pattern: mass inlet -> tee tree ->
+  one pressure sink), propagated per-node Pt differences are
+  path-length artifacts and the Bernoulli sign logic seeded REVERSED
+  channel m_dots -- parking the first iterate inside the junctions'
+  soft-barrier penalty region (|F(x0)| ~ 1.15e6 of pure penalty on a
+  real 5-tee GUI network, hybr immediately "not making good progress")
+  while the plain cold start converges in 16 evaluations. Such
+  networks now keep the plain default initialization. The certified
+  audit result behind the auto-upgrade is unaffected (all 32 fixtures
+  are PB-driven).
 - **GUI ``mpce_tee`` junctions are now built with ``strict=False``.**
   Strict mode raises whenever a Newton ITERATE (not the converged
   answer) explores a wrong-sign port m_dot, killing GUI solves that

--- a/python/combaero/network/solver.py
+++ b/python/combaero/network/solver.py
@@ -1416,11 +1416,16 @@ class NetworkSolver:
                 parameter sweeps.
             init_strategy: Initialization strategy. ``default`` uses
                 direct x0 construction; for networks containing a
-                ``MultiPortChamberElement`` it auto-upgrades to
+                ``MultiPortChamberElement`` AND at least two
+                ``PressureBoundary`` nodes it auto-upgrades to
                 ``analytical_pt_prop`` (32/32 vs 28/32 certified-root
                 convergence on the 2026-07 inverse-design audit,
                 ``tmp/mpce_audit_v2_runner.py``) -- pass another
-                strategy or an explicit ``x0`` to opt out.
+                strategy or an explicit ``x0`` to opt out. The >= 2 PB
+                requirement exists because the strategy's Pt
+                propagation needs a boundary pressure gradient: on
+                MFB-driven networks it seeds reversed channel m_dots
+                from path-length artifacts.
                 ``analytical_pt_prop`` seeds topology-aware initial
                 guesses (channel Bernoulli m_dot + MPCE junction P_jct
                 at the common port). ``incompressible_warmstart``
@@ -1487,6 +1492,15 @@ class NetworkSolver:
         # The incompressible_warmstart proxy solve passes "default" and
         # must keep the legacy plain cold start (flag below), otherwise
         # the deprecated strategy's behavior silently changes.
+        # The upgrade additionally requires >= 2 PressureBoundary nodes:
+        # the strategy's Pt propagation needs a boundary pressure
+        # gradient to be meaningful. On MFB-driven networks with a
+        # single PB, propagated per-node Pt differences are path-length
+        # artifacts and the Bernoulli sign logic seeds REVERSED channel
+        # m_dots, parking the first iterate inside the junctions'
+        # soft-barrier region (observed on a real 5-tee GUI network:
+        # |F(x0)| = 1.15e6 of pure penalty, hybr immediately stuck,
+        # while the plain cold start converges in 16 evals).
         if (
             x0 is None
             and init_strategy == "default"
@@ -1494,7 +1508,8 @@ class NetworkSolver:
         ):
             from .components import MultiPortChamberElement as _MPCElem
 
-            if any(isinstance(e, _MPCElem) for e in self.network.elements.values()):
+            _n_pb = sum(isinstance(n, PressureBoundary) for n in self.network.nodes.values())
+            if _n_pb >= 2 and any(isinstance(e, _MPCElem) for e in self.network.elements.values()):
                 init_strategy = "analytical_pt_prop"
 
         # analytical_pt_prop seeds channel m_dot + MPCE P_jct through the

--- a/python/tests/test_network_compressible.py
+++ b/python/tests/test_network_compressible.py
@@ -896,6 +896,25 @@ def test_mpce_explicit_strategy_opts_out_of_auto_upgrade():
     assert used == "homotopy"
 
 
+def test_mfb_driven_mpce_network_keeps_plain_default_init():
+    """MFB-driven MPCE networks (< 2 PressureBoundaries) must NOT
+    auto-upgrade to analytical_pt_prop.
+
+    The strategy's Pt propagation needs a boundary pressure gradient.
+    With a single PB the propagated per-node Pt differences are
+    path-length artifacts and the Bernoulli sign logic seeds REVERSED
+    channel m_dots, parking the first iterate inside the junctions'
+    soft-barrier penalty region (|F(x0)| ~ 1e6 observed on a real
+    5-tee GUI network) while the plain cold start converges.
+    """
+    net = _mpce_mfb_merge_network()
+    solver = NetworkSolver(net)
+    sol = solver.solve(timeout=30.0)
+    used = solver._diagnostic_data["solver_settings_used"]["init_strategy"]
+    assert used == "default"
+    assert sol["__success__"], sol.get("__message__")
+
+
 def test_incompressible_warmstart_deprecated():
     net = FlowNetwork()
     net.add_node(PressureBoundary("in", Pt=200000.0, Tt=300.0))


### PR DESCRIPTION
## Problem

#214's MPCE `analytical_pt_prop` auto-upgrade regressed MFB-driven networks — the common GUI pattern of one mass-flow inlet feeding a tee tree into a single pressure sink.

With one `PressureBoundary` there is no boundary pressure gradient: `_propagate_pressure_guess` produces path-length artifacts, and the Bernoulli sign logic seeds **reversed** channel m_dots (−0.209 vs the physical +0.18 on the reporting 5-tee GUI network). The first iterate lands inside the junctions' soft-barrier penalty region — |F(x0)| = 1.15e6 of pure penalty, bit-for-bit matching the user's exported convergence trace — and hybr reports "not making good progress" within a second, while the plain cold start converges in 16 evaluations.

## Fix

The auto-upgrade now additionally requires **>= 2 `PressureBoundary` nodes** (the strategy's Pt propagation precondition). MFB-driven networks keep the plain default initialization. Explicit `init_strategy="analytical_pt_prop"` remains available; its docstring documents the limitation.

The certified-audit evidence behind #214 is unaffected — all 32 fixtures are PB-driven.

## Verification on the reporting network (`gui/tmp/network_5_mpce_tees-2.json`)

| case | before | after |
|---|---|---|
| incompressible, clean | stuck at |F|=1.15e6, 9 evals | converges, 16 evals, |F|=1.8e-8 |
| incompressible, stored-result warm start | — | converges, 7 evals |
| compressible, clean | stuck at |F|=1.15e6 | converges, 156 evals (needs timeout > 20 s) |

## Tests

- `test_mfb_driven_mpce_network_keeps_plain_default_init` — MFB-driven MPCE net records `init_strategy="default"` and converges.
- Existing auto-upgrade tests (PB-driven fixtures) unchanged and passing.
- Full suite green: 1541 passed, 28 skipped, 4 xfailed, 1 xpassed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
