### PR TITLE
feat(solver): promote outlet-ref retry via LM-phase stall detection; cold-only stall gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Solver: LM-phase stall detection -- doomed primaries fail fast so
+  the outlet-ref auto-retry gets the budget.** The stall detector
+  (previously hybr-phase only) now also watches the LM fallback: when
+  LM's best |F| plateaus (< 10% improvement over 5 s) while still far
+  from tolerance (> 100x), the attempt is abandoned via
+  ``SolverStallError`` instead of grinding unbounded. On the doomed
+  three-port junction net the primary previously burned ~187 s flat at
+  |F| ~ 4e3 before the outlet-referenced warm-start retry rescued it in
+  3 s; it now fails ~10 s after LM flatlines and the full solve drops
+  to ~25 s. Discrimination verified on recorded traces: fires at 5.5 s
+  and 8.2 s into the two doomed LM phases, never on the 16 kg/s net
+  whose LM fallback is the rescue (converges in 4.8 s). Also fixes a
+  #224 side effect: the 5-tee net at 0.32 kg/s converged cold pre-#224
+  (161 s of hybr grinding) but the handover sent it to an LM that
+  plateaus -- it burned the full 180 s timeout and survived only via
+  the auto-retry; the doomed burn now ends in seconds. Diagnostics
+  record ``lm_stall: true``. Stall detection (BOTH phases, including
+  the earlier hybr handover) now applies to cold attempts only: seeded
+  solves (explicit x0 or a warm-start proxy seed) are the last retry
+  rung and keep their full grind. Certified-audit evidence: 4/32
+  outlet-ref seeded cases plateau far from tolerance for > 5 s and
+  still dig out to the root (the LM-phase abort turned those slow
+  successes into fast failures), and the hybr handover firing
+  mid-seeded-solve turned two 20 s successes into failures (cases
+  13/19) because LM cannot always finish from the same seed.
+- **Solver/GUI: ``init_strategy="outletref_warmstart"`` is selectable.**
+  The outlet-referenced incompressible proxy (the auto-retry's seed)
+  can now be chosen directly as the primary initialization -- no cold
+  attempt first -- for networks known to stall the cold path. Certified
+  audit: 16/16 same-root on branch topologies, 11/16 on merge (prefer
+  ``default``/``analytical_pt_prop`` for merge networks; on healthy
+  branch nets the cold start remains ~4x faster, which is why this is
+  not the default). Exposed in the GUI init-strategy dropdown.
 - **CI: Windows extension import smoke test.** The MSVC Python extension
   build job now imports ``combaero`` and ``combaero._core`` via
   ``pytest python/tests/test_import.py``; previously the extension was

--- a/docs/API_PYTHON.md
+++ b/docs/API_PYTHON.md
@@ -390,14 +390,25 @@ graph.add_element(OrificeElement("ori1", "nodeA", "nodeB", Cd=0.6, diameter=0.01
 
 solver = NetworkSolver(graph)
 # init_strategy options: "default", "analytical_pt_prop", "homotopy",
-# "continuation", "incompressible_warmstart" (deprecated).
+# "continuation", "outletref_warmstart", "incompressible_warmstart"
+# (deprecated).
 # "default" auto-upgrades to "analytical_pt_prop" for networks that
 # contain a MultiPortChamberElement; pass another strategy or an
 # explicit x0 to opt out.
+# "outletref_warmstart" solves the outlet-referenced incompressible
+# proxy (densities at the downstream static) and warm-starts the
+# compressible solve from it directly -- the auto-retry's seed as a
+# primary strategy, for networks known to stall the cold path.
 # auto_retry (default True): failed cold solves on compressible
 # MPCE networks are retried once from an outlet-referenced
 # incompressible warm start (densities at the downstream static).
 # The primary attempt gets 40% of `timeout`, the retry the rest.
+# Stall detection ends doomed phases early: when hybr's best |F|
+# plateaus far from tolerance it hands over to the LM fallback, and
+# when the LM fallback plateaus too the attempt fails fast so the
+# auto-retry gets the budget. Cold attempts only -- seeded solves
+# (explicit x0 or a warm-start seed) are the last rung and keep
+# their full budget.
 results = solver.solve(method="hybr", init_strategy="homotopy")
 ```
 

--- a/gui/backend/schemas.py
+++ b/gui/backend/schemas.py
@@ -302,6 +302,7 @@ class SolverSettings(BaseModel):
         "default",
         "analytical_pt_prop",
         "incompressible_warmstart",
+        "outletref_warmstart",
         "homotopy",
         "continuation",
     ] = "default"

--- a/gui/frontend/src/components/Sidebar.tsx
+++ b/gui/frontend/src/components/Sidebar.tsx
@@ -360,6 +360,9 @@ const Sidebar = () => {
 						<option value="incompressible_warmstart">
 							Incomp. Warmstart (deprecated)
 						</option>
+						<option value="outletref_warmstart">
+							Incomp. Warmstart (Outlet-ref)
+						</option>
 						<option value="homotopy">Load-Stepping (Homotopy)</option>
 						<option
 							value="continuation"

--- a/gui/frontend/src/store/useStore.ts
+++ b/gui/frontend/src/store/useStore.ts
@@ -59,6 +59,7 @@ export interface RFState {
 			| "default"
 			| "analytical_pt_prop"
 			| "incompressible_warmstart"
+			| "outletref_warmstart"
 			| "homotopy"
 			| "continuation";
 		method: string;

--- a/python/combaero/network/solver.py
+++ b/python/combaero/network/solver.py
@@ -31,12 +31,14 @@ class SolverTimeoutError(Exception):
 
 
 class SolverStallError(SolverTimeoutError):
-    """Raised when hybr's best residual plateaus and an LM fallback exists.
+    """Raised when a solve phase's best residual plateaus far from the root.
 
     Subclasses SolverTimeoutError so every existing handler treats it as
-    "this phase is over, keep the best iterate" -- the LM fallback then
-    runs with all the remaining budget instead of waiting for hybr to
-    burn its fixed share.
+    "this phase is over, keep the best iterate". In the hybr phase the
+    LM fallback then runs with all the remaining budget instead of
+    waiting for hybr to burn its fixed share; in the LM fallback phase
+    the primary attempt fails fast so the outlet-referenced warm-start
+    auto-retry gets the budget instead of a doomed LM grind.
     """
 
     pass
@@ -59,7 +61,7 @@ _STALL_MIN_REL_IMPROVEMENT = 0.10
 _STALL_FAR_FACTOR = 100.0
 
 
-def _hybr_stall_detected(
+def _stall_detected(
     samples: list[tuple[float, float]],
     window: float = _STALL_WINDOW_S,
     min_rel: float = _STALL_MIN_REL_IMPROVEMENT,
@@ -67,6 +69,10 @@ def _hybr_stall_detected(
     far_factor: float = _STALL_FAR_FACTOR,
 ) -> bool:
     """Return True when the best-|F| trace has plateaued far from the root.
+
+    Phase-agnostic: used for both the hybr phase and the LM fallback
+    phase (the LM phase feeds phase-relative times so the grace period
+    applies from the start of the phase, not the solve).
 
     ``samples`` is the per-eval history of ``(t_elapsed_s, best_norm)``
     with best_norm non-increasing. Stall = the newest best norm is still
@@ -1454,7 +1460,11 @@ class NetworkSolver:
         use_jac: bool = True,
         x0: np.ndarray | None = None,
         init_strategy: Literal[
-            "default", "incompressible_warmstart", "homotopy", "analytical_pt_prop"
+            "default",
+            "incompressible_warmstart",
+            "outletref_warmstart",
+            "homotopy",
+            "analytical_pt_prop",
         ] = "default",
         warmstart_maxfev: int = 150,
         lambda_steps: list[float] | None = None,
@@ -1483,6 +1493,13 @@ class NetworkSolver:
         attempt gets 40% of the budget, the proxy at most 25%, and the
         seeded retry the remainder (at least 30%). Compressible tee
         networks are best given 90-120 s total.
+
+        Pass ``init_strategy='outletref_warmstart'`` to run the proxy
+        seed directly as the primary initialization (no cold attempt
+        first) -- useful on networks known to stall the cold path.
+        Certified audit (2026-07): 16/16 same-root on branch
+        topologies, 11/16 on merge -- prefer 'default' /
+        'analytical_pt_prop' for merge networks.
         """
         retry_applicable = (
             auto_retry
@@ -1671,7 +1688,11 @@ class NetworkSolver:
         use_jac: bool = True,
         x0: np.ndarray | None = None,
         init_strategy: Literal[
-            "default", "incompressible_warmstart", "homotopy", "analytical_pt_prop"
+            "default",
+            "incompressible_warmstart",
+            "outletref_warmstart",
+            "homotopy",
+            "analytical_pt_prop",
         ] = "default",
         warmstart_maxfev: int = 150,
         lambda_steps: list[float] | None = None,
@@ -1710,6 +1731,11 @@ class NetworkSolver:
                 (DEPRECATED: 10/32 on the same audit at ~10x the wall
                 time) first solves an incompressible-regime proxy
                 network and uses that solution as x0.
+                ``outletref_warmstart`` solves the outlet-referenced
+                incompressible proxy (densities at the DOWNSTREAM
+                static; the auto-retry's seed) and warm-starts from it
+                directly -- 16/16 same-root on branch topologies,
+                11/16 on merge in the certified audit.
             warmstart_maxfev: Maximum function evaluations for the
                 incompressible proxy solve when
                 ``init_strategy='incompressible_warmstart'``.
@@ -1725,13 +1751,14 @@ class NetworkSolver:
         if init_strategy not in (
             "default",
             "incompressible_warmstart",
+            "outletref_warmstart",
             "homotopy",
             "continuation",
             "analytical_pt_prop",
         ):
             raise ValueError(
                 "init_strategy must be one of: 'default', 'incompressible_warmstart', "
-                "'homotopy', 'continuation', 'analytical_pt_prop'."
+                "'outletref_warmstart', 'homotopy', 'continuation', 'analytical_pt_prop'."
             )
         if warmstart_maxfev <= 0:
             raise ValueError("warmstart_maxfev must be > 0.")
@@ -1824,6 +1851,24 @@ class NetworkSolver:
             options.setdefault("maxiter", _default_iters)
 
         warmstart_x0: np.ndarray | None = None
+        if x0 is None and init_strategy == "outletref_warmstart":
+            # Explicit selection of the auto-retry's seed: solve the
+            # outlet-referenced incompressible proxy and warm-start the
+            # compressible solve from it. Same budget formula as the
+            # retry path. When the proxy fails, warn and proceed cold --
+            # mirroring incompressible_warmstart's failure behavior.
+            _proxy_timeout = 60.0 if timeout is None else max(min(0.3 * timeout, 60.0), 10.0)
+            warmstart_x0 = self._outlet_ref_incompressible_seed(
+                use_jac=use_jac, timeout=_proxy_timeout
+            )
+            if warmstart_x0 is None:
+                warnings.warn(
+                    "Outlet-referenced incompressible proxy did not converge. "
+                    "Proceeding with default initialization.",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+
         if x0 is None and init_strategy == "incompressible_warmstart":
             overrides = self._compressible_element_overrides()
             if overrides:
@@ -2010,11 +2055,27 @@ class NetworkSolver:
         _RECORD_INTERVAL = 0.1
         _eval_count: list[int] = [0]
         _lm_started_at_eval: list[int | None] = [None]
-        # Per-eval (t, best|F|) trace for the stall detector; checked every
-        # _STALL_CHECK_EVERY evals during the hybr phase only.
+        # Per-eval (t, best|F|) traces for the stall detector; checked every
+        # _STALL_CHECK_EVERY evals. The hybr trace uses solve-relative
+        # times; the LM-fallback trace uses phase-relative times so the
+        # detector's grace period applies from the start of the LM phase.
         _stall_samples: list[tuple[float, float]] = []
+        _lm_stall_samples: list[tuple[float, float]] = []
         _STALL_CHECK_EVERY = 10
         _stall_fired: list[bool] = [False]
+        _lm_stall_fired: list[bool] = [False]
+        _lm_start_t: list[float] = [0.0]
+        # Stall detection (both phases) only makes sense for COLD
+        # attempts, where a later rung (LM fallback / warm-start retry)
+        # exists to receive the freed budget. Seeded solves (explicit
+        # x0 or a warmstart proxy seed) are the LAST rung and must keep
+        # their full grind: on the certified audit the seeded LM phase
+        # can plateau far from tolerance for > 5 s and still dig out to
+        # the root (4/32 outletref cases), and the hybr handover firing
+        # mid-seeded-solve turned two 20 s successes into failures
+        # (audit cases 13/19) because LM cannot always finish from the
+        # same seed.
+        _cold_attempt = x0 is None and warmstart_x0 is None
 
         # State for timeout and best iterate tracking (in real space)
         start_time = time.perf_counter()
@@ -2057,10 +2118,16 @@ class NetworkSolver:
                 # its budget share -- LM (which is what actually cracks
                 # these networks) should get the time instead. Active only
                 # while a compressible/tee LM fallback exists and has not
-                # started yet.
-                if method == "hybr" and _has_compressible and _lm_started_at_eval[0] is None:
+                # started yet, and only on cold attempts -- see
+                # _cold_attempt above.
+                if (
+                    method == "hybr"
+                    and _has_compressible
+                    and _cold_attempt
+                    and _lm_started_at_eval[0] is None
+                ):
                     _stall_samples.append((_t, float(best_res_norm)))
-                    if _eval_count[0] % _STALL_CHECK_EVERY == 0 and _hybr_stall_detected(
+                    if _eval_count[0] % _STALL_CHECK_EVERY == 0 and _stall_detected(
                         _stall_samples, tol=_RESIDUAL_TOL
                     ):
                         _stall_fired[0] = True
@@ -2070,6 +2137,26 @@ class NetworkSolver:
                             f"{_STALL_MIN_REL_IMPROVEMENT:.0%} over the last "
                             f"{_STALL_WINDOW_S:.0f} s; handing over to the "
                             "LM fallback."
+                        )
+
+                # Same detector for the LM fallback phase (phase-relative
+                # times): when LM also plateaus far from tolerance the
+                # primary attempt is doomed -- fail fast so the caller's
+                # outlet-referenced warm-start auto-retry gets the budget
+                # instead of an unbounded LM grind (observed 180 s flat at
+                # |F| ~ 4e3 on nets the retry then solves in seconds).
+                # Cold attempts only -- see _cold_attempt above.
+                elif _has_compressible and _cold_attempt and _lm_started_at_eval[0] is not None:
+                    _lm_stall_samples.append((_t - _lm_start_t[0], float(best_res_norm)))
+                    if _eval_count[0] % _STALL_CHECK_EVERY == 0 and _stall_detected(
+                        _lm_stall_samples, tol=_RESIDUAL_TOL
+                    ):
+                        _lm_stall_fired[0] = True
+                        raise SolverStallError(
+                            f"LM fallback stalled: best |F|={best_res_norm:.3e} "
+                            f"improved less than "
+                            f"{_STALL_MIN_REL_IMPROVEMENT:.0%} over the last "
+                            f"{_STALL_WINDOW_S:.0f} s; abandoning this attempt."
                         )
 
                 # Scale residuals
@@ -2169,6 +2256,7 @@ class NetworkSolver:
             _remaining = (timeout - _elapsed) if timeout is not None else None
             if _remaining is None or _remaining > 2.0:
                 _lm_started_at_eval[0] = _eval_count[0]
+                _lm_start_t[0] = time.perf_counter() - start_time
                 _timeout_eff[0] = timeout
                 # For MPCE networks the impulse + sum-mass residual structure
                 # leaves hybr near-singular at low Mach; its "best iterate" is
@@ -2200,6 +2288,10 @@ class NetworkSolver:
                     pass
                 except Exception:
                     pass
+                if not success and _lm_stall_fired[0]:
+                    message = (
+                        f"{message} LM fallback also stalled at |F|={float(best_res_norm):.3e}."
+                    )
 
         # Post-solve direction verification for constrained junctions.
         # strict=False soft-barrier mode can manufacture EXACT artifact
@@ -2270,6 +2362,7 @@ class NetworkSolver:
             "worst_residuals": [{"name": n, "residual": v} for n, v in _worst],
             "lm_started_at_eval": _lm_started_at_eval[0],
             "stall_handover": _stall_fired[0],
+            "lm_stall": _lm_stall_fired[0],
             "solver_settings_used": {
                 "method": method,
                 "init_strategy": init_strategy,

--- a/python/tests/test_gui_schemas.py
+++ b/python/tests/test_gui_schemas.py
@@ -4,6 +4,7 @@ from gui.backend.schemas import (
     DiscreteLossData,
     MomentumChamberData,
     PlenumData,
+    SolverSettings,
 )
 
 
@@ -75,6 +76,11 @@ def test_discrete_loss_data_multipliers():
     d2 = DiscreteLossData(Nu_multiplier=1.2, f_multiplier=1.1)
     assert d2.Nu_multiplier == 1.2
     assert d2.f_multiplier == 1.1
+
+
+def test_solver_settings_accepts_outletref_warmstart():
+    s = SolverSettings(init_strategy="outletref_warmstart")
+    assert s.init_strategy == "outletref_warmstart"
 
 
 if __name__ == "__main__":

--- a/python/tests/test_multi_port_chamber.py
+++ b/python/tests/test_multi_port_chamber.py
@@ -92,9 +92,9 @@ def three_port_solution() -> tuple[NetworkSolver, dict]:
     assertions below (each previously re-ran the identical ~3 min solve).
 
     The primary attempt on this net is known-doomed (hybr stalls, the LM
-    fallback grinds without converging) and the outlet-referenced warm-start
-    auto-retry rescues it in seconds; the finite timeout bounds the doomed
-    phase and pins that rescue-within-budget behavior.
+    fallback stalls too) and the outlet-referenced warm-start auto-retry
+    rescues it in seconds; the finite timeout bounds the doomed phase and
+    pins that rescue-within-budget behavior.
     """
     net = _three_port_net()
     solver = NetworkSolver(net)
@@ -111,6 +111,35 @@ def test_three_port_network_converges(three_port_solution):
     x = np.array([sol.get(n, 0.0) for n in solver.unknown_names])
     res, _ = solver._residuals_and_jacobian(x, compute_jacobian=False)
     assert max(abs(r) for r in res) < 1e-3, f"residuals not small: {res}"
+
+    # Document the rescue path: this net converges via the outlet-ref
+    # warm-start auto-retry after the doomed primary fails fast.
+    ssu = solver._diagnostic_data["solver_settings_used"]
+    assert ssu["init_strategy"] == "outletref_warmstart"
+    assert ssu.get("auto_retry") is True
+
+
+def test_three_port_doomed_primary_fails_fast_via_lm_stall():
+    """Without the auto-retry, the doomed primary must fail FAST: hybr
+    stalls (handover), the LM fallback then plateaus far from tolerance
+    and the LM-phase stall detector aborts it. Pre-detector this burned
+    ~187 s flat at |F| ~ 4e3 (timeout=None leaves LM unbounded); with it
+    the attempt ends ~10 s after LM flatlines.
+    """
+    import time
+
+    net = _three_port_net()
+    solver = NetworkSolver(net)
+    t0 = time.perf_counter()
+    with pytest.warns(UserWarning, match="did not converge"):
+        sol = solver.solve(timeout=None, auto_retry=False)
+    wall = time.perf_counter() - t0
+    assert not sol["__success__"]
+    diag = solver._diagnostic_data
+    assert diag["stall_handover"] is True
+    assert diag["lm_stall"] is True
+    assert "LM fallback also stalled" in str(sol.get("__message__"))
+    assert wall < 60.0, f"doomed primary took {wall:.1f} s; LM-stall abort broken"
 
 
 def test_three_port_mass_conservation(three_port_solution):

--- a/python/tests/test_network_compressible.py
+++ b/python/tests/test_network_compressible.py
@@ -1343,3 +1343,24 @@ def test_outlet_ref_seeded_solve_reaches_same_root_as_cold():
     assert sol_seeded["__success__"], sol_seeded.get("__message__")
     assert sol_seeded["ch_str.m_dot"] == pytest.approx(sol_cold["ch_str.m_dot"], rel=1e-3)
     assert sol_seeded["ch_bra.m_dot"] == pytest.approx(sol_cold["ch_bra.m_dot"], rel=1e-3)
+
+
+def test_outletref_warmstart_explicit_strategy_converges():
+    """init_strategy='outletref_warmstart' runs the proxy seed directly
+    as the primary initialization (no cold attempt first) and reaches
+    the same root as the cold start."""
+    net = _mfb_branch_tee_orifice_network(0.2, "compressible")
+    solver = NetworkSolver(net)
+    sol_cold = solver.solve(timeout=60.0, auto_retry=False)
+    assert sol_cold["__success__"], sol_cold.get("__message__")
+
+    net2 = _mfb_branch_tee_orifice_network(0.2, "compressible")
+    solver2 = NetworkSolver(net2)
+    sol = solver2.solve(timeout=60.0, init_strategy="outletref_warmstart")
+    assert sol["__success__"], sol.get("__message__")
+    ssu = solver2._diagnostic_data["solver_settings_used"]
+    assert ssu["init_strategy"] == "outletref_warmstart"
+    # Explicit strategy selection opts out of the auto-retry chain.
+    assert "auto_retry" not in ssu
+    assert sol["ch_str.m_dot"] == pytest.approx(sol_cold["ch_str.m_dot"], rel=1e-3)
+    assert sol["ch_bra.m_dot"] == pytest.approx(sol_cold["ch_bra.m_dot"], rel=1e-3)

--- a/python/tests/test_solver_timeout.py
+++ b/python/tests/test_solver_timeout.py
@@ -122,18 +122,18 @@ def test_stall_detector_fires_on_far_plateau():
     """A residual parked at |F| ~ 1e4 (far above tolerance) for longer
     than the window is a stall (the 16 kg/s 5-tee signature: hybr
     plateaus, LM-from-x0 converges in seconds)."""
-    from combaero.network.solver import _hybr_stall_detected
+    from combaero.network.solver import _stall_detected
 
     trace = _trace([(0.5 * i, 1.0e4) for i in range(30)])
-    assert _hybr_stall_detected(trace, window=5.0, min_rel=0.10, tol=1e-3)
+    assert _stall_detected(trace, window=5.0, min_rel=0.10, tol=1e-3)
 
 
 def test_stall_detector_ignores_steady_improvement():
     """20% improvement per window is progress, not a stall."""
-    from combaero.network.solver import _hybr_stall_detected
+    from combaero.network.solver import _stall_detected
 
     trace = _trace([(0.5 * i, 1.0e4 * (0.8 ** (0.5 * i / 5.0))) for i in range(60)])
-    assert not _hybr_stall_detected(trace, window=5.0, min_rel=0.10, tol=1e-3)
+    assert not _stall_detected(trace, window=5.0, min_rel=0.10, tol=1e-3)
 
 
 def test_stall_detector_ignores_slow_grind_near_tolerance():
@@ -141,19 +141,19 @@ def test_stall_detector_ignores_slow_grind_near_tolerance():
     retry on the 5-tee at 0.18 kg/s crawls at |F| ~ 1e-2 (12x tol) and
     then converges. Cutting it over to LM turned a success into a
     failure, so plateaus below far_factor*tol must NOT count."""
-    from combaero.network.solver import _hybr_stall_detected
+    from combaero.network.solver import _stall_detected
 
     trace = _trace([(0.5 * i, 1.2e-2) for i in range(30)])
-    assert not _hybr_stall_detected(trace, window=5.0, min_rel=0.10, tol=1e-3, far_factor=100.0)
+    assert not _stall_detected(trace, window=5.0, min_rel=0.10, tol=1e-3, far_factor=100.0)
 
 
 def test_stall_detector_grace_period():
     """Histories shorter than the window never stall."""
-    from combaero.network.solver import _hybr_stall_detected
+    from combaero.network.solver import _stall_detected
 
     trace = _trace([(0.5 * i, 1.0e4) for i in range(8)])  # 3.5 s < 5 s
-    assert not _hybr_stall_detected(trace, window=5.0, min_rel=0.10, tol=1e-3)
-    assert not _hybr_stall_detected([], window=5.0)
+    assert not _stall_detected(trace, window=5.0, min_rel=0.10, tol=1e-3)
+    assert not _stall_detected([], window=5.0)
 
 
 def test_stall_error_is_timeout_subclass():


### PR DESCRIPTION
## Summary

Promotes the outlet-referenced warm-start retry for **doomed-primary** nets: instead of running earlier unconditionally (the certified audit rules that out — on healthy branch nets the cold start is 4x faster, and outletref is only 11/16 on merge), the retry now engages as soon as the primary is *provably stuck*. Plus `outletref_warmstart` becomes a first-class selectable init strategy.

## 1. LM-phase stall detection

The #224 stall detector only watched the hybr phase; after handover, the LM fallback could grind unbounded (`timeout=None`) or to `maxiter`. On the doomed three-port net that meant ~187 s flat at |F| ~ 4e3 before the auto-retry rescued in 3 s.

The same detector (same window/threshold/far-gate, phase-relative times) now watches the LM fallback and aborts via `SolverStallError` when it plateaus far from tolerance. Trace-validated discrimination on the three exemplars:

| net | LM phase | detector |
|---|---|---|
| three-port (doomed) | flat at |F|~4e3 for 180 s | fires 5.5 s into LM |
| 16 kg/s 20 bar (LM **is** the rescue) | converges in 4.8 s | never fires (verified live: still 23.5 s) |
| 5-tee @ 0.32 kg/s | flat at |F|~11-53, burns 180 s | fires 8.2 s into LM |

Full three-port `solve()`: **190 s → ~16 s**. Diagnostics record `lm_stall`.

## 2. Stall detection is now cold-attempts-only (both phases)

The certified audit caught two things the exemplars couldn't:

- The new LM abort turned 4/32 outlet-ref **seeded** cases from slow successes (far plateau > 5 s, then digs out to the root) into fast failures.
- The **#224 hybr handover itself** regresses seeded solves: firing mid-seeded-solve turned two 20 s successes into failures (audit cases 13/19) because LM cannot always finish from the same seed. This was a #224 side effect never re-measured against the audit (the 27/32 reference predates the merge).

Principle: stall detection exists to hand budget to the *next* rung. Seeded solves (explicit `x0` or a warmstart proxy seed) are the **last** rung — they keep their full grind. With the cold-only gate:

| strategy | audit result |
|---|---|
| cold_default | 32/32 (unchanged, 45 s) |
| outletref_warmstart | **28/32** — above the pre-#224 reference of 27/32 (cases 13/19 restored) |

Side effect fixed en route: the 5-tee @ 0.32 kg/s converged cold pre-#224 (161 s of hybr grinding); post-#224 the handover sent it to an LM that plateaus, so it burned the full 180 s timeout and survived only via the auto-retry. Now the doomed burn ends in seconds and the full solve lands at 84.7 s via the retry.

## 3. `init_strategy="outletref_warmstart"` selectable

Solver Literal/validation, GUI schema, and sidebar dropdown ("Incomp. Warmstart (Outlet-ref)"). Runs the proxy seed directly as primary initialization for nets known to stall the cold path; explicit selection opts out of the auto-retry chain. Docs positioning: 16/16 branch, 11/16 merge on the certified audit — prefer default/analytical on merge nets.

`_hybr_stall_detected` renamed `_stall_detected` (phase-agnostic).

## Verification

- New integration test: doomed primary fails fast (`stall_handover` + `lm_stall`, wall < 60 s at `timeout=None`; measured ~13 s). Explicit-strategy test reaches the cold root and stamps ssu. Schema test for the new value.
- Three-port shared fixture setup: 51 s → **16.2 s** (test-suite side effect).
- Touched modules 56 passed; full suite 1560 passed / 28 skipped / 5 xfailed in 45.9 s parallel (the xfail delta vs baseline is `test_mixing_plenum_convergence`, self-documented as non-deterministic in suite).
- Frontend: 11 vitest passed, biome clean. Pre-commit fully green.
- API_PYTHON.md + CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
