### PR TITLE
feat(gui): true reset, effective init display, full strategy dropdown, Tee naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   poorly conditioned region for the compressible restart. Will be
   removed once the GUI drops the option.
 
+### Added
+- **GUI: all supported init strategies selectable in the sidebar.**
+  ``analytical_pt_prop`` added to the strategy dropdown (the backend
+  accepted it since the auto-upgrade PR but the frontend never offered
+  it); ``incompressible_warmstart`` is labelled "(deprecated)".
+- **GUI: the solver status badge shows the init strategy that actually
+  ran** (from ``solver_settings_used``), flagged "(auto)" when the
+  solver upgraded the requested "default" -- previously the MPCE
+  auto-upgrade was invisible from the GUI.
+
+### Changed
+- **GUI: "Reset All Initial Guesses" is now "Reset Guesses & Results"
+  and truly resets.** It previously cleared only
+  ``node.data.initial_guess`` -- but the graph builder warm-starts from
+  ``node.data.result`` whenever ``initial_guess`` is empty, so the old
+  button silently RE-ENABLED result-based seeding instead of giving a
+  cold start. It now clears stored solve results as well; the next
+  solve behaves like a freshly built network.
+- **GUI: ``mpce_tee`` is displayed as "Tee".** Sidebar drag entry, node
+  card default label, and Inspector header now say "Tee"; the Inspector
+  section carries a short explainer naming the underlying model
+  (momentum-based multi-port chamber junction, MPCE / Mynard closure).
+  The internal node type and save-file format are unchanged.
+
 ### Fixed
 - **The MPCE ``analytical_pt_prop`` auto-upgrade now requires >= 2
   ``PressureBoundary`` nodes.** The strategy's Pt propagation needs a

--- a/gui/frontend/src/components/Inspector.tsx
+++ b/gui/frontend/src/components/Inspector.tsx
@@ -238,7 +238,12 @@ const Inspector = () => {
 					</div>
 				)}
 				<h2 className="text-lg font-bold border-b pb-2 capitalize flex justify-between items-center">
-					<span>{(selectedNode.type || "unknown").replace("_", " ")} Node</span>
+					<span>
+						{selectedNode.type === "mpce_tee"
+							? "Tee"
+							: (selectedNode.type || "unknown").replace("_", " ")}{" "}
+						Node
+					</span>
 					<div className="flex gap-2">
 						<button
 							type="button"
@@ -1289,6 +1294,13 @@ const Inspector = () => {
 
 						return (
 							<div className="flex flex-col gap-4">
+								{/* Model explainer: the canvas calls this element just
+								    "Tee"; the underlying model name lives here. */}
+								<div className="text-[9px] leading-snug text-stone-500 italic">
+									Momentum-based multi-port chamber junction (MPCE): a
+									momentum-control-volume tee model (Mynard closure) for
+									splitting ("branch") and joining ("merge") flow.
+								</div>
 								{/* Port legend (MPCE indigo / rose theme) */}
 								<div className="rounded border border-stone-200 bg-stone-50 px-3 py-2 text-[9px] leading-snug text-stone-600">
 									<div className="font-bold uppercase text-stone-400 mb-1">

--- a/gui/frontend/src/components/Sidebar.tsx
+++ b/gui/frontend/src/components/Sidebar.tsx
@@ -56,15 +56,20 @@ const Sidebar = () => {
 		check();
 	}, [solverSettings, solveResults]);
 
-	const resetAllInitialGuesses = () => {
+	// True reset: clears explicit initial-guess overrides AND stored solve
+	// results. The graph builder warm-starts from node.data.result whenever
+	// initial_guess is empty, so clearing guesses alone would silently
+	// RE-ENABLE result-based seeding instead of giving a cold start. After
+	// this, the next solve behaves like a freshly built network.
+	const resetGuessesAndResults = () => {
 		let touched = 0;
 		const next = nodes.map((n) => {
-			if (
-				n.data?.initial_guess &&
-				Object.keys(n.data.initial_guess).length > 0
-			) {
+			const hasGuess =
+				n.data?.initial_guess && Object.keys(n.data.initial_guess).length > 0;
+			const hasResult = n.data?.result != null;
+			if (hasGuess || hasResult) {
 				touched += 1;
-				const { initial_guess: _ig, ...rest } = n.data;
+				const { initial_guess: _ig, result: _res, ...rest } = n.data;
 				return { ...n, data: { ...rest, initial_guess: {} } };
 			}
 			return n;
@@ -288,7 +293,7 @@ const Sidebar = () => {
 				draggable
 			>
 				<Split size={18} className="text-indigo-500" />
-				<span>MPCE Tee</span>
+				<span>Tee</span>
 			</button>
 
 			<button
@@ -351,7 +356,10 @@ const Sidebar = () => {
 						}
 					>
 						<option value="default">Default Cold Start</option>
-						<option value="incompressible_warmstart">Incomp. Warmstart</option>
+						<option value="analytical_pt_prop">Analytical (Pt Prop.)</option>
+						<option value="incompressible_warmstart">
+							Incomp. Warmstart (deprecated)
+						</option>
 						<option value="homotopy">Load-Stepping (Homotopy)</option>
 						<option
 							value="continuation"
@@ -404,11 +412,11 @@ const Sidebar = () => {
 				<div className="border-t border-stone-200 pt-2 flex flex-col gap-2">
 					<button
 						type="button"
-						onClick={resetAllInitialGuesses}
+						onClick={resetGuessesAndResults}
 						className="w-full text-[10px] font-bold uppercase tracking-wider bg-white hover:bg-amber-50 text-amber-700 border border-amber-200 rounded px-2 py-1.5 transition-colors"
-						title="Clear initial-guess overrides on every node and element; solver reverts to auto-seeding"
+						title="Clear initial-guess overrides AND stored solve results on every node; the next solve starts cold, like a freshly built network"
 					>
-						Reset All Initial Guesses
+						Reset Guesses & Results
 					</button>
 
 					{solveResults && (solveResults as any).isTopologyMismatch && (

--- a/gui/frontend/src/components/SolverStatusBadge.tsx
+++ b/gui/frontend/src/components/SolverStatusBadge.tsx
@@ -5,7 +5,7 @@ import useStore from "../store/useStore";
 import ConvergenceChart from "./ConvergenceChart";
 
 const SolverStatusBadge: React.FC = () => {
-	const { solveResults, dismissSolveStatus } = useStore();
+	const { solveResults, dismissSolveStatus, solverSettings } = useStore();
 	const [showChart, setShowChart] = useState(false);
 
 	if (!solveResults) return null;
@@ -16,6 +16,15 @@ const SolverStatusBadge: React.FC = () => {
 		(isSuccess ? "Solve completed" : "Failed to converge");
 	const finalNorm = solveResults.final_norm;
 	const hasHistory = (solveResults.convergence_history?.length ?? 0) > 0;
+	// The solver may auto-upgrade "default" (e.g. to analytical_pt_prop on
+	// MPCE networks); show what actually ran, flagged when it differs from
+	// the requested strategy.
+	const usedInit = solveResults.solver_settings_used?.init_strategy as
+		| string
+		| undefined;
+	const initLabel =
+		usedInit &&
+		`init: ${usedInit}${usedInit !== solverSettings.init_strategy ? " (auto)" : ""}`;
 
 	if (isSuccess) {
 		return (
@@ -29,6 +38,11 @@ const SolverStatusBadge: React.FC = () => {
 						{finalNorm !== undefined && finalNorm !== null && (
 							<span className="text-xs font-mono">
 								||F|| = {finalNorm.toExponential(3)}
+							</span>
+						)}
+						{initLabel && (
+							<span className="text-[10px] font-mono opacity-70">
+								{initLabel}
 							</span>
 						)}
 						<span className="text-xs opacity-80">{message}</span>
@@ -84,6 +98,11 @@ const SolverStatusBadge: React.FC = () => {
 					</button>
 				</div>
 				<div className="px-4 py-2 max-h-40 overflow-y-auto">
+					{initLabel && (
+						<div className="text-[10px] font-mono opacity-70 pb-1">
+							{initLabel}
+						</div>
+					)}
 					<pre className="text-xs font-mono whitespace-pre-wrap break-words">
 						{message}
 					</pre>

--- a/gui/frontend/src/components/nodes/MPCETeeNode.tsx
+++ b/gui/frontend/src/components/nodes/MPCETeeNode.tsx
@@ -64,7 +64,7 @@ const MPCETeeNode = ({ id, data, selected }: NodeProps) => {
 				style={{ transform: `rotate(${textRotation}deg)` }}
 			>
 				<div className="text-[10px] font-bold uppercase leading-none whitespace-nowrap">
-					{data.label ? data.label : "MPCE Tee"}
+					{data.label ? data.label : "Tee"}
 				</div>
 				<div
 					className={`text-[9px] font-mono whitespace-nowrap ${isMerge ? "text-indigo-500" : "text-rose-500"}`}

--- a/gui/frontend/src/store/useStore.ts
+++ b/gui/frontend/src/store/useStore.ts
@@ -41,6 +41,7 @@ export interface RFState {
 		global_regime: "incompressible" | "compressible";
 		init_strategy:
 			| "default"
+			| "analytical_pt_prop"
 			| "incompressible_warmstart"
 			| "homotopy"
 			| "continuation";


### PR DESCRIPTION
## What

Four GUI UX fixes that fell out of the 5-tee debugging session:

1. **True reset.** "Reset All Initial Guesses" -> **"Reset Guesses & Results"**. The old button cleared only `node.data.initial_guess` — but the graph builder warm-starts from `node.data.result` whenever `initial_guess` is empty, so it silently **re-enabled** result-based seeding instead of giving a cold start (one bad solve could poison every subsequent solve of the session). It now clears stored solve results too; the next solve behaves like a freshly built network.
2. **Effective init strategy is visible.** The solver status badge (success and failure layouts) shows the strategy that actually ran, from `solver_settings_used`, flagged **"(auto)"** when the solver upgraded the requested "default" — the MPCE auto-upgrade (#214/#217) was previously invisible from the GUI.
3. **All supported strategies selectable.** `analytical_pt_prop` added to the sidebar dropdown (backend accepted it since #214; the frontend never offered it); `incompressible_warmstart` labelled "(deprecated)".
4. **`mpce_tee` displays as "Tee".** Sidebar drag entry, node card default label, and Inspector header; the Inspector tee section gains a one-line explainer naming the underlying model (momentum-based multi-port chamber junction, MPCE / Mynard closure). Internal node type and save-file format unchanged — existing networks load as before.

## Tests

- Biome clean, `tsc -b && vite build` green, vitest 3/3.
- Python suite green via pre-commit (no backend changes in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
