### PR TITLE
fix(gui): stale-input cross-node edits, topology result invalidation, paste deep-clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to 29 s at timeout=90.
 
 ### Fixed
+- **GUI: editing a value could apply it to two nodes.** React Flow
+  prevents default on node mousedown, so a focused Inspector input never
+  blurred when clicking another node; React then reused the same input
+  component (still holding the typed value) rewired to the newly
+  selected node, and the eventual blur committed the old node's edit
+  onto it. The Inspector's node/edge subtrees are now keyed by the
+  selected entity's id, forcing a remount (fresh input state) on every
+  selection change.
+- **GUI: topology edits now invalidate stored results.** Adding or
+  removing nodes/edges (including drag-drop creation, new connections,
+  and paste) previously kept every node's ``result`` from the last
+  solve, and the backend warm-starts from those -- so after adding a
+  tee to a converged network the first solve was seeded with the old
+  topology's solution and stalled ("poisoned by 5-tee data" on a 6-tee
+  network). Structural changes now strip all stored node/edge results;
+  position/selection changes keep them.
+- **GUI: copy/paste no longer shares nested data between nodes.** The
+  clipboard stored live node references and paste spread ``data``
+  shallowly, so nested objects (composition, initial guesses, wall
+  layers) stayed shared between the original and the pasted node;
+  both are now deep-cloned.
 - **Homotopy init: the rung ladder now shares the caller's ``timeout``
   as a total deadline.** Previously every rung received the full budget,
   so an ``init_strategy="homotopy"`` solve could run to ~6x the

--- a/gui/frontend/src/components/Inspector.tsx
+++ b/gui/frontend/src/components/Inspector.tsx
@@ -130,7 +130,10 @@ const Inspector = () => {
 		);
 
 		return (
-			<aside className="w-80 border-l bg-white p-4 flex flex-col gap-4 overflow-y-auto">
+			<aside
+				key={selectedNode.id}
+				className="w-80 border-l bg-white p-4 flex flex-col gap-4 overflow-y-auto"
+			>
 				<h2 className="text-lg font-bold border-b pb-2 flex items-center gap-2 text-blue-600">
 					<Crosshair size={18} />
 					<span>Probe</span>
@@ -226,7 +229,17 @@ const Inspector = () => {
 
 	if (selectedNode) {
 		return (
-			<aside className="w-80 border-l bg-white p-4 flex flex-col gap-4 overflow-y-auto">
+			// key: remount the whole subtree when the selection changes.
+			// React Flow prevents default on node mousedown, so a focused
+			// input never blurs when the user clicks another node; without
+			// the remount React rewires the still-focused input (holding the
+			// typed value) to the NEW node, and the eventual blur commits the
+			// old node's edit onto it (observed as "diameter edit applied to
+			// 2 nodes").
+			<aside
+				key={selectedNode.id}
+				className="w-80 border-l bg-white p-4 flex flex-col gap-4 overflow-y-auto"
+			>
 				{validationErrors.length > 0 && (
 					<div className="bg-amber-50 border border-amber-200 p-2 rounded text-[10px] text-amber-800 flex flex-col gap-1">
 						<div className="font-bold uppercase">Network Warnings</div>
@@ -2702,7 +2715,10 @@ const Inspector = () => {
 		const h_total = h_total_inv > 0 ? 1 / h_total_inv : 0;
 
 		return (
-			<aside className="w-80 border-l bg-white p-4 flex flex-col gap-4 overflow-y-auto">
+			<aside
+				key={selectedEdge.id}
+				className="w-80 border-l bg-white p-4 flex flex-col gap-4 overflow-y-auto"
+			>
 				<h2 className="text-lg font-bold border-b pb-2 uppercase text-orange-600">
 					Thermal Wall
 				</h2>
@@ -2937,7 +2953,10 @@ const Inspector = () => {
 
 	if (selectedEdge) {
 		return (
-			<aside className="w-80 border-l bg-white p-4 flex flex-col gap-4 overflow-y-auto">
+			<aside
+				key={selectedEdge.id}
+				className="w-80 border-l bg-white p-4 flex flex-col gap-4 overflow-y-auto"
+			>
 				<h2 className="text-lg font-bold border-b pb-2 uppercase text-slate-600">
 					Connection
 				</h2>

--- a/gui/frontend/src/components/NetworkCanvas.tsx
+++ b/gui/frontend/src/components/NetworkCanvas.tsx
@@ -7,7 +7,7 @@ import ReactFlow, {
 import "reactflow/dist/style.css";
 import { useCallback } from "react";
 import { useCopyPaste } from "../hooks/useCopyPaste";
-import useStore from "../store/useStore";
+import useStore, { stripResults } from "../store/useStore";
 import { edgeTypes, nodeTypes } from "./flowTypes";
 import SolverStatusBadge from "./SolverStatusBadge";
 
@@ -119,7 +119,9 @@ const NetworkCanvas = () => {
 				data,
 			};
 
-			setNodes(nodes.concat(newNode));
+			// Adding a node is a structural edit: stored results solved a
+			// different network and must not warm-start the next solve.
+			setNodes(stripResults(nodes).concat(newNode));
 		},
 		[nodes, setNodes, screenToFlowPosition],
 	);

--- a/gui/frontend/src/hooks/useCopyPaste.ts
+++ b/gui/frontend/src/hooks/useCopyPaste.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from "react";
 import type { Node } from "reactflow";
-import useStore from "../store/useStore";
+import useStore, { stripResults } from "../store/useStore";
 
 const PASTE_OFFSET = 50;
 
@@ -32,20 +32,25 @@ export const useCopyPaste = () => {
 			if (e.key === "c") {
 				const selected = nodesRef.current.filter((n) => n.selected);
 				if (!selected.length) return;
-				clipboard.current = selected;
+				// Deep-clone: the clipboard must be a snapshot, and pasted
+				// nodes must never share nested data objects (composition,
+				// initial_guess, wall layers, ...) with the originals.
+				clipboard.current = structuredClone(selected);
 			}
 
 			if (e.key === "v" && clipboard.current?.length) {
 				e.preventDefault();
 				const stamp = Date.now().toString(36);
 				const newNodes: Node[] = clipboard.current.map((n, i) => {
-					// Copy physics/config data; strip identity fields and stale results
+					// Copy physics/config data; strip identity fields and stale results.
+					// structuredClone again: repeated pastes from the same clipboard
+					// must not share nested data objects with each other either.
 					const {
 						id: _id,
 						label: _label,
 						result: _result,
 						...physicsData
-					} = n.data as Record<string, unknown>;
+					} = structuredClone(n.data) as Record<string, unknown>;
 					const newId = `node_${stamp}_${i}`;
 					return {
 						...n,
@@ -62,7 +67,9 @@ export const useCopyPaste = () => {
 					};
 				});
 
-				const current = nodesRef.current;
+				// Structural edit: stored results solved a different network,
+				// so drop them from the existing nodes too.
+				const current = stripResults(nodesRef.current);
 				setNodes([
 					...current.map((n) => ({ ...n, selected: false })),
 					...newNodes,

--- a/gui/frontend/src/store/useStore.ts
+++ b/gui/frontend/src/store/useStore.ts
@@ -13,6 +13,22 @@ import { create } from "zustand";
 import { exportResults } from "../api";
 import { discoverFields } from "../utils/diagnostics";
 
+// Stored per-node/edge results warm-start the next solve (backend
+// graph_builder). A structural edit (add/remove node or edge, new
+// connection) changes the system those results solved, so they must be
+// dropped: a converged 5-tee solution seeding a 6-tee network poisons
+// the first solve after the topology edit. Position/selection changes
+// keep results.
+export const stripResults = <T extends Node | Edge>(items: T[]): T[] =>
+	items.map((item) => {
+		if (!item.data?.result) return item;
+		const { result: _result, ...rest } = item.data;
+		return { ...item, data: rest };
+	});
+
+const isStructural = (changes: (NodeChange | EdgeChange)[]): boolean =>
+	changes.some((c) => c.type === "add" || c.type === "remove");
+
 export interface RFState {
 	nodes: Node[];
 	edges: Edge[];
@@ -79,17 +95,29 @@ const useStore = create<RFState>((set, get) => ({
 	isExporting: false,
 
 	onNodesChange: (changes: NodeChange[]) => {
-		set({
-			nodes: applyNodeChanges(changes, get().nodes),
-			solveResults: null,
-		});
+		const nodes = applyNodeChanges(changes, get().nodes);
+		if (isStructural(changes)) {
+			set({
+				nodes: stripResults(nodes),
+				edges: stripResults(get().edges),
+				solveResults: null,
+			});
+		} else {
+			set({ nodes, solveResults: null });
+		}
 	},
 
 	onEdgesChange: (changes: EdgeChange[]) => {
-		set({
-			edges: applyEdgeChanges(changes, get().edges),
-			solveResults: null,
-		});
+		const edges = applyEdgeChanges(changes, get().edges);
+		if (isStructural(changes)) {
+			set({
+				edges: stripResults(edges),
+				nodes: stripResults(get().nodes),
+				solveResults: null,
+			});
+		} else {
+			set({ edges, solveResults: null });
+		}
 	},
 
 	onConnect: (connection: Connection) => {
@@ -123,7 +151,8 @@ const useStore = create<RFState>((set, get) => ({
 		} as Edge;
 
 		set({
-			edges: addEdge(edge, get().edges),
+			edges: stripResults(addEdge(edge, get().edges)),
+			nodes: stripResults(get().nodes),
 			solveResults: null,
 		});
 	},


### PR DESCRIPTION
## Summary

Three GUI integrity fixes for the field reports from the 6-tee session: cross-node "linked" edits, stale results poisoning solves after topology edits, and shallow copy/paste data sharing.

## 1. Editing a value could apply it to two nodes (the "linked edit")

User repro: select a node, change a value, click another node — the value lands on both. Root cause: React Flow prevents default on node mousedown, so the focused Inspector input **never blurs** when you click another node. React reuses the same input component (which still holds the typed value in local state) and rewires its `onChange` to the newly selected node; when the deferred blur finally fires, it commits the old node's edit onto the new node. The original already got the value per-keystroke — hence "two nodes".

Fix: the Inspector's node/edge subtrees are keyed by the selected entity's id, so every selection change remounts the inputs with fresh state. Not multi-select — no such feature existed. Saved networks were also scanned for duplicate node ids (the other candidate mechanism): none found.

## 2. Topology edits now invalidate stored results

Adding a 6th tee to a converged 5-tee network kept every node's `result`, and the backend warm-starts from stored results (#220 only gates *failed* ones) — so the first solve after the edit was seeded with the old topology's solution ("poisoned by 5-tee data"). Structural changes (drag-drop node creation, connect, delete, paste) now strip all stored node/edge results. Position and selection changes keep them, so normal canvas interaction doesn't destroy displayed results.

## 3. Copy/paste deep-clones

The clipboard stored live node references and paste spread `data` shallowly — nested objects (`composition`, `initial_guess`, wall `layers`) stayed shared between original and pasted nodes. Copy and paste now `structuredClone`.

## Verification

- Biome clean; pre-commit green.
- Manual check-list after restart: (a) edit value on node A, click node B → B unchanged; (b) solve a network, add a node or edge → all result overlays clear, next solve starts cold; (c) paste a humid-air boundary, edit the original's composition → pasted node unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
