### PR TITLE
feat(solver): stall-triggered handover from hybr to the LM fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Solver: stall-triggered handover from hybr to the LM fallback.**
+  On compressible/tee networks hybr previously kept 65% of the
+  wall-clock budget even when its best residual had flatlined; the LM
+  fallback (which is what actually cracks these networks) only started
+  afterwards. A plateau detector now ends the hybr phase early: if the
+  best |F| improves by less than 10% over a trailing 5 s window while
+  still far from tolerance (> 100x), a ``SolverStallError`` (a
+  ``SolverTimeoutError`` subclass, so every existing handler applies)
+  hands the remaining budget to the LM fallback. Verified live: a
+  16 kg/s 20 bar 5-tee network drops from 103.5 s to 23.0 s
+  ("hybr stalled at 1.2e4, LM |F|=1.7e-4"), while steadily-converging
+  networks are untouched (the detector never fires on them). The
+  far-from-tolerance gate exists because slow-but-steady grinding near
+  the root is not a stall: the outlet-ref seeded retry on a 5-tee at
+  0.18 kg/s crawls at |F| ~ 1e-2 before converging, and cutting it
+  over to LM turned that success into a failure during live
+  verification. Diagnostics record ``stall_handover: true``.
+  Alternating hybr/LM was evaluated first and rejected: chaining the
+  best iterate between methods poisons LM with hybr's plateau basin
+  and failed on all four benchmark cases (``tmp/alternating_probe.py``,
+  ``tmp/stall_detector_sim.py``, ``tmp/stall_handover_verify.py``).
 - **Solver: automatic outlet-referenced incompressible warm-start retry
   for failed cold solves on compressible MPCE networks.** Cold hybr on
   compressible tee networks shows non-monotone "slow pockets" (5-tee

--- a/python/combaero/network/solver.py
+++ b/python/combaero/network/solver.py
@@ -30,6 +30,65 @@ class SolverTimeoutError(Exception):
     pass
 
 
+class SolverStallError(SolverTimeoutError):
+    """Raised when hybr's best residual plateaus and an LM fallback exists.
+
+    Subclasses SolverTimeoutError so every existing handler treats it as
+    "this phase is over, keep the best iterate" -- the LM fallback then
+    runs with all the remaining budget instead of waiting for hybr to
+    burn its fixed share.
+    """
+
+    pass
+
+
+# Stall-handover tuning. Validated offline against recorded convergence
+# histories (tmp/stall_detector_sim.py) and live (tmp/stall_handover_
+# verify.py, 2026-07-05): with a 5 s window and a 10% relative-improvement
+# floor the detector fired at 15.5 s on a 16 kg/s 20 bar 5-tee network
+# where hybr plateaus at |F| ~ 1e4 and LM-from-cold converges in ~6 s
+# (103.5 s -> 23.0 s total), and never fired on networks where hybr
+# converges steadily (one-tee 0.4, 5-tee 0.18). The far-from-tolerance
+# gate (100x tol) exists because slow-but-steady grinding NEAR the root
+# is not a stall: the outlet-ref seeded retry on the 5-tee at 0.18 kg/s
+# crawls at |F| ~ 1e-2 for a while and then converges -- cutting it over
+# to LM (which cannot finish that network) turned a success into a
+# failure during live verification.
+_STALL_WINDOW_S = 5.0
+_STALL_MIN_REL_IMPROVEMENT = 0.10
+_STALL_FAR_FACTOR = 100.0
+
+
+def _hybr_stall_detected(
+    samples: list[tuple[float, float]],
+    window: float = _STALL_WINDOW_S,
+    min_rel: float = _STALL_MIN_REL_IMPROVEMENT,
+    tol: float = 1e-3,
+    far_factor: float = _STALL_FAR_FACTOR,
+) -> bool:
+    """Return True when the best-|F| trace has plateaued far from the root.
+
+    ``samples`` is the per-eval history of ``(t_elapsed_s, best_norm)``
+    with best_norm non-increasing. Stall = the newest best norm is still
+    far above tolerance (``> far_factor * tol``) and improved by less
+    than ``min_rel`` relative to the best norm from ``window`` seconds
+    ago. Histories shorter than the window never stall (grace period).
+    """
+    if not samples:
+        return False
+    t_now, best_now = samples[-1]
+    if best_now <= far_factor * tol or t_now < window:
+        return False
+    best_then = None
+    for tv, bv in reversed(samples):
+        if tv <= t_now - window:
+            best_then = bv
+            break
+    if best_then is None or best_then <= 0.0:
+        return False
+    return (best_then - best_now) / best_then < min_rel
+
+
 class NetworkSolver:
     """
     Orchestrates the numerical solution of a fluid flow network using scipy.optimize.root.
@@ -1951,6 +2010,11 @@ class NetworkSolver:
         _RECORD_INTERVAL = 0.1
         _eval_count: list[int] = [0]
         _lm_started_at_eval: list[int | None] = [None]
+        # Per-eval (t, best|F|) trace for the stall detector; checked every
+        # _STALL_CHECK_EVERY evals during the hybr phase only.
+        _stall_samples: list[tuple[float, float]] = []
+        _STALL_CHECK_EVERY = 10
+        _stall_fired: list[bool] = [False]
 
         # State for timeout and best iterate tracking (in real space)
         start_time = time.perf_counter()
@@ -1987,6 +2051,26 @@ class NetworkSolver:
                     _history.append({"eval": _eval_count[0], "t": round(_t, 3), "norm": res_norm})
                     _last_record_t[0] = _t
                 _eval_count[0] += 1
+
+                # Stall-triggered handover to the LM fallback: when hybr's
+                # best |F| plateaus there is no point burning the rest of
+                # its budget share -- LM (which is what actually cracks
+                # these networks) should get the time instead. Active only
+                # while a compressible/tee LM fallback exists and has not
+                # started yet.
+                if method == "hybr" and _has_compressible and _lm_started_at_eval[0] is None:
+                    _stall_samples.append((_t, float(best_res_norm)))
+                    if _eval_count[0] % _STALL_CHECK_EVERY == 0 and _hybr_stall_detected(
+                        _stall_samples, tol=_RESIDUAL_TOL
+                    ):
+                        _stall_fired[0] = True
+                        raise SolverStallError(
+                            f"hybr stalled: best |F|={best_res_norm:.3e} "
+                            f"improved less than "
+                            f"{_STALL_MIN_REL_IMPROVEMENT:.0%} over the last "
+                            f"{_STALL_WINDOW_S:.0f} s; handing over to the "
+                            "LM fallback."
+                        )
 
                 # Scale residuals
                 res_scaled = res * inv_D_f
@@ -2105,9 +2189,11 @@ class NetworkSolver:
                     if _lm_norm < _RESIDUAL_TOL:
                         final_x = best_x
                         success = True
+                        _hybr_end = "stalled at" if _stall_fired[0] else "|F|="
                         message = (
                             f"Converged with LM fallback "
-                            f"(hybr |F|={final_norm:.3e}, LM |F|={_lm_norm:.3e})."
+                            f"(hybr {_hybr_end} {final_norm:.3e}, "
+                            f"LM |F|={_lm_norm:.3e})."
                         )
                         final_norm = _lm_norm
                 except SolverTimeoutError:
@@ -2183,6 +2269,7 @@ class NetworkSolver:
             "residual_breakdown": _breakdown,
             "worst_residuals": [{"name": n, "residual": v} for n, v in _worst],
             "lm_started_at_eval": _lm_started_at_eval[0],
+            "stall_handover": _stall_fired[0],
             "solver_settings_used": {
                 "method": method,
                 "init_strategy": init_strategy,

--- a/python/tests/test_solver_timeout.py
+++ b/python/tests/test_solver_timeout.py
@@ -101,3 +101,64 @@ def test_solver_unexpected_error_graceful_exit():
         solution = solver.solve()
 
     assert "orf.m_dot" in solution
+
+
+# ---------------------------------------------------------------------------
+# Stall-triggered LM handover: plateau detector unit tests
+# ---------------------------------------------------------------------------
+
+
+def _trace(points: list[tuple[float, float]]) -> list[tuple[float, float]]:
+    """Build a running-best (t, best|F|) trace from raw (t, |F|) points."""
+    out: list[tuple[float, float]] = []
+    best = float("inf")
+    for t, norm in points:
+        best = min(best, norm)
+        out.append((t, best))
+    return out
+
+
+def test_stall_detector_fires_on_far_plateau():
+    """A residual parked at |F| ~ 1e4 (far above tolerance) for longer
+    than the window is a stall (the 16 kg/s 5-tee signature: hybr
+    plateaus, LM-from-x0 converges in seconds)."""
+    from combaero.network.solver import _hybr_stall_detected
+
+    trace = _trace([(0.5 * i, 1.0e4) for i in range(30)])
+    assert _hybr_stall_detected(trace, window=5.0, min_rel=0.10, tol=1e-3)
+
+
+def test_stall_detector_ignores_steady_improvement():
+    """20% improvement per window is progress, not a stall."""
+    from combaero.network.solver import _hybr_stall_detected
+
+    trace = _trace([(0.5 * i, 1.0e4 * (0.8 ** (0.5 * i / 5.0))) for i in range(60)])
+    assert not _hybr_stall_detected(trace, window=5.0, min_rel=0.10, tol=1e-3)
+
+
+def test_stall_detector_ignores_slow_grind_near_tolerance():
+    """Regression (live verification 2026-07-05): the outlet-ref seeded
+    retry on the 5-tee at 0.18 kg/s crawls at |F| ~ 1e-2 (12x tol) and
+    then converges. Cutting it over to LM turned a success into a
+    failure, so plateaus below far_factor*tol must NOT count."""
+    from combaero.network.solver import _hybr_stall_detected
+
+    trace = _trace([(0.5 * i, 1.2e-2) for i in range(30)])
+    assert not _hybr_stall_detected(trace, window=5.0, min_rel=0.10, tol=1e-3, far_factor=100.0)
+
+
+def test_stall_detector_grace_period():
+    """Histories shorter than the window never stall."""
+    from combaero.network.solver import _hybr_stall_detected
+
+    trace = _trace([(0.5 * i, 1.0e4) for i in range(8)])  # 3.5 s < 5 s
+    assert not _hybr_stall_detected(trace, window=5.0, min_rel=0.10, tol=1e-3)
+    assert not _hybr_stall_detected([], window=5.0)
+
+
+def test_stall_error_is_timeout_subclass():
+    """SolverStallError must route through every existing timeout handler
+    (end the phase, keep the best iterate, reach the LM fallback)."""
+    from combaero.network.solver import SolverStallError, SolverTimeoutError
+
+    assert issubclass(SolverStallError, SolverTimeoutError)


### PR DESCRIPTION
## Summary

Implements the stall-triggered hybr → LM handover (user observation: "hybr hangs on a plateau and lm rescues it"). Previously hybr kept 65% of the wall-clock budget even when flatlined; the LM fallback — which is what actually cracks these networks — only started afterwards.

**Alternating hybr/LM was evaluated first and rejected**: chaining the best iterate between methods poisons LM with hybr's plateau basin (the known LM-from-x0 issue) and failed on all four benchmark cases. lm-first wins spectacularly on one network (5.8 s vs 103.5 s) but loses on others — no fixed ordering dominates. Plateau detection is the variant that keeps every case's best path.

## Design

- Detector: best |F| improved < 10% over a trailing 5 s window, **and** still far from tolerance (> 100× tol). Checked every 10 evals, only during the hybr phase of compressible/tee solves where an LM fallback exists.
- On trigger: `SolverStallError` (subclass of `SolverTimeoutError`, so every existing handler applies — end the phase, keep the best iterate) routes into the existing LM fallback with all the remaining budget. LM keeps its restart-from-x0 behavior for MPCE nets.
- The far-from-tolerance gate is load-bearing: without it the detector fired on the outlet-ref seeded retry of the 5-tee at 0.18 kg/s, which crawls at |F| ≈ 1e-2 before converging — LM cannot finish that network, and the premature handover turned a success into a failure during live verification.
- Diagnostics record `stall_handover: true`; the LM success message reads "hybr stalled at …".

## Verification (live, 150 s budget)

| case | before | after |
|---|---|---|
| 16 kg/s 20 bar 5-tee | 103.5 s | **23.0 s** (stall at |F|=1.2e4 → LM) |
| one-tee 0.4 (steady hybr) | 25.5 s | 25.9 s, detector never fires |
| 5-tee 0.18 | retry path | converges via retry, detector silent on the grind |
| 5-tee 0.32 | retry path | converges via retry (primary fails faster → more retry budget) |

Detector unit tests in `test_solver_timeout.py` (fires on far plateau / ignores steady improvement / ignores near-tolerance grind / grace period / subclass contract). Affected suites: 120 passed. Full pre-commit suite green.

Evidence scripts: `tmp/alternating_probe.py`, `tmp/stall_detector_sim.py`, `tmp/stall_handover_verify.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
