### PR TITLE
feat(solver): outlet-referenced incompressible warm-start auto-retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Solver: automatic outlet-referenced incompressible warm-start retry
+  for failed cold solves on compressible MPCE networks.** Cold hybr on
+  compressible tee networks shows non-monotone "slow pockets" (5-tee
+  GUI network: 0.32 kg/s needs 510 evals/161 s while 0.4 kg/s needs
+  276/88 s), which look like hard failures at GUI timeouts. When a cold
+  ``default``/``analytical_pt_prop`` solve fails, ``NetworkSolver.solve``
+  now re-solves the network once in the incompressible regime with
+  element densities evaluated at the DOWNSTREAM static pressure and
+  warm-starts the compressible retry from that proxy solution. The
+  outlet-referenced proxy tracks the compressible solution 6-7x closer
+  than the classic inlet-referenced incompressible solve (RMS junction
+  pressures 5-30 kPa vs 32-211 kPa across 3 diagnosed networks) and its
+  seed converges cases where the inlet-referenced seed fails outright.
+  The worst slow-pocket case now converges in 86 s total (vs 161 s+
+  cold). Budget split: primary 40%, proxy <= 25%, seeded retry the
+  rest; the effective strategy is recorded as
+  ``solver_settings_used.init_strategy = "outletref_warmstart"`` with
+  ``auto_retry: true``. Opt out with ``solve(auto_retry=False)``.
+  Evidence: ``tmp/outlet_ref_seed_experiment.py`` (2026-07-05). NOTE:
+  the homotopy ladder was also evaluated as the retry strategy and
+  rejected -- its true wall cost is 64-200 s on the 5-tee network (each
+  rung is a full solve; earlier per-rung timings undercounted it).
+
+### Fixed
+- **Homotopy init: the rung ladder now shares the caller's ``timeout``
+  as a total deadline.** Previously every rung received the full budget,
+  so an ``init_strategy="homotopy"`` solve could run to ~6x the
+  requested timeout -- blowing through the GUI's hard (soft + 10 s)
+  request timeout and returning a 504 instead of a diagnosable result.
+
 ### Changed
 - **MPCE networks now default to ``analytical_pt_prop`` initialization.**
   ``NetworkSolver.solve(init_strategy="default")`` auto-upgrades to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,14 +22,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pressures 5-30 kPa vs 32-211 kPa across 3 diagnosed networks) and its
   seed converges cases where the inlet-referenced seed fails outright.
   The worst slow-pocket case now converges in 86 s total (vs 161 s+
-  cold). Budget split: primary 40%, proxy <= 25%, seeded retry the
-  rest; the effective strategy is recorded as
-  ``solver_settings_used.init_strategy = "outletref_warmstart"`` with
-  ``auto_retry: true``. Opt out with ``solve(auto_retry=False)``.
-  Evidence: ``tmp/outlet_ref_seed_experiment.py`` (2026-07-05). NOTE:
-  the homotopy ladder was also evaluated as the retry strategy and
-  rejected -- its true wall cost is 64-200 s on the 5-tee network (each
-  rung is a full solve; earlier per-rung timings undercounted it).
+  cold). Budget split: primary 40%, proxy <= 30% (up to 60 s -- heavy
+  high-Re networks need ~35 s even incompressible), seeded retry the
+  rest; when the stiffer outlet-referenced proxy does not converge the
+  retry falls back to the classic inlet-referenced proxy seed (which
+  rescued a 16 kg/s 20 bar 5-tee network where outlet-ref starved).
+  The effective strategy is recorded as
+  ``solver_settings_used.init_strategy = "outletref_warmstart"`` (or
+  ``"inletref_warmstart"`` for the fallback) with ``auto_retry: true``.
+  Opt out with ``solve(auto_retry=False)``. Evidence:
+  ``tmp/outlet_ref_seed_experiment.py`` (2026-07-05) and the certified
+  inverse-design audit: seeded outlet-ref scores 27/32 same-root on
+  PB-driven fixtures (weak on merge topologies) vs 32/32 for the
+  analytical default -- hence retry, not primary. NOTE: the homotopy
+  ladder was also evaluated as the retry strategy and rejected -- its
+  true wall cost is 64-200 s on the 5-tee network (each rung is a full
+  solve; earlier per-rung timings undercounted it). A useful side
+  effect of the 40% primary budget: hybr hands over to the
+  LM fallback earlier, which alone cut the 16 kg/s network from 104 s
+  to 29 s at timeout=90.
 
 ### Fixed
 - **Homotopy init: the rung ladder now shares the caller's ``timeout``

--- a/docs/API_PYTHON.md
+++ b/docs/API_PYTHON.md
@@ -394,6 +394,10 @@ solver = NetworkSolver(graph)
 # "default" auto-upgrades to "analytical_pt_prop" for networks that
 # contain a MultiPortChamberElement; pass another strategy or an
 # explicit x0 to opt out.
+# auto_retry (default True): failed cold solves on compressible
+# MPCE networks are retried once from an outlet-referenced
+# incompressible warm start (densities at the downstream static).
+# The primary attempt gets 40% of `timeout`, the retry the rest.
 results = solver.solve(method="hybr", init_strategy="homotopy")
 ```
 

--- a/python/combaero/network/components.py
+++ b/python/combaero/network/components.py
@@ -1527,11 +1527,18 @@ class OrificeElement(NetworkElement):
                 getattr(self, "beta", 0.0),
             )
         else:
-            # Use incompressible Bernoulli formulation
+            # Use incompressible Bernoulli formulation. The density
+            # reference is the upstream static by default; the solver's
+            # compressible-seed proxy switches it to the downstream static
+            # (_incompressible_p_ref = "outlet"), which tracks the
+            # compressible solution far better on blow-down networks
+            # (6-7x closer junction pressures on the 2026-07-05 outlet-ref
+            # seed experiment, tmp/outlet_ref_seed_experiment.py).
+            _p_ref_outlet = getattr(self, "_incompressible_p_ref", "inlet") == "outlet"
             res_cpp = _solver_tools.orifice_residuals_and_jacobian(
                 m_dot,
                 state_in.Pt,
-                state_in.P,
+                state_out.P if _p_ref_outlet else state_in.P,
                 state_in.T,
                 state_in.Y,
                 state_out.P,
@@ -1547,11 +1554,20 @@ class OrificeElement(NetworkElement):
             0: {
                 f"{self.id}.m_dot": 1.0,
                 f"{self.from_node}.Pt": -res_cpp.d_mdot_dP_total_up,
-                f"{self.from_node}.P": -res_cpp.d_mdot_dP_static_up,
                 f"{self.from_node}.T": -res_cpp.d_mdot_dT_up,
-                f"{self.to_node}.P": -res_cpp.d_mdot_dP_static_down,
             }
         }
+        if self.regime != "compressible" and (
+            getattr(self, "_incompressible_p_ref", "inlet") == "outlet"
+        ):
+            # Density evaluated at the downstream static: its sensitivity
+            # moves onto the downstream node's P.
+            jac[0][f"{self.to_node}.P"] = -(
+                res_cpp.d_mdot_dP_static_down + res_cpp.d_mdot_dP_static_up
+            )
+        else:
+            jac[0][f"{self.from_node}.P"] = -res_cpp.d_mdot_dP_static_up
+            jac[0][f"{self.to_node}.P"] = -res_cpp.d_mdot_dP_static_down
         # Add species sensitivities
         for i, val in enumerate(res_cpp.d_mdot_dY_up):
             jac[0][f"{self.from_node}.Y[{i}]"] = -val
@@ -2288,11 +2304,15 @@ class ChannelElement(NetworkElement):
                 f_mult,
             )
         else:
-            # Use incompressible Darcy-Weisbach formulation
+            # Use incompressible Darcy-Weisbach formulation. Density
+            # reference: upstream static by default, downstream static when
+            # the solver's compressible-seed proxy sets
+            # _incompressible_p_ref = "outlet" (see OrificeElement).
+            _p_ref_outlet = getattr(self, "_incompressible_p_ref", "inlet") == "outlet"
             res_cpp = _solver_tools.channel_residuals_and_jacobian(
                 m_dot,
                 state_in.Pt,
-                state_in.P,
+                state_out.P if _p_ref_outlet else state_in.P,
                 state_in.T,
                 state_in.Y,
                 state_out.P,
@@ -2323,11 +2343,18 @@ class ChannelElement(NetworkElement):
             0: {
                 f"{self.id}.m_dot": -res_cpp.d_dP_d_mdot,
                 f"{upstream_id}.Pt": 1.0,
-                f"{upstream_id}.P": -res_cpp.d_dP_dP_static_up,
                 f"{upstream_id}.T": -res_cpp.d_dP_dT_up,
                 f"{downstream_id}.Pt": -1.0,
             }
         }
+        if self.regime != "compressible" and (
+            getattr(self, "_incompressible_p_ref", "inlet") == "outlet"
+        ):
+            # Density evaluated at the downstream static: the friction-loss
+            # pressure sensitivity moves onto the downstream node's P.
+            jac[0][f"{downstream_id}.P"] = -res_cpp.d_dP_dP_static_up
+        else:
+            jac[0][f"{upstream_id}.P"] = -res_cpp.d_dP_dP_static_up
         for i, val in enumerate(res_cpp.d_dP_dY_up):
             jac[0][f"{upstream_id}.Y[{i}]"] = -val
 

--- a/python/combaero/network/solver.py
+++ b/python/combaero/network/solver.py
@@ -14,8 +14,10 @@ from .components import (
     EnergyBoundary,
     LosslessConnectionElement,
     MassFlowBoundary,
+    MultiPortChamberElement,
     NetworkMixtureState,
     NetworkNode,
+    OrificeElement,
     PressureBoundary,
     WallNode,
 )
@@ -1397,10 +1399,203 @@ class NetworkSolver:
         ] = "default",
         warmstart_maxfev: int = 150,
         lambda_steps: list[float] | None = None,
+        auto_retry: bool = True,
     ) -> dict[str, float]:
         """
         Executes the root finding algorithm to solve the network.
         Returns a dictionary mapping unknown names to their solved values.
+
+        For cold solves (``x0=None``, ``init_strategy`` 'default' or
+        'analytical_pt_prop') on COMPRESSIBLE networks containing a
+        ``MultiPortChamberElement``, a failed solve is automatically
+        retried once from an outlet-referenced incompressible warm
+        start (disable via ``auto_retry=False``): the network is
+        re-solved in the incompressible regime with element densities
+        evaluated at the DOWNSTREAM static pressure, and that solution
+        seeds the compressible retry. On blow-down networks this proxy
+        tracks the compressible solution 6-7x closer than the classic
+        inlet-referenced incompressible solve and rescues the cold
+        path's non-monotone 'slow pockets' (5-tee GUI network at
+        0.32 kg/s: cold needs 510 evals/161 s, the seeded retry 96
+        evals/30 s; the seed even converges cases where the
+        inlet-referenced seed fails -- 2026-07-05 outlet-ref seed
+        experiment, tmp/outlet_ref_seed_experiment.py). When a
+        ``timeout`` is given and the retry is applicable, the primary
+        attempt gets 40% of the budget, the proxy at most 25%, and the
+        seeded retry the remainder (at least 30%). Compressible tee
+        networks are best given 90-120 s total.
+        """
+        retry_applicable = (
+            auto_retry
+            and x0 is None
+            and init_strategy in ("default", "analytical_pt_prop")
+            and any(isinstance(e, MultiPortChamberElement) for e in self.network.elements.values())
+            and bool(self._compressible_element_overrides())
+        )
+        if not retry_applicable:
+            return self._solve_impl(
+                method=method,
+                timeout=timeout,
+                options=options,
+                use_jac=use_jac,
+                x0=x0,
+                init_strategy=init_strategy,
+                warmstart_maxfev=warmstart_maxfev,
+                lambda_steps=lambda_steps,
+            )
+
+        _t0 = time.time()
+        primary_timeout = 0.4 * timeout if timeout is not None else None
+        sol = self._solve_impl(
+            method=method,
+            timeout=primary_timeout,
+            options=options,
+            use_jac=use_jac,
+            x0=None,
+            init_strategy=init_strategy,
+            warmstart_maxfev=warmstart_maxfev,
+            lambda_steps=lambda_steps,
+        )
+        if sol.get("__success__", False):
+            return sol
+
+        primary_norm = sol.get("__final_norm__")
+        primary_msg = str(sol.get("__message__", "")).strip()
+        warnings.warn(
+            f"Cold '{init_strategy}' solve failed (|F|={primary_norm:.3e}); "
+            "auto-retrying from an outlet-referenced incompressible warm "
+            "start. Pass auto_retry=False to disable.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        proxy_timeout = 30.0 if timeout is None else max(min(0.25 * timeout, 30.0), 10.0)
+        _primary_diag = getattr(self, "_diagnostic_data", None)
+        seed_x0 = self._outlet_ref_incompressible_seed(use_jac=use_jac, timeout=proxy_timeout)
+        if seed_x0 is None:
+            # Restore the primary attempt's diagnostics -- the failed proxy
+            # solve overwrote them, and we are returning the primary result.
+            if _primary_diag is not None:
+                self._diagnostic_data = _primary_diag
+            sol["__message__"] = (
+                f"{primary_msg} [outlet-referenced incompressible warm-start "
+                "auto-retry skipped: the proxy solve did not converge]"
+            )
+            return sol
+
+        remaining = None
+        if timeout is not None:
+            remaining = max(timeout - (time.time() - _t0), 0.3 * timeout)
+        retry_sol = self._solve_impl(
+            method=method,
+            timeout=remaining,
+            options=options,
+            use_jac=use_jac,
+            x0=seed_x0,
+            init_strategy="default",
+        )
+        # Stamp what actually ran so the GUI badge and headless tooling
+        # report the effective strategy.
+        _diag = getattr(self, "_diagnostic_data", None)
+        if isinstance(_diag, dict):
+            _ssu = _diag.get("solver_settings_used")
+            if isinstance(_ssu, dict):
+                _ssu["init_strategy"] = "outletref_warmstart"
+                _ssu["auto_retry"] = True
+        if retry_sol.get("__success__", False):
+            retry_sol["__message__"] = (
+                "Converged via outlet-referenced incompressible warm-start "
+                f"auto-retry after the '{init_strategy}' attempt failed "
+                f"({primary_msg[:120]})."
+            )
+            return retry_sol
+        retry_sol["__message__"] = (
+            f"{str(retry_sol.get('__message__', '')).strip()} "
+            "[outlet-referenced warm-start auto-retry; the primary "
+            f"'{init_strategy}' attempt failed at |F|={primary_norm:.3e} "
+            f"with: {primary_msg[:120]}]"
+        )
+        return retry_sol
+
+    def _outlet_ref_incompressible_seed(
+        self, use_jac: bool = True, timeout: float = 30.0
+    ) -> np.ndarray | None:
+        """Solve the incompressible outlet-referenced proxy; return its x.
+
+        Temporarily flips every compressible element to its incompressible
+        fallback regime and sets ``_incompressible_p_ref = 'outlet'`` on all
+        channel/orifice elements so densities are evaluated at the
+        downstream static. Returns the proxy solution vector for use as a
+        compressible warm start, or ``None`` when the proxy fails.
+        """
+        overrides = self._compressible_element_overrides()
+        if not overrides:
+            return None
+        original_regimes = {
+            elem_id: getattr(self.network.elements[elem_id], "regime", None)
+            for elem_id in overrides
+        }
+        ref_elems = [
+            e
+            for e in self.network.elements.values()
+            if isinstance(e, (ChannelElement, OrificeElement))
+        ]
+        seed: np.ndarray | None = None
+        try:
+            for elem_id, fallback_regime in overrides.items():
+                self.network.elements[elem_id].regime = fallback_regime
+            for e in ref_elems:
+                e._incompressible_p_ref = "outlet"
+            self.network.resolve_all_topology()
+            self._in_warmstart_proxy = True
+            # No maxfev cap: the outlet-referenced system is stiffer than
+            # the classic inlet-referenced one (couples pressures through
+            # the downstream density) and can need a few hundred cheap
+            # incompressible evaluations. A tight timeout would push the
+            # solve into the slower LM fallback phase and starve it.
+            proxy_sol = self._solve_impl(
+                method="hybr",
+                timeout=timeout,
+                use_jac=use_jac,
+                x0=None,
+                init_strategy="default",
+            )
+            if bool(proxy_sol.get("__success__", False)):
+                candidate = getattr(self, "_last_x", None)
+                if candidate is not None:
+                    seed = np.asarray(candidate, dtype=float)
+        except Exception as e:
+            warnings.warn(
+                "Outlet-referenced incompressible proxy solve raised; "
+                f"skipping warm-start auto-retry: {e}",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            seed = None
+        finally:
+            self._in_warmstart_proxy = False
+            for elem_id, regime in original_regimes.items():
+                self.network.elements[elem_id].regime = regime
+            for e in ref_elems:
+                e._incompressible_p_ref = "inlet"
+            self.network.resolve_all_topology()
+        return seed
+
+    def _solve_impl(
+        self,
+        method: str = "hybr",
+        timeout: float | None = None,
+        options: dict[str, Any] | None = None,
+        use_jac: bool = True,
+        x0: np.ndarray | None = None,
+        init_strategy: Literal[
+            "default", "incompressible_warmstart", "homotopy", "analytical_pt_prop"
+        ] = "default",
+        warmstart_maxfev: int = 150,
+        lambda_steps: list[float] | None = None,
+    ) -> dict[str, float]:
+        """
+        Single solve attempt (no auto-retry). See ``solve`` for the
+        public entry point and argument semantics.
 
         Args:
             method: The scipy.optimize.root method to use.
@@ -1563,7 +1758,7 @@ class NetworkSolver:
                     self._in_warmstart_proxy = True
                     with warnings.catch_warnings():
                         warnings.simplefilter("ignore", DeprecationWarning)
-                        warm_sol = self.solve(
+                        warm_sol = self._solve_impl(
                             method="hybr",
                             timeout=timeout,
                             options=warm_options,
@@ -1607,6 +1802,12 @@ class NetworkSolver:
 
                 current_x0 = None
                 last_sol = {"__success__": False}
+                # The whole ladder shares the caller's timeout as a
+                # deadline. Previously each rung got the full budget, so
+                # a slow ladder could run to ~6x the requested timeout --
+                # blowing straight through the GUI's hard (soft + 10 s)
+                # request timeout.
+                _ladder_t0 = time.time()
 
                 for lam in lambda_steps:
                     # Update boundaries
@@ -1621,9 +1822,12 @@ class NetworkSolver:
                     # it.  The setdefault here is only reached if the caller
                     # explicitly zeroed out maxfev/maxiter, which should not happen.
 
-                    last_sol = self.solve(
+                    rung_timeout = (
+                        None if timeout is None else max(timeout - (time.time() - _ladder_t0), 1.0)
+                    )
+                    last_sol = self._solve_impl(
                         method=method,
-                        timeout=timeout,
+                        timeout=rung_timeout,
                         options=step_options,
                         use_jac=use_jac,
                         x0=current_x0,

--- a/python/combaero/network/solver.py
+++ b/python/combaero/network/solver.py
@@ -1468,17 +1468,31 @@ class NetworkSolver:
             RuntimeWarning,
             stacklevel=2,
         )
-        proxy_timeout = 30.0 if timeout is None else max(min(0.25 * timeout, 30.0), 10.0)
+        # Heavy networks (high Re, thermal surfaces) can need tens of
+        # seconds even for the incompressible proxy (observed 35 s on a
+        # 16 kg/s 20 bar 5-tee net), so give it up to 60 s / 30% of budget.
+        proxy_timeout = 60.0 if timeout is None else max(min(0.3 * timeout, 60.0), 10.0)
         _primary_diag = getattr(self, "_diagnostic_data", None)
         seed_x0 = self._outlet_ref_incompressible_seed(use_jac=use_jac, timeout=proxy_timeout)
+        _seed_kind = "outlet-referenced"
+        if seed_x0 is None:
+            # The outlet-referenced system is stiffer and can time out where
+            # the classic inlet-referenced proxy solves in a handful of
+            # evaluations; its (coarser) seed still rescues heavy MFB-driven
+            # networks, so fall back to it before giving up.
+            seed_x0 = self._outlet_ref_incompressible_seed(
+                use_jac=use_jac, timeout=proxy_timeout, p_ref="inlet"
+            )
+            _seed_kind = "inlet-referenced (outlet-ref proxy did not converge)"
         if seed_x0 is None:
             # Restore the primary attempt's diagnostics -- the failed proxy
-            # solve overwrote them, and we are returning the primary result.
+            # solves overwrote them, and we are returning the primary result.
             if _primary_diag is not None:
                 self._diagnostic_data = _primary_diag
             sol["__message__"] = (
-                f"{primary_msg} [outlet-referenced incompressible warm-start "
-                "auto-retry skipped: the proxy solve did not converge]"
+                f"{primary_msg} [incompressible warm-start auto-retry "
+                "skipped: neither the outlet- nor the inlet-referenced "
+                "proxy solve converged]"
             )
             return sol
 
@@ -1499,33 +1513,43 @@ class NetworkSolver:
         if isinstance(_diag, dict):
             _ssu = _diag.get("solver_settings_used")
             if isinstance(_ssu, dict):
-                _ssu["init_strategy"] = "outletref_warmstart"
+                _ssu["init_strategy"] = (
+                    "outletref_warmstart"
+                    if _seed_kind.startswith("outlet")
+                    else "inletref_warmstart"
+                )
                 _ssu["auto_retry"] = True
         if retry_sol.get("__success__", False):
             retry_sol["__message__"] = (
-                "Converged via outlet-referenced incompressible warm-start "
+                f"Converged via {_seed_kind} incompressible warm-start "
                 f"auto-retry after the '{init_strategy}' attempt failed "
                 f"({primary_msg[:120]})."
             )
             return retry_sol
         retry_sol["__message__"] = (
             f"{str(retry_sol.get('__message__', '')).strip()} "
-            "[outlet-referenced warm-start auto-retry; the primary "
+            f"[{_seed_kind} warm-start auto-retry; the primary "
             f"'{init_strategy}' attempt failed at |F|={primary_norm:.3e} "
             f"with: {primary_msg[:120]}]"
         )
         return retry_sol
 
     def _outlet_ref_incompressible_seed(
-        self, use_jac: bool = True, timeout: float = 30.0
+        self,
+        use_jac: bool = True,
+        timeout: float = 30.0,
+        p_ref: str = "outlet",
     ) -> np.ndarray | None:
-        """Solve the incompressible outlet-referenced proxy; return its x.
+        """Solve the incompressible proxy; return its solution vector.
 
         Temporarily flips every compressible element to its incompressible
-        fallback regime and sets ``_incompressible_p_ref = 'outlet'`` on all
-        channel/orifice elements so densities are evaluated at the
-        downstream static. Returns the proxy solution vector for use as a
-        compressible warm start, or ``None`` when the proxy fails.
+        fallback regime and sets ``_incompressible_p_ref = p_ref`` on all
+        channel/orifice elements. ``p_ref='outlet'`` (default) evaluates
+        densities at the downstream static -- the seed that tracks the
+        compressible solution best; ``p_ref='inlet'`` is the classic,
+        easier-to-solve proxy used as a fallback. Returns the proxy
+        solution vector for use as a compressible warm start, or ``None``
+        when the proxy fails.
         """
         overrides = self._compressible_element_overrides()
         if not overrides:
@@ -1544,7 +1568,7 @@ class NetworkSolver:
             for elem_id, fallback_regime in overrides.items():
                 self.network.elements[elem_id].regime = fallback_regime
             for e in ref_elems:
-                e._incompressible_p_ref = "outlet"
+                e._incompressible_p_ref = p_ref
             self.network.resolve_all_topology()
             self._in_warmstart_proxy = True
             # No maxfev cap: the outlet-referenced system is stiffer than

--- a/python/tests/test_network_compressible.py
+++ b/python/tests/test_network_compressible.py
@@ -1288,3 +1288,51 @@ def test_auto_retry_skipped_on_incompressible_networks():
     sol = solver.solve(timeout=30.0)
     assert not sol["__success__"]
     assert len(calls) == 1
+
+
+def test_outlet_ref_proxy_seed_tracks_compressible_root_better_than_inlet():
+    """Core hypothesis pin (2026-07-05 outlet-ref seed experiment): the
+    incompressible proxy with densities at the DOWNSTREAM static lands
+    closer to the compressible solution than the classic inlet-referenced
+    proxy -- measured as RMS over pressure unknowns. If a model change
+    breaks this ordering, the auto-retry seed quality regresses silently."""
+    net = _mfb_branch_tee_orifice_network(0.2, "compressible")
+    solver = NetworkSolver(net)
+    sol = solver.solve(timeout=60.0, auto_retry=False)
+    assert sol["__success__"], sol.get("__message__")
+    names = solver.unknown_names
+    x_comp = {n: sol[n] for n in names}
+
+    seed_out = solver._outlet_ref_incompressible_seed(p_ref="outlet", timeout=30.0)
+    seed_in = solver._outlet_ref_incompressible_seed(p_ref="inlet", timeout=30.0)
+    assert seed_out is not None, "outlet-ref proxy must converge on this fixture"
+    assert seed_in is not None, "inlet-ref proxy must converge on this fixture"
+
+    def rms_p(seed) -> float:
+        sq = [
+            (v - x_comp[n]) ** 2
+            for n, v in zip(names, seed, strict=False)
+            if ".P" in n or ".Pt" in n
+        ]
+        return math.sqrt(sum(sq) / len(sq))
+
+    assert rms_p(seed_out) < rms_p(seed_in)
+
+
+def test_outlet_ref_seeded_solve_reaches_same_root_as_cold():
+    """The outlet-ref seed must not steer the compressible solve to a
+    different root than the cold start finds."""
+    net = _mfb_branch_tee_orifice_network(0.2, "compressible")
+    solver = NetworkSolver(net)
+    sol_cold = solver.solve(timeout=60.0, auto_retry=False)
+    assert sol_cold["__success__"], sol_cold.get("__message__")
+
+    net2 = _mfb_branch_tee_orifice_network(0.2, "compressible")
+    solver2 = NetworkSolver(net2)
+    net2.resolve_all_topology()
+    seed = solver2._outlet_ref_incompressible_seed(p_ref="outlet", timeout=30.0)
+    assert seed is not None
+    sol_seeded = solver2.solve(timeout=60.0, x0=seed)
+    assert sol_seeded["__success__"], sol_seeded.get("__message__")
+    assert sol_seeded["ch_str.m_dot"] == pytest.approx(sol_cold["ch_str.m_dot"], rel=1e-3)
+    assert sol_seeded["ch_bra.m_dot"] == pytest.approx(sol_cold["ch_bra.m_dot"], rel=1e-3)

--- a/python/tests/test_network_compressible.py
+++ b/python/tests/test_network_compressible.py
@@ -865,7 +865,10 @@ def test_mpce_network_default_init_auto_upgrades():
         flow_direction="branch",
     )
     solver = NetworkSolver(net)
-    _ = solver.solve(timeout=10.0, options={"maxfev": 5})
+    # auto_retry=False: this test forces a failure (maxfev=5) to inspect
+    # the recorded strategy; with the retry enabled the diagnostics would
+    # reflect the outlet-ref warm-start retry instead of the upgrade.
+    _ = solver.solve(timeout=10.0, options={"maxfev": 5}, auto_retry=False)
     used = solver._diagnostic_data["solver_settings_used"]["init_strategy"]
     assert used == "analytical_pt_prop"
 
@@ -943,6 +946,7 @@ def test_analytical_pt_prop_respects_user_initial_guess():
         init_strategy="analytical_pt_prop",
         timeout=10.0,
         options={"maxfev": 5},  # 5 evals: enough to observe x0 but not to converge
+        auto_retry=False,
     )
     # After solve, _init_overrides must be cleared (single-shot semantics).
     assert solver._init_overrides == {}
@@ -1175,3 +1179,112 @@ def test_flow_tee_pressure_cold_start_converges(regime: str):
     assert m_str + m_bra == pytest.approx(0.2, abs=1e-4)
     # The larger straight orifice (0.032 vs 0.03 bore) must carry more flow.
     assert m_str > m_bra
+
+
+def _mk_state(P: float, Pt: float, m_dot: float = 0.1) -> "object":
+    from combaero.network.components import NetworkMixtureState
+
+    y_air = list(cb.mole_to_mass(cb.species.dry_air()))
+    return NetworkMixtureState(P=P, Pt=Pt, T=300.0, Tt=300.0, m_dot=m_dot, Y=y_air)
+
+
+def test_outlet_ref_channel_moves_density_sensitivity_downstream():
+    """With _incompressible_p_ref='outlet' the incompressible channel
+    evaluates density at the downstream static, so the friction-loss
+    pressure sensitivity must land on the downstream node's P (and the
+    default inlet reference must be unchanged)."""
+    ch = ChannelElement("ch", "up", "dn", length=1.0, diameter=0.05, regime="incompressible")
+    s_in = _mk_state(P=1.5e5, Pt=1.51e5)
+    s_out = _mk_state(P=1.2e5, Pt=1.21e5)
+
+    _, jac_default = ch.residuals(s_in, s_out)
+    assert "up.P" in jac_default[0]
+    assert "dn.P" not in jac_default[0]
+
+    ch._incompressible_p_ref = "outlet"
+    res_out, jac_outlet = ch.residuals(s_in, s_out)
+    assert "dn.P" in jac_outlet[0]
+    assert "up.P" not in jac_outlet[0]
+
+    # Lower reference pressure -> lower density -> higher velocity ->
+    # larger friction loss -> smaller residual (res = Pt_in - Pt_out - dP).
+    ch._incompressible_p_ref = "inlet"
+    res_inlet, _ = ch.residuals(s_in, s_out)
+    assert res_out[0] < res_inlet[0]
+
+
+def test_outlet_ref_orifice_moves_density_sensitivity_downstream():
+    orf = OrificeElement(
+        "orf", "up", "dn", Cd=0.6, diameter=0.03, regime="incompressible", correlation="fixed"
+    )
+    s_in = _mk_state(P=1.5e5, Pt=1.51e5)
+    s_out = _mk_state(P=1.2e5, Pt=1.2e5)
+
+    _, jac_default = orf.residuals(s_in, s_out)
+    assert "up.P" in jac_default[0]
+
+    orf._incompressible_p_ref = "outlet"
+    _, jac_outlet = orf.residuals(s_in, s_out)
+    assert "up.P" not in jac_outlet[0]
+    assert "dn.P" in jac_outlet[0]
+
+
+def test_auto_retry_outletref_rescues_failed_cold_solve():
+    """When the cold compressible solve fails, solve() must retry from
+    the outlet-referenced incompressible warm start and succeed. The
+    primary failure is forced so the test is deterministic and fast."""
+    net = _mfb_branch_tee_orifice_network(0.2, "compressible")
+    solver = NetworkSolver(net)
+    real_impl = solver._solve_impl
+    calls: list[dict] = []
+
+    def fake_impl(**kwargs):
+        calls.append(kwargs)
+        if len(calls) == 1:
+            return {"__success__": False, "__message__": "forced failure", "__final_norm__": 1e3}
+        return real_impl(**kwargs)
+
+    solver._solve_impl = fake_impl
+    with pytest.warns(RuntimeWarning, match="auto-retrying"):
+        sol = solver.solve(timeout=120.0)
+    assert sol["__success__"], sol.get("__message__")
+    # primary (forced fail) + incompressible proxy + seeded retry
+    assert len(calls) == 3
+    assert calls[1].get("x0") is None  # proxy solves cold
+    assert calls[2].get("x0") is not None  # retry is seeded
+    ssu = solver._diagnostic_data["solver_settings_used"]
+    assert ssu["init_strategy"] == "outletref_warmstart"
+    assert ssu["auto_retry"] is True
+    assert "auto-retry" in sol["__message__"]
+
+
+def test_auto_retry_optout_returns_primary_failure():
+    net = _mfb_branch_tee_orifice_network(0.2, "compressible")
+    solver = NetworkSolver(net)
+    calls: list[dict] = []
+
+    def fake_impl(**kwargs):
+        calls.append(kwargs)
+        return {"__success__": False, "__message__": "forced failure", "__final_norm__": 1e3}
+
+    solver._solve_impl = fake_impl
+    sol = solver.solve(timeout=30.0, auto_retry=False)
+    assert not sol["__success__"]
+    assert len(calls) == 1
+
+
+def test_auto_retry_skipped_on_incompressible_networks():
+    """The retry proxy re-solves in the incompressible regime, which is a
+    no-op for already-incompressible networks -- no retry there."""
+    net = _mfb_branch_tee_orifice_network(0.2, "incompressible")
+    solver = NetworkSolver(net)
+    calls: list[dict] = []
+
+    def fake_impl(**kwargs):
+        calls.append(kwargs)
+        return {"__success__": False, "__message__": "forced failure", "__final_norm__": 1e3}
+
+    solver._solve_impl = fake_impl
+    sol = solver.solve(timeout=30.0)
+    assert not sol["__success__"]
+    assert len(calls) == 1

--- a/scripts/check-python-style.sh
+++ b/scripts/check-python-style.sh
@@ -225,7 +225,10 @@ if "${PYTHON}" -m mypy --version > /dev/null 2>&1; then
         if [ "$VERBOSE" = true ]; then
             echo "$MYPY_OUTPUT"
         else
-            echo "$MYPY_OUTPUT" | grep "error:" | head -10
+            # sed consumes all input (unlike head, which closes the pipe
+            # early and can kill grep with SIGPIPE -> exit 141 under
+            # `set -o pipefail`, flakily failing the pre-commit hook).
+            echo "$MYPY_OUTPUT" | grep "error:" | sed -n '1,10p'
         fi
         if [ "$STRICT" = true ]; then
             ((VIOLATIONS++))


### PR DESCRIPTION
## Summary

Implements the auto-retry for failed cold solves on compressible MPCE networks — but the retry strategy is the **outlet-referenced incompressible warm start** (the user's outlet-pressure hypothesis), not homotopy.

### The outlet-reference result

Solving the incompressible proxy with element densities evaluated at the **downstream** static pressure lands 6–7× closer to the compressible solution than the classic inlet-referenced form:

| case | inlet-ref RMS(P) / as seed | outlet-ref RMS(P) / as seed |
|---|---|---|
| one-tee 0.4 kg/s | 32.1 kPa / 194 evals | **5.1 kPa / 50 evals** |
| 5-tee 0.32 kg/s | 210.8 kPa / seed FAILS | **29.9 kPa / 96 evals** |
| 5-tee 0.18 kg/s | 56.2 kPa / 237 evals | **8.6 kPa / 69 evals** |

(`tmp/outlet_ref_seed_experiment.py`, 2026-07-05)

### Why not homotopy

The homotopy ladder's true wall cost is 64–200 s on the 5-tee network — each rung is a full nonlinear solve, and earlier per-rung `wall_time` figures undercounted it. The outlet-ref proxy costs ~2–8 s and its seed dominates.

## Changes

- `ChannelElement`/`OrificeElement` incompressible residuals honor `_incompressible_p_ref = "outlet"`: density at `state_out.P`, sensitivity remapped onto the downstream node's P (analytical Jacobian stays exact).
- `NetworkSolver.solve(auto_retry=True)`: failed cold `default`/`analytical_pt_prop` solves on compressible MPCE networks re-solve the outlet-ref incompressible proxy and warm-start a retry. Budget: primary 40%, proxy ≤ 25% (no maxfev cap — the outlet-ref system needs a few hundred cheap evals; starving it pushes the solve into the slow LM phase), retry the rest. Effective strategy recorded as `outletref_warmstart` + `auto_retry: true` (GUI badge shows it as `init: outletref_warmstart (auto)` with no frontend change). Primary diagnostics restored when the proxy fails.
- **Homotopy ladder timeout fix**: rungs now share the caller's `timeout` as a total deadline. Previously each rung got the full budget (up to ~6× overrun), which is how an explicit-homotopy GUI solve blew through the hard `soft + 10 s` request timeout and returned the ironic 504.
- `scripts/check-python-style.sh`: `grep | head` SIGPIPE race under `set -o pipefail` flakily failed the pre-commit hook when mypy reported > 10 (pre-existing, unrelated) errors; replaced `head` with `sed -n '1,10p'`.
- Tests: outlet-ref Jacobian remap (channel + orifice), retry rescue wiring, opt-out, incompressible-network skip. Auto-upgrade stamp tests now pass `auto_retry=False` to inspect the primary attempt in isolation.

## Verification

- `gui/tmp/network_5_mpce_tees-2.json` at 0.32 kg/s compressible (the worst slow pocket: cold needs 161 s, previously failed at any GUI timeout): `solve(timeout=90)` converges in **85.5 s** via the auto-retry.
- Affected suites: 147 passed. Full pre-commit suite green on commit.

Recommend compressible tee networks get 90–120 s timeouts in the GUI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
