### PR TITLE
fix(solver): MPCE impulse rows were residual-scaled as mass flows (doomed-primary root cause)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to 29 s at timeout=90.
 
 ### Fixed
+- **Solver: MPCE impulse rows were residual-scaled as mass flows --
+  the root cause of the "doomed primary" stall class on junction
+  networks.** ``_build_residual_scales`` classified all N+1
+  ``MultiPortChamberElement`` rows as ``ref_mdot``, but the N impulse
+  rows ``(P_i + rho_i u_i^2) - P_jct`` are PRESSURE-magnitude: in the
+  scaled system hybr/LM actually optimize they were over-weighted by
+  ``ref_p/ref_mdot`` (~1e5; measured 7.5e4 vs O(0.1) for correctly
+  classified rows on the three-port fixture at x0). With the corrected
+  classification (``[ref_p] * N + [ref_mdot]``) every known
+  doomed-primary network converges COLD with no stall handover, no LM
+  fallback, and no warm-start retry: three-port fixture 187 s doomed
+  grind -> 2.6 s, 5-tee slow pockets at 0.26/0.32/0.40 kg/s (all
+  previously failing cold) -> 5-7 s, 16 kg/s 20 bar net 23 s
+  (stall+LM rescue) -> 12 s direct, one-tee choke net 25 s -> 2.3 s.
+  Certified audit unchanged at 32/32 (39 s). The stall-handover and
+  outlet-ref auto-retry machinery remains as a safety net but no
+  longer fires on these networks. Found while investigating why the
+  phi-closure prototype's trf solver crawled: least-squares objectives
+  are brutally sensitive to row weights where root-finders merely
+  degrade. NOTE: the faster cold path exposes that the sign-symmetric
+  v1 MPCE (no ``flow_direction`` constraint, no direction verification
+  hook) can converge onto exact mirror/reversed roots on
+  pressure-driven nets with ambiguous direction -- a pre-existing
+  model property; affected tests now pin the physical basin
+  explicitly, and GUI networks are unaffected (MPCEv2 with direction
+  verification).
 - **GUI: editing a value could apply it to two nodes.** React Flow
   prevents default on node mousedown, so a focused Inspector input never
   blurred when clicking another node; React then reused the same input

--- a/python/combaero/network/solver.py
+++ b/python/combaero/network/solver.py
@@ -196,9 +196,23 @@ class NetworkSolver:
             if not getattr(node, "_is_junction_port", False):
                 scales.append(ref_mdot)
 
-        from .components import TeeJunctionElement
+        from .components import MultiPortChamberElement, TeeJunctionElement
 
         for element in self.network.elements.values():
+            # MultiPortChamberElement emits N impulse rows,
+            # (P_i + rho_i u_i^2) - P_jct, which are PRESSURE-magnitude,
+            # followed by one sum-mass row. Classifying all N+1 rows as
+            # ref_mdot (the pre-2026-07-07 behavior) over-weighted the
+            # impulse rows by ref_p/ref_mdot (~1e5) in the scaled system
+            # hybr/LM optimize -- the root cause of the "doomed primary"
+            # stall class on MPCE networks (three-port fixture: cold hybr
+            # 187 s stall -> 2.6 s clean convergence with correct scales;
+            # 5-tee slow pockets and the 16 kg/s net likewise solve cold
+            # with no stall handover).
+            if isinstance(element, MultiPortChamberElement):
+                scales.extend([ref_p] * element.N)
+                scales.append(ref_mdot)
+                continue
             elem_scale = (
                 ref_p
                 if isinstance(

--- a/python/tests/test_momentum_cv_vs_tee.py
+++ b/python/tests/test_momentum_cv_vs_tee.py
@@ -160,11 +160,14 @@ def test_both_models_give_forward_dominant_inlet_flow():
     # all-forward root and its mirrored all-reverse image are equally exact,
     # and the default cold start may land either. Seed the forward basin
     # explicitly -- this test compares the models' forward solutions, it
-    # does not test cold-start basin selection.
+    # does not test cold-start basin selection. Seeds are anchored near
+    # the all-forward root (m_com ~ +1.41); after the 2026-07-07
+    # residual-scale fix the basin geometry changed and the previous
+    # 0.4/0.25/0.15 seeds flowed to the mirror image.
     mp_net = _mpce_branching_net()
-    mp_net.elements["lc_com"].initial_guess = {"lc_com.m_dot": 0.4}
-    mp_net.elements["lc_str"].initial_guess = {"lc_str.m_dot": 0.25}
-    mp_net.elements["lc_bra"].initial_guess = {"lc_bra.m_dot": 0.15}
+    mp_net.elements["lc_com"].initial_guess = {"lc_com.m_dot": 1.0}
+    mp_net.elements["lc_str"].initial_guess = {"lc_str.m_dot": 0.8}
+    mp_net.elements["lc_bra"].initial_guess = {"lc_bra.m_dot": 0.2}
     mp_sol = NetworkSolver(mp_net).solve()
 
     assert v3_sol["__success__"], f"v3 did not converge: {v3_sol.get('__message__')}"

--- a/python/tests/test_multi_port_chamber.py
+++ b/python/tests/test_multi_port_chamber.py
@@ -89,16 +89,24 @@ def _three_port_net(
 @pytest.fixture(scope="module")
 def three_port_solution() -> tuple[NetworkSolver, dict]:
     """One shared solve of the default 3-port net for the test_three_port_*
-    assertions below (each previously re-ran the identical ~3 min solve).
+    assertions below.
 
-    The primary attempt on this net is known-doomed (hybr stalls, the LM
-    fallback stalls too) and the outlet-referenced warm-start auto-retry
-    rescues it in seconds; the finite timeout bounds the doomed phase and
-    pins that rescue-within-budget behavior.
+    The solve is seeded via init_strategy='outletref_warmstart' to pin
+    the PHYSICAL root: this net sits in the ejector regime (the 2.05 bar
+    straight sink is entrained by the 2.1 bar feed and everything exits
+    through the 2.0 bar branch -- Bassett 2001 Section 3), and the
+    sign-symmetric v1 impulse rows admit an exact MIRROR root as well
+    (flow entering from the LOWEST-Pt sink and exiting to the highest --
+    energetically impossible for a passive junction; the known v1
+    joining-flow inconsistency). The plain cold start converges onto
+    that mirror root, and v1 has no direction/energy verification hook
+    to demote it (MPCEv2 does; GUI networks are v2). Since the
+    2026-07-07 residual-scale fix all init paths converge in seconds
+    (this net was previously the ~187 s "doomed primary" exemplar).
     """
     net = _three_port_net()
     solver = NetworkSolver(net)
-    sol = solver.solve(timeout=120.0)
+    sol = solver.solve(timeout=120.0, init_strategy="outletref_warmstart")
     return solver, sol
 
 
@@ -112,34 +120,48 @@ def test_three_port_network_converges(three_port_solution):
     res, _ = solver._residuals_and_jacobian(x, compute_jacobian=False)
     assert max(abs(r) for r in res) < 1e-3, f"residuals not small: {res}"
 
-    # Document the rescue path: this net converges via the outlet-ref
-    # warm-start auto-retry after the doomed primary fails fast.
-    ssu = solver._diagnostic_data["solver_settings_used"]
-    assert ssu["init_strategy"] == "outletref_warmstart"
-    assert ssu.get("auto_retry") is True
 
-
-def test_three_port_doomed_primary_fails_fast_via_lm_stall():
-    """Without the auto-retry, the doomed primary must fail FAST: hybr
-    stalls (handover), the LM fallback then plateaus far from tolerance
-    and the LM-phase stall detector aborts it. Pre-detector this burned
-    ~187 s flat at |F| ~ 4e3 (timeout=None leaves LM unbounded); with it
-    the attempt ends ~10 s after LM flatlines.
+def test_residual_scales_classify_mpce_impulse_rows_as_pressure():
+    """Regression for the 2026-07-07 scaling fix: on the 3-port net the
+    ONLY ref_mdot-scaled row is the junction sum-mass row (port-MCN mass
+    rows are skipped; MCN closures, channel rows, and the N impulse rows
+    are all pressure-magnitude). Before the fix all N+1 MPCE rows were
+    ref_mdot, over-weighting the impulse rows by ref_p/ref_mdot (~1e5)
+    in the scaled system -- the root cause of the doomed-primary stall
+    class on MPCE networks.
     """
-    import time
-
     net = _three_port_net()
     solver = NetworkSolver(net)
-    t0 = time.perf_counter()
+    net.resolve_all_topology()
+    net.validate()
+    x0 = solver._build_x0()
+    ref_p, ref_mdot = solver._reference_scales(x0)
+    scales = solver._build_residual_scales(x0)
+    assert len(scales) == len(x0)
+    n_mdot_rows = int(np.sum(scales == ref_mdot))
+    n_p_rows = int(np.sum(scales == ref_p))
+    assert n_mdot_rows == 1, f"expected 1 ref_mdot row (junction sum-mass), got {n_mdot_rows}"
+    assert n_p_rows == len(scales) - 1
+
+
+def test_stall_wiring_forced_detector(monkeypatch):
+    """Deterministic wiring test for the stall machinery (its natural
+    fixture, this net's doomed primary, was cured by the residual-scale
+    fix): force the detector to fire in both phases and assert the
+    hybr handover and the LM-phase abort route correctly.
+    """
+    from combaero.network import solver as solver_module
+
+    monkeypatch.setattr(solver_module, "_stall_detected", lambda *a, **k: True)
+    net = _three_port_net()
+    solver = NetworkSolver(net)
     with pytest.warns(UserWarning, match="did not converge"):
-        sol = solver.solve(timeout=None, auto_retry=False)
-    wall = time.perf_counter() - t0
+        sol = solver.solve(timeout=30.0, auto_retry=False)
     assert not sol["__success__"]
     diag = solver._diagnostic_data
     assert diag["stall_handover"] is True
     assert diag["lm_stall"] is True
     assert "LM fallback also stalled" in str(sol.get("__message__"))
-    assert wall < 60.0, f"doomed primary took {wall:.1f} s; LM-stall abort broken"
 
 
 def test_three_port_mass_conservation(three_port_solution):


### PR DESCRIPTION
## Summary

**Root cause fix for the entire "doomed primary" stall class on MPCE junction networks: a residual-scale classification bug.**

`_build_residual_scales` classified all N+1 `MultiPortChamberElement` rows as `ref_mdot`, but the N impulse rows `(P_i + rho_i*u_i^2) - P_jct` are *pressure*-magnitude. In the scaled system hybr/LM actually optimize, those rows were over-weighted by `ref_p/ref_mdot` (~1e5) — measured on the three-port fixture at x0: scaled impulse rows at **7.5e4** while every correctly classified row sits at O(0.1). The junction sum-mass row keeps `ref_mdot`; `TeeJunctionElement`'s rows are pressure closures and were already correct.

## Impact

With the corrected classification (`[ref_p]*N + [ref_mdot]`), every known doomed-primary network converges **cold** — no stall handover, no LM fallback, no warm-start retry:

| net | before | after |
|---|---|---|
| three-port fixture | 187 s doomed grind (retry-rescued) | **2.6 s** |
| 5-tee @ 0.26 / 0.32 / 0.40 kg/s | all failed cold | **5–7 s** |
| 16 kg/s 20 bar 5-tee | 23 s via stall→LM rescue | **12 s** direct |
| one-tee choke @ 0.4 | 25 s | **2.3 s** |
| certified audit (32 cases) | 32/32, 45 s | **32/32, 39 s** |

The #221/#224/#227 machinery (outlet-ref retry, stall handover, LM-stall abort) remains as a legitimate safety net but no longer fires on these networks. GUI users should see compressible tee networks solve in seconds at default timeouts.

Found while investigating the phi-closure prototype's trf crawl (`exp/phi-closure-prototype`): least-squares objectives are brutally sensitive to row weights where root-finders merely degrade, so trf surfaced in minutes what hybr had been quietly fighting for weeks.

## Exposure handled in tests (none silently relaxed)

The faster cold path exposes a pre-existing v1 MPCE model property: its impulse rows are sign-symmetric (direction-blind, energetically inconsistent for joining flow) and v1 has no direction-verification hook — so on pressure-driven nets with ambiguous direction, cold solves can now land on exact mirror/reversed roots (e.g. the 2.0 bar branch "pumping" into the 2.1 bar reservoir). **GUI networks are unaffected** (MPCEv2 with `flow_direction` constraints + #215 direction verification).

- `test_multi_port_chamber`: the shared three-port fixture pins the physical ejector root via `init_strategy="outletref_warmstart"` (docstring explains the mirror-root mechanism); new `test_residual_scales_classify_mpce_impulse_rows_as_pressure` pins the fix directly (exactly one `ref_mdot` row); `test_three_port_doomed_primary_fails_fast_via_lm_stall` is replaced by `test_stall_wiring_forced_detector` (deterministic monkeypatched detector) because its fixture net is no longer doomed.
- `test_momentum_cv_vs_tee`: forward-basin seeds re-anchored near the all-forward root (m_com ~ +1.41) — the old seeds flow to the mirror under corrected scales. Assertions unchanged (both models forward, magnitudes within 5x: v3 +0.79 vs MPCE +1.41).

Possible follow-up (not this PR): an energy-consistency `verify_solution_consistent` for v1 MPCE so mirror roots are demoted like MPCEv2's wrong-direction roots.

## Verification

- Full suite: 1561 passed / 28 skipped / 4 xfailed in 39.8 s (parallel).
- Certified audit re-run with the real code: 32/32 same-root, 39 s.
- Doomed set re-run with the real code: all cold, `stall_handover=False`, `lm_stall=False` everywhere.
- Three-root structure on the comparison net mapped explicitly (mirror −1.408 / ejector +0.542 / all-forward +1.408) to make the test re-anchoring evidence-based.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
