### PR TITLE
fix(gui): show effective inherited ambient pressure placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The internal node type and save-file format are unchanged.
 
 ### Fixed
+- **GUI: inherited ambient pressure placeholder showed ``0.00``.** For
+  humid-air compositions inheriting ambient conditions from the global
+  solver settings, the Inspector's Ambient Pressure field displayed a
+  hardcoded ``0.00`` grey placeholder while Temperature and Relative
+  Humidity correctly showed the effective inherited values.
+  ``UnitInput`` now accepts an effective-value placeholder (in Pa,
+  scaled to the selected display unit).
 - **The MPCE ``analytical_pt_prop`` auto-upgrade now requires >= 2
   ``PressureBoundary`` nodes.** The strategy's Pt propagation needs a
   boundary pressure gradient to be meaningful. On MFB-driven networks

--- a/gui/frontend/src/components/CompositionEditor.tsx
+++ b/gui/frontend/src/components/CompositionEditor.tsx
@@ -52,6 +52,7 @@ const CompositionEditor: React.FC<CompositionEditorProps> = ({
 	// Effective ambient values: local override → global setting → ISO default
 	const effT = localComp.ambient_T ?? solverSettings.ambient_T ?? 288.15;
 	const effRH = localComp.relative_humidity ?? solverSettings.ambient_RH ?? 0.6;
+	const effP = localComp.ambient_P ?? solverSettings.ambient_P ?? 101325;
 
 	return (
 		<div className="flex flex-col gap-3 p-3 bg-stone-50 rounded-lg border border-stone-200">
@@ -165,6 +166,7 @@ const CompositionEditor: React.FC<CompositionEditorProps> = ({
 					<UnitInput
 						label="Ambient Pressure"
 						value={localComp.ambient_P}
+						placeholder={effP}
 						onChange={(val) => updateComp({ ambient_P: val })}
 						onClear={() => updateComp({ ambient_P: null })}
 					/>

--- a/gui/frontend/src/components/UnitInput.tsx
+++ b/gui/frontend/src/components/UnitInput.tsx
@@ -8,6 +8,8 @@ interface UnitInputProps {
 	onChange: (val: number) => void;
 	onClear?: () => void;
 	id?: string;
+	/** Placeholder shown when value is null, in Pa; scaled to the display unit. */
+	placeholder?: number;
 }
 
 const UnitInput: React.FC<UnitInputProps> = ({
@@ -16,6 +18,7 @@ const UnitInput: React.FC<UnitInputProps> = ({
 	onChange,
 	onClear,
 	id,
+	placeholder,
 }) => {
 	const { unitPreferences, setPressureUnit } = useStore();
 	const unit = unitPreferences.pressure;
@@ -35,7 +38,7 @@ const UnitInput: React.FC<UnitInputProps> = ({
 					onChange={(v) => onChange(v * scale)}
 					onClear={onClear}
 					className="flex-grow p-1.5 border rounded text-sm bg-stone-50 focus:bg-white focus:ring-1 focus:ring-orange-500 outline-none"
-					placeholder="0.00"
+					placeholder={placeholder != null ? `${placeholder / scale}` : "0.00"}
 				/>
 				<select
 					value={unit}


### PR DESCRIPTION
## Summary

For humid-air compositions inheriting ambient conditions from the global solver settings, the Inspector showed the effective inherited values as grey placeholders for Temperature and Relative Humidity — but Ambient Pressure displayed a hardcoded `0.00` (e.g. "0.00 kPa").

Root cause: the T and RH fields pass their effective value as the `NumericInput` placeholder, while the pressure field goes through the shared `UnitInput` component, which hardcoded `placeholder="0.00"`.

## Changes

- `UnitInput` gains an optional `placeholder` prop (value in Pa, divided by the unit scale for display), falling back to `"0.00"` when absent — other call sites unchanged.
- `CompositionEditor` computes the effective ambient pressure (`local override -> global setting -> 101325 Pa`) and passes it as the placeholder.
- CHANGELOG entry under `[Unreleased] / Fixed`.

## Verification

- `./scripts/check-gui-style.sh` passes.
- Pre-commit full suite passed on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
