### PR TITLE
fix(gui): never warm-start a solve from a failed prior result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The internal node type and save-file format are unchanged.
 
 ### Fixed
+- **GUI: failed solve results no longer poison subsequent solves.**
+  The graph builder warm-started every solve from the previous result
+  stored on each node -- including the best iterate of a FAILED solve
+  (e.g. a timeout). Seeding from a stall point parks Newton exactly
+  where the last attempt died, so one failure made a network
+  "practically unsolvable" even when it converges fine from cold
+  (observed on a single-tee mdot-to-pressure network: cold start 173
+  evaluations, warm-from-failed stalls at |F| ~ 1.5e2 with the same
+  residual signature on every retry). ``_guess_from_prior_result`` now
+  ignores results with ``success != True``. Added a practical
+  ``flow -> tee -> orifices -> pressure`` cold-start regression fixture
+  (GUI-parity geometry) in both regimes.
+- **GUI: the hard-timeout error message no longer recommends the
+  homotopy init strategy** (it could appear while already running
+  homotopy, and suggested a "shorter timeout" where a longer one is
+  what helps).
 - **GUI: inherited ambient pressure placeholder showed ``0.00``.** For
   humid-air compositions inheriting ambient conditions from the global
   solver settings, the Inspector's Ambient Pressure field displayed a

--- a/gui/backend/graph_builder.py
+++ b/gui/backend/graph_builder.py
@@ -196,9 +196,14 @@ def _guess_from_prior_result(node_data: dict, prefix: str) -> dict:
     solves on a difficult network benefit from accumulated Newton progress.
     Works for both pressure-node results (state.P/T/Pt/Tt) and element
     results (m_dot stored at the top level).
+
+    Only CONVERGED prior results are used: the best iterate of a failed
+    solve is stored too, and seeding from it parks Newton at the stall
+    point -- one failed solve (e.g. a timeout) would otherwise poison
+    every subsequent run of a network that converges fine from cold.
     """
     prior = node_data.get("result")
-    if not prior:
+    if not prior or not prior.get("success"):
         return {}
     short: dict[str, float] = {}
     state = prior.get("state")

--- a/gui/backend/main.py
+++ b/gui/backend/main.py
@@ -162,7 +162,8 @@ async def solve(schema: NetworkGraphSchema):
         raise HTTPException(
             status_code=504,
             detail=f"Solver exceeded the hard timeout of {hard_timeout:.0f}s. "
-            "Try a shorter timeout, a simpler network, or the homotopy init strategy.",
+            "Try raising the solver timeout, simplifying the network, or a "
+            "different init strategy.",
         ) from None
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e

--- a/python/tests/test_gui_graph_builder.py
+++ b/python/tests/test_gui_graph_builder.py
@@ -211,3 +211,43 @@ def test_expand_initial_guess_mixed_short_and_qualified():
         "comb.m_dot": 1.2,
         "other.X[0]": 0.767,
     }
+
+
+# ---------------------------------------------------------------------------
+# _guess_from_prior_result: warm start only from CONVERGED prior results
+# ---------------------------------------------------------------------------
+
+
+def test_prior_result_warm_start_requires_success():
+    """Regression: the best iterate of a FAILED solve is stored in
+    node_data["result"] too; seeding from it parks Newton at the stall
+    point, so one timed-out solve poisoned every subsequent run of a
+    network that converges fine from cold (observed on
+    one_mpce_tee_mdot_to_p.json: cold 173 evals OK, warm-from-failed
+    stalls at |F|~1.5e2)."""
+    from gui.backend.graph_builder import _guess_from_prior_result
+
+    failed = {"result": {"success": False, "state": {"P": 1.0e5, "T": 300.0}}}
+    assert _guess_from_prior_result(failed, "n") == {}
+
+    legacy_no_flag = {"result": {"state": {"P": 1.0e5, "T": 300.0}}}
+    assert _guess_from_prior_result(legacy_no_flag, "n") == {}
+
+
+def test_prior_result_warm_start_used_when_converged():
+    from gui.backend.graph_builder import _guess_from_prior_result
+
+    ok = {
+        "result": {
+            "success": True,
+            "state": {"P": 1.5e5, "T": 320.0, "Pt": 1.51e5, "Tt": 321.0},
+        }
+    }
+    out = _guess_from_prior_result(ok, "n")
+    assert out["n.P"] == 1.5e5
+    assert out["n.Pt"] == 1.51e5
+    assert out["n.T"] == 320.0
+    assert out["n.Tt"] == 321.0
+
+    ok_elem = {"result": {"success": True, "m_dot": 0.4}}
+    assert _guess_from_prior_result(ok_elem, "ch")["ch.m_dot"] == 0.4

--- a/python/tests/test_network_compressible.py
+++ b/python/tests/test_network_compressible.py
@@ -1079,3 +1079,99 @@ def test_certified_merge_root_passes_direction_verification():
     # Certified ground truth from the inverse-design generator.
     assert abs(sol["ch_str.m_dot"] - 0.25761378909667976) < 5e-3
     assert abs(sol["ch_bra.m_dot"] - 0.21294516374058128) < 5e-3
+
+
+def _mfb_branch_tee_orifice_network(m_dot: float, regime: str) -> FlowNetwork:
+    """Practical flow -> tee -> pressure topology (GUI parity fixture).
+
+    Mirrors gui/tmp/one_mpce_tee_mdot_to_p.json: a mass-flow inlet feeds a
+    separating MPCEv2 tee whose two legs each end in an orifice discharging
+    to a single ambient PressureBoundary. The orifices provide the leg
+    resistance that makes the fixture family feasible (bare equal-Pt sinks
+    with resistance-free constant-area legs have no root for any physical
+    tee closure -- see the 2026-07-04 case-31 analysis).
+    """
+    from combaero.network.mpce_v2_element import MPCEv2Element
+
+    D_main, D_leg = 0.1, 0.06
+    A_main = math.pi * (D_main / 2.0) ** 2
+    A_leg = math.pi * (D_leg / 2.0) ** 2
+    net = FlowNetwork()
+    net.add_node(MassFlowBoundary("mfb_in", m_dot=m_dot, Tt=300.0))
+    net.add_node(PressureBoundary("pb_amb", Pt=101325.0, Tt=300.0))
+    net.add_node(MomentumChamberNode("mc_com", area=A_main))
+    net.add_node(MomentumChamberNode("mc_str", area=A_main))
+    net.add_node(MomentumChamberNode("mc_bra", area=A_leg))
+    net.add_node(PlenumNode("pl_str"))
+    net.add_node(PlenumNode("pl_bra"))
+    net.add_element(
+        ChannelElement("ch_in", "mfb_in", "mc_com", length=1.0, diameter=D_main, regime=regime)
+    )
+    net.add_element(
+        ChannelElement("ch_str", "mc_str", "pl_str", length=1.0, diameter=D_main, regime=regime)
+    )
+    net.add_element(
+        ChannelElement("ch_bra", "mc_bra", "pl_bra", length=1.0, diameter=D_leg, regime=regime)
+    )
+    net.add_element(
+        OrificeElement(
+            "orf_str",
+            "pl_str",
+            "pb_amb",
+            Cd=0.6,
+            diameter=0.032,
+            regime=regime,
+            correlation="fixed",
+        )
+    )
+    net.add_element(
+        OrificeElement(
+            "orf_bra",
+            "pl_bra",
+            "pb_amb",
+            Cd=0.6,
+            diameter=0.03,
+            regime=regime,
+            correlation="fixed",
+        )
+    )
+    net.add_element(
+        MPCEv2Element(
+            id="tee",
+            inlet_nodes=["mc_com"],
+            outlet_nodes=["mc_str", "mc_bra"],
+            inlet_angles_deg=[0.0],
+            outlet_angles_deg=[0.0, 90.0],
+            port_areas=[A_main, A_main, A_leg],
+            flow_direction="branch",
+            strict=False,
+        )
+    )
+    return net
+
+
+@pytest.mark.parametrize("regime", ["incompressible", "compressible"])
+def test_flow_tee_pressure_cold_start_converges(regime: str):
+    """Regression: the practical MFB -> tee -> orifices -> PB topology must
+    converge from a plain cold start.
+
+    The GUI network this mirrors was reported 'practically unsolvable' at
+    m_dot=0.4 compressible; headless diagnosis (2026-07-05) showed the
+    root exists at every m_dot and the GUI failures came from warm-starting
+    off a stored FAILED result. This pins the cold-start behavior so a
+    genuine solver regression cannot hide behind that GUI artifact again.
+    m_dot=0.2 keeps the compressible solve fast (~50 evals); higher m_dot
+    approaches the orifice choke edge and only costs iterations, not the
+    root.
+    """
+    net = _mfb_branch_tee_orifice_network(0.2, regime)
+    solver = NetworkSolver(net)
+    sol = solver.solve(timeout=60.0)
+    assert sol["__success__"], sol.get("__message__")
+    assert sol["__final_norm__"] < 1e-3
+    m_str = sol["ch_str.m_dot"]
+    m_bra = sol["ch_bra.m_dot"]
+    assert m_str > 0.0 and m_bra > 0.0
+    assert m_str + m_bra == pytest.approx(0.2, abs=1e-4)
+    # The larger straight orifice (0.032 vs 0.03 bore) must carry more flow.
+    assert m_str > m_bra

--- a/python/tests/test_network_runner.py
+++ b/python/tests/test_network_runner.py
@@ -477,10 +477,15 @@ def test_swap_missing_label_raises():
 
 @pytest.mark.skipif(not _MULTI_WALL_TEE.exists(), reason="fixture not present")
 def test_multi_wall_tee_solve():
+    # init_strategy="default": the fixture's stored results are from a
+    # FAILED solve, so since the warm-start success gate they no longer
+    # seed the solver -- and the deprecated incompressible_warmstart this
+    # test used to pin only converged FROM that poisoned seed. The plain
+    # default converges cold.
     runner = NetworkRunner.from_file(_MULTI_WALL_TEE)
     result = runner.solve(
         method="hybr",
-        init_strategy="incompressible_warmstart",
+        init_strategy="default",
         timeout=60.0,
     )
     assert result.success, f"Solver failed: {result.message}"
@@ -492,7 +497,7 @@ def test_multi_wall_tee_to_dataframe():
     runner = NetworkRunner.from_file(_MULTI_WALL_TEE)
     result = runner.solve(
         method="hybr",
-        init_strategy="incompressible_warmstart",
+        init_strategy="default",
         timeout=60.0,
     )
     df = result.to_dataframe()


### PR DESCRIPTION
## Summary

The "practically unsolvable" `one_mpce_tee_mdot_to_p.json` network (m_dot=0.4 compressible) is solvable — it converges from a plain cold start in 173 evaluations / 25 s at every tested m_dot, both regimes. The GUI failures were self-inflicted: the graph builder warm-started every solve from `node.data.result`, **including the best iterate of a failed solve**. One timeout stored a stall point, and every retry re-started exactly there and stalled with the identical worst-residual signature (reproduced bit-for-bit against the user's convergence CSV, |F| ~ 1.5e2).

The choke suspicion was a red herring in the end — but a well-aimed one: orifices near the choke edge only cost iterations (50 evals at 0.2 kg/s vs 226 at 0.35 kg/s), which is what pushed the first solve past the 30 s GUI timeout and planted the poisoned result.

## Changes

- `_guess_from_prior_result` now ignores stored results with `success != True` (missing flag counts as failed — safe for legacy saves).
- Hard-timeout HTTP message no longer recommends "a shorter timeout ... or the homotopy init strategy" (it could appear while already running homotopy; a *longer* timeout is what actually helps).
- New unit tests for the success gate in `test_gui_graph_builder.py`.
- New practical `flow -> tee -> orifices -> pressure` cold-start regression fixture (GUI-parity geometry from the reported network) in `test_network_compressible.py`, both regimes — the requested flow→tee→pressure test. Note the bare variant without orifice leg resistance is the known infeasible fixture family and is deliberately not pinned.
- `test_multi_wall_tee_solve`/`_to_dataframe` switched from the deprecated `incompressible_warmstart` to `default`: they only passed by warm-starting from their fixture's stored *failed* results; `default` converges the fixture cold (|F| = 8.5e-8).

## Verification

- Warm-from-failed repro (`tmp/one_tee_choke_repro.py warm`): before — default stalls at |F|=1.5e2; after — default 173 evals, analytical 218, homotopy 18, all converged.
- Full pre-commit suite green (1546 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
