### PR TITLE
chore(tests): share three-port solve, parallel pytest, CI coverage gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
               - '.pre-commit-config.yaml'
               - 'ruff.toml'
               - 'Makefile'
+              - 'uv.lock'
             gui:
               - 'gui/**'
             documentation:
@@ -207,6 +208,11 @@ jobs:
 
       - name: Build Python extension (MSVC)
         run: uv pip install --system --no-deps -e .
+
+      - name: Import smoke test (MSVC extension)
+        run: |
+          uv pip install --system pytest numpy scipy
+          python -m pytest python/tests/test_import.py -q
 
   status-check:
     # IMPORTANT: Keep this literal name in sync with Iron ruleset required context:

--- a/.github/workflows/validation-tests.yml
+++ b/.github/workflows/validation-tests.yml
@@ -45,6 +45,7 @@ jobs:
               - 'ruff.toml'
               - '.python-version'
               - 'Makefile'
+              - 'uv.lock'
             gui:
               - 'gui/**'
             documentation:
@@ -145,7 +146,7 @@ jobs:
         env:
           PYTHONPATH: ${{ github.workspace }}
         run: |
-          uv run pytest -v --tb=short
+          uv run pytest -n auto --dist loadscope -q --tb=short --durations=25
 
   frontend-validation:
     name: Frontend Validation (Node 24 LTS)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
 
       - id: python-unit-tests
         name: Python Unit Tests
-        entry: bash -c 'uv run pytest python/tests/ -v'
+        entry: bash -c 'uv run pytest python/tests/ -n auto --dist loadscope -q'
         language: system
         pass_filenames: false
         always_run: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **CI: Windows extension import smoke test.** The MSVC Python extension
+  build job now imports ``combaero`` and ``combaero._core`` via
+  ``pytest python/tests/test_import.py``; previously the extension was
+  built on Windows but never loaded, so DLL/ABI load failures could
+  merge undetected.
+- **GUI: frontend unit tests for topology result invalidation.**
+  ``useStore.test.ts`` locks in the result-stripping semantics shipped
+  with the GUI integrity fixes: structural edits (add/remove node or
+  edge, new connection) drop all stored node/edge results while
+  position/selection changes keep them.
 - **Solver: stall-triggered handover from hybr to the LM fallback.**
   On compressible/tee networks hybr previously kept 65% of the
   wall-clock budget even when its best residual had flatlined; the LM
@@ -92,6 +102,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   request timeout and returning a 504 instead of a diagnosable result.
 
 ### Changed
+- **Test suite and CI: 3-4x faster merge gate at unchanged coverage.**
+  The four ``test_three_port_*`` network tests now share one
+  module-scoped solve instead of re-running the identical ~3 min solve
+  each (that single network is a known doomed-primary case: hybr
+  stalls, the LM fallback grinds, and the outlet-referenced warm-start
+  retry rescues it in seconds -- the shared solve pins that
+  rescue-within-budget behavior with ``timeout=120``); pytest runs in
+  parallel (``pytest-xdist``, ``-n auto --dist loadscope``) in CI and
+  in the pre-commit hook; CI logs report ``--durations=25`` to keep
+  slow-test creep visible. Python unit test job: ~29 min to a few
+  minutes; local pre-commit test hook similarly.
+- **CI: dependency lockfile changes now trigger the test suite.**
+  ``uv.lock`` was missing from the change filters in both workflows,
+  so dependency bumps (e.g. scipy/numpy) could merge without running
+  a single Python test.
 - **MPCE networks now default to ``analytical_pt_prop`` initialization.**
   ``NetworkSolver.solve(init_strategy="default")`` auto-upgrades to
   ``analytical_pt_prop`` when the network contains a

--- a/gui/frontend/src/store/useStore.test.ts
+++ b/gui/frontend/src/store/useStore.test.ts
@@ -1,0 +1,128 @@
+/** @vitest-environment jsdom */
+import type { Edge, EdgeChange, Node, NodeChange } from "reactflow";
+import { beforeEach, describe, expect, it } from "vitest";
+import useStore, { stripResults } from "./useStore";
+
+// Regression coverage for the topology result invalidation shipped with the
+// GUI integrity fixes: stored per-node/edge results warm-start the next
+// solve, so structural edits must drop them while position/selection
+// changes keep them.
+
+const nodeWithResult = (id: string): Node => ({
+	id,
+	position: { x: 0, y: 0 },
+	data: { label: id, diameter: 0.05, result: { P: 101325, success: true } },
+});
+
+const edgeWithResult = (id: string, source: string, target: string): Edge => ({
+	id,
+	source,
+	target,
+	data: { result: { m_dot: 0.2 } },
+});
+
+describe("stripResults", () => {
+	it("removes data.result and preserves sibling keys", () => {
+		const stripped = stripResults([nodeWithResult("n1")]);
+		expect(stripped[0].data.result).toBeUndefined();
+		expect(stripped[0].data.label).toBe("n1");
+		expect(stripped[0].data.diameter).toBe(0.05);
+	});
+
+	it("returns items without a result unchanged", () => {
+		const plain: Node = {
+			id: "n1",
+			position: { x: 0, y: 0 },
+			data: { label: "n1" },
+		};
+		const noData: Node = {
+			id: "n2",
+			position: { x: 0, y: 0 },
+			data: undefined,
+		};
+		const stripped = stripResults([plain, noData]);
+		expect(stripped[0]).toBe(plain);
+		expect(stripped[1]).toBe(noData);
+	});
+});
+
+describe("useStore topology result invalidation", () => {
+	beforeEach(() => {
+		useStore.setState({
+			nodes: [nodeWithResult("n1"), nodeWithResult("n2")],
+			edges: [edgeWithResult("e1", "n1", "n2")],
+			solveResults: { success: true },
+		});
+	});
+
+	it("keeps results on position changes", () => {
+		const changes: NodeChange[] = [
+			{
+				id: "n1",
+				type: "position",
+				position: { x: 10, y: 20 },
+				dragging: false,
+			},
+		];
+		useStore.getState().onNodesChange(changes);
+		const { nodes, edges } = useStore.getState();
+		expect(nodes[0].position).toEqual({ x: 10, y: 20 });
+		expect(nodes[0].data.result).toBeDefined();
+		expect(edges[0].data.result).toBeDefined();
+	});
+
+	it("keeps results on selection changes", () => {
+		const changes: NodeChange[] = [
+			{ id: "n1", type: "select", selected: true },
+		];
+		useStore.getState().onNodesChange(changes);
+		expect(useStore.getState().nodes[0].data.result).toBeDefined();
+	});
+
+	it("strips all node and edge results when a node is removed", () => {
+		const changes: NodeChange[] = [{ id: "n2", type: "remove" }];
+		useStore.getState().onNodesChange(changes);
+		const { nodes, edges, solveResults } = useStore.getState();
+		expect(nodes.map((n) => n.id)).toEqual(["n1"]);
+		expect(nodes[0].data.result).toBeUndefined();
+		expect(edges[0].data.result).toBeUndefined();
+		expect(solveResults).toBeNull();
+	});
+
+	it("strips all node and edge results when a node is added", () => {
+		const changes: NodeChange[] = [
+			{ type: "add", item: { id: "n3", position: { x: 5, y: 5 }, data: {} } },
+		];
+		useStore.getState().onNodesChange(changes);
+		const { nodes, edges } = useStore.getState();
+		// applyNodeChanges prepends added items.
+		expect(nodes.map((n) => n.id)).toEqual(["n3", "n1", "n2"]);
+		expect(nodes[1].data.result).toBeUndefined();
+		expect(nodes[2].data.result).toBeUndefined();
+		expect(edges[0].data.result).toBeUndefined();
+	});
+
+	it("strips all node and edge results when an edge is removed", () => {
+		const changes: EdgeChange[] = [{ id: "e1", type: "remove" }];
+		useStore.getState().onEdgesChange(changes);
+		const { nodes, edges } = useStore.getState();
+		expect(edges).toEqual([]);
+		expect(nodes[0].data.result).toBeUndefined();
+		expect(nodes[1].data.result).toBeUndefined();
+	});
+
+	it("strips all node and edge results on a new connection", () => {
+		useStore.getState().onConnect({
+			source: "n2",
+			target: "n1",
+			sourceHandle: null,
+			targetHandle: null,
+		});
+		const { nodes, edges, solveResults } = useStore.getState();
+		expect(edges).toHaveLength(2);
+		expect(nodes[0].data.result).toBeUndefined();
+		expect(nodes[1].data.result).toBeUndefined();
+		expect(edges[0].data.result).toBeUndefined();
+		expect(solveResults).toBeNull();
+	});
+});

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dev = [
     "build>=1.2.0",
     "pytest-cov",
     "setuptools-scm>=10.0.5",
+    "pytest-xdist>=3.6",
 ]
 
 [tool.scikit-build]

--- a/python/tests/test_multi_port_chamber.py
+++ b/python/tests/test_multi_port_chamber.py
@@ -15,6 +15,7 @@ Hager / Bassett / Perez-Garcia / Wang reference data live in separate files.
 import math
 
 import numpy as np
+import pytest
 
 import combaero as cb
 from combaero.network import (
@@ -85,11 +86,25 @@ def _three_port_net(
     return net
 
 
-def test_three_port_network_converges():
-    """Solver assembles and converges on the basic 3-port momentum-CV network."""
+@pytest.fixture(scope="module")
+def three_port_solution() -> tuple[NetworkSolver, dict]:
+    """One shared solve of the default 3-port net for the test_three_port_*
+    assertions below (each previously re-ran the identical ~3 min solve).
+
+    The primary attempt on this net is known-doomed (hybr stalls, the LM
+    fallback grinds without converging) and the outlet-referenced warm-start
+    auto-retry rescues it in seconds; the finite timeout bounds the doomed
+    phase and pins that rescue-within-budget behavior.
+    """
     net = _three_port_net()
     solver = NetworkSolver(net)
-    sol = solver.solve()
+    sol = solver.solve(timeout=120.0)
+    return solver, sol
+
+
+def test_three_port_network_converges(three_port_solution):
+    """Solver assembles and converges on the basic 3-port momentum-CV network."""
+    solver, sol = three_port_solution
     assert sol["__success__"], f"did not converge: {sol.get('__message__')}"
 
     # Residual norm at the converged state is small.
@@ -98,7 +113,7 @@ def test_three_port_network_converges():
     assert max(abs(r) for r in res) < 1e-3, f"residuals not small: {res}"
 
 
-def test_three_port_mass_conservation():
+def test_three_port_mass_conservation(three_port_solution):
     """All three port flows balance at the junction (sum-mass residual = 0).
 
     Junction convention: ch_in is the declared inlet (sign -1: +ch_in is flow
@@ -106,9 +121,7 @@ def test_three_port_mass_conservation():
     are flow OUT of junction). Conservation:
         -ch_in.m_dot + ch_str.m_dot + ch_bra.m_dot = 0
     """
-    net = _three_port_net()
-    solver = NetworkSolver(net)
-    sol = solver.solve()
+    _, sol = three_port_solution
     assert sol["__success__"], f"did not converge: {sol.get('__message__')}"
 
     m_in = sol["ch_in.m_dot"]
@@ -120,7 +133,7 @@ def test_three_port_mass_conservation():
     )
 
 
-def test_three_port_converges_with_conservation():
+def test_three_port_converges_with_conservation(three_port_solution):
     """Network converges and conserves mass.
 
     Directional behaviour at asymmetric pressure BCs depends on the cross-
@@ -130,9 +143,7 @@ def test_three_port_converges_with_conservation():
     Section 3 (and the basis of the K6 < 0 region at low q). We assert
     convergence + mass conservation only; direction is BC-dependent.
     """
-    net = _three_port_net()
-    solver = NetworkSolver(net)
-    sol = solver.solve()
+    _, sol = three_port_solution
     assert sol["__success__"], f"did not converge: {sol.get('__message__')}"
 
     m_in = sol["ch_in.m_dot"]
@@ -147,14 +158,13 @@ def test_three_port_converges_with_conservation():
     )
 
 
-def test_three_port_p_jct_in_physical_range():
+def test_three_port_p_jct_in_physical_range(three_port_solution):
     """P_jct should lie between the lowest collector Pt and the source Pt."""
+    # Fixture defaults (see _three_port_net signature).
     Pt_in = 2.1e5
     Pt_str = 2.05e5
     Pt_bra = 2.00e5
-    net = _three_port_net(Pt_in=Pt_in, Pt_str=Pt_str, Pt_bra=Pt_bra)
-    solver = NetworkSolver(net)
-    sol = solver.solve()
+    _, sol = three_port_solution
     assert sol["__success__"]
 
     P_jct = sol["jct.P_jct"]

--- a/python/tests/test_network_compressible.py
+++ b/python/tests/test_network_compressible.py
@@ -822,6 +822,10 @@ def test_choke_barrier_rejects_dead_branch_spurious_root():
         psi=1.0,
         flow_direction="branch",
     )
+    # Residual probes outside solve() require resolved topology: without it
+    # the port MCNs are not marked as junction ports and _residuals is a
+    # different function than the one the solver sees.
+    net.resolve_all_topology()
     solver = NetworkSolver(net)
     x = solver._build_x0()
     spurious = {
@@ -868,7 +872,9 @@ def test_mpce_network_default_init_auto_upgrades():
     # auto_retry=False: this test forces a failure (maxfev=5) to inspect
     # the recorded strategy; with the retry enabled the diagnostics would
     # reflect the outlet-ref warm-start retry instead of the upgrade.
-    _ = solver.solve(timeout=10.0, options={"maxfev": 5}, auto_retry=False)
+    # Short timeout: only the recorded strategy stamp matters here; the LM
+    # fallback would otherwise idle away the rest of the budget.
+    _ = solver.solve(timeout=2.0, options={"maxfev": 5}, auto_retry=False)
     used = solver._diagnostic_data["solver_settings_used"]["init_strategy"]
     assert used == "analytical_pt_prop"
 
@@ -894,7 +900,8 @@ def test_mpce_explicit_strategy_opts_out_of_auto_upgrade():
         flow_direction="branch",
     )
     solver = NetworkSolver(net)
-    _ = solver.solve(init_strategy="homotopy", timeout=10.0, options={"maxfev": 5})
+    # Short timeout: only the recorded strategy stamp matters here.
+    _ = solver.solve(init_strategy="homotopy", timeout=2.0, options={"maxfev": 5})
     used = solver._diagnostic_data["solver_settings_used"]["init_strategy"]
     assert used == "homotopy"
 

--- a/uv.lock
+++ b/uv.lock
@@ -221,6 +221,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "setuptools-scm" },
 ]
@@ -244,6 +245,7 @@ dev = [
     { name = "pre-commit", specifier = ">=4.0.0" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist", specifier = ">=3.6" },
     { name = "ruff", specifier = ">=0.8.0" },
     { name = "setuptools-scm", specifier = ">=10.0.5" },
 ]


### PR DESCRIPTION
## Summary

Test/CI hygiene and speed PR. The Python unit test job was the merge-gate bottleneck: **28.9 min on CI** (every other required job finishes in < 7 min) and ~14.5 min locally in pre-commit on every commit. Profiling found 88% of the suite was four tests re-running one identical solve. This PR cuts the suite to **55 s locally** (15.7x) at unchanged coverage, and closes three CI coverage gaps found along the way.

## Speed (quality-neutral: same tests, same assertions)

**1. Share the three-port solve.** The four `test_three_port_*` tests in `test_multi_port_chamber.py` each rebuilt the identical `_three_port_net()` and paid a full ~190 s `solve(timeout=None)`. Diagnosis of one solve: the auto-upgraded primary attempt is *doomed* on this net — hybr stalls at |F|=3.7e3, the #224 stall handover fires correctly, the LM fallback grinds ~185 s without converging (unbounded because `timeout=None`) — and the #221 outlet-ref warm-start auto-retry then converges in **3 s**. The tests now share one module-scoped solve with `timeout=120`, which bounds the doomed phase and *pins the rescue-within-budget behavior*: 761 s → 51 s. This also explains the CI job history: 8.7 min (#211) → 13.2 min (#214 changed the primary path on this 3-PB net) → 28.9 min (#224 changed the doomed-phase split). Evidence for the roadmap item "promote `outletref_warmstart` earlier for such nets"; no solver changes in this PR.

**2. Parallel pytest.** `pytest-xdist` added to the dev group; CI and the pre-commit hook run `-n auto --dist loadscope` (`loadscope` keeps each module on one worker so the shared fixture solves once). All tests were scanned for parallel hazards (fixed paths, ports, env, ordering): none. Verified: full suite 1557 passed with outcome counts identical to the serial baseline, 867 s → 55 s wall. CI logs now include `--durations=25` so slow-test creep stays visible.

**3. Stamp-test budgets.** The two auto-upgrade stamp tests only inspect `solver_settings_used` after a forced `maxfev=5` failure, but let the LM fallback idle away the rest of a 10 s budget each; timeout 10 → 2 s.

## CI coverage gaps closed

**4. `uv.lock` now triggers CI.** The change filters in both workflows omitted `uv.lock`, so the two dependabot python-safe-updates merges on 2026-07-05 ran **zero Python tests** (job skipped) — a scipy/numpy bump could merge untested.

**5. Windows import smoke test.** `build-python-windows` built the MSVC extension but never loaded it; it now runs `pytest python/tests/test_import.py` (imports `combaero` and `combaero._core`), catching DLL/ABI load failures.

**6. Frontend tests for the #225 store behavior.** New `useStore.test.ts` locks in the result-stripping semantics: structural edits (add/remove node or edge, connect) strip all stored node/edge results; position/selection changes keep them; `stripResults` preserves sibling data keys.

## Hygiene

**7.** `test_choke_barrier_rejects_dead_branch_spurious_root` now calls `net.resolve_all_topology()` before probing `_residuals` (the known probe trap: without it the port MCNs are not marked as junction ports and the probed residual is a different function than the one the solver sees). Pre-verified: the spurious state's resolved norm is 1.6e5, so the `> 1e4` assertion holds against the real residual. Other direct `_residuals` probes were checked — none affected.

## Verification

- Full suite parallel: 1557 passed / 28 skipped / 4 xfailed / 1 xpassed in 55.3 s — identical outcome counts to the serial baseline run.
- Touched modules serial: 37 passed in 92.6 s (shared fixture setup 51.5 s).
- `pnpm run test` (11 passed) + biome clean; pre-commit fully green (with the parallel hook).
- Expected on this PR's CI: python-unit job in single-digit minutes (from 29); Windows smoke step green; durations table in the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
