### PR TITLE
feat(network): energy-consistency verification for v1 MPCE mirror roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Solver: energy-consistency verification for v1
+  ``MultiPortChamberElement`` -- mirror roots are demoted like
+  MPCEv2's wrong-direction roots.** The v1 impulse rows are even in
+  the port flows, so the sign-flipped image of any root is also an
+  exact root, and the image of a physical root is energetically
+  impossible (a passive junction collecting flow from low-Pt ports
+  into a higher-Pt port). Post-#228 the fast cold path converges onto
+  such mirror roots and reported success (three-port net: the 2.0 bar
+  branch "pumping" into the 2.1 bar reservoir). The new
+  ``verify_solution_consistent`` demotes them via the existing
+  post-solve gate: no collector port's total pressure may exceed the
+  single supplier's (1e-4 relative tolerance). Scope: separating mode
+  only (exactly one supplier at the converged state) -- in joining
+  mode the v1 impulse rows themselves can manufacture flow work (the
+  documented deficiency that motivated MPCEv2, which merge networks
+  must use), so policing energy there would reject the v1 merge
+  model's own legitimate solutions. Direction cannot be checked
+  instead: v1 legitimately supports runtime reversal (ejector
+  regimes). End-to-end effect: the plain cold solve on ambiguous v1
+  nets now self-heals -- the mirror root is demoted and the
+  outlet-ref auto-retry reaches the physical root. The post-solve
+  demotion message is generalized to cover both verification kinds.
 - **Solver: LM-phase stall detection -- doomed primaries fail fast so
   the outlet-ref auto-retry gets the budget.** The stall detector
   (previously hybr-phase only) now also watches the LM fallback: when

--- a/python/combaero/network/components.py
+++ b/python/combaero/network/components.py
@@ -3155,6 +3155,54 @@ class MultiPortChamberElement(NetworkElement):
     def n_equations(self) -> int:
         return self.N + 1  # N impulse + 1 sum-mass
 
+    def verify_solution_consistent(
+        self,
+        sol: dict[str, float],
+        rel_tol: float = 1e-4,
+    ) -> bool:
+        """Post-solve energy-consistency check: no collector port may end
+        up with a higher total pressure than the best supplier port.
+
+        The v1 impulse rows are even in the port flows (u_i^2), so the
+        sign-flipped image of any root is also an exact root -- and the
+        image of a physical root is energetically impossible (flow
+        collected from low-Pt ports and delivered to a higher-Pt port,
+        i.e. a passive junction manufacturing flow work). Canonical
+        direction CANNOT be checked instead: v1 legitimately supports
+        runtime reversal (ejector regimes, Bassett 2001 Section 3), where
+        a below-supply-Pt port feeds the junction. The max-Pt bound is
+        deliberately weak -- Pt and m_dot are the only quantities in the
+        solution dict, and the goal is demoting mirror images, not fine
+        energy accounting. Missing keys => True (do not police
+        incomplete dicts; same convention as MPCEv2's direction check).
+
+        SCOPE: the check applies only when the converged state has
+        exactly ONE supplier port (separating mode). In joining mode
+        (>= 2 suppliers) the v1 impulse rows themselves can manufacture
+        flow work -- the documented deficiency that motivated MPCEv2,
+        which merge networks must use -- so policing energy there would
+        reject the v1 model's own legitimate solutions (observed on the
+        certified-audit merge fixtures).
+        """
+        flows: list[float] = []
+        pts: list[float] = []
+        for i in range(self.N):
+            eid = self._port_element_ids[i]
+            m_key = f"{eid}.m_dot"
+            pt_key = f"{self.port_nodes[i]}.Pt"
+            if not eid or m_key not in sol or pt_key not in sol:
+                return True
+            # Junction convention: positive = flow OUT of the junction.
+            flows.append(float(self._port_signs[i]) * float(sol[m_key]))
+            pts.append(float(sol[pt_key]))
+        m_ref = max(abs(f) for f in flows)
+        thr = max(1e-9, 1e-6 * m_ref)
+        suppliers = [pt for f, pt in zip(flows, pts, strict=True) if f < -thr]
+        collectors = [pt for f, pt in zip(flows, pts, strict=True) if f > thr]
+        if len(suppliers) != 1 or not collectors:
+            return True
+        return max(collectors) <= suppliers[0] * (1.0 + rel_tol)
+
     def all_source_nodes(self) -> list[str]:
         # Inlet ports = nodes the junction draws flow FROM (canonical orientation).
         return list(self.inlet_nodes)

--- a/python/combaero/network/solver.py
+++ b/python/combaero/network/solver.py
@@ -2307,15 +2307,20 @@ class NetworkSolver:
                         f"{message} LM fallback also stalled at |F|={float(best_res_norm):.3e}."
                     )
 
-        # Post-solve direction verification for constrained junctions.
-        # strict=False soft-barrier mode can manufacture EXACT artifact
-        # roots: the one-sided penalty alpha * mdot^2 on a slightly
-        # reversed port can cancel that row's Pt-continuity mismatch, so
-        # the solver converges (|F| ~ 1e-10) to a wrong-direction state
+        # Post-solve physical-consistency verification for junctions.
+        # Two known ways a junction net converges (|F| ~ 1e-10) onto an
+        # unphysical exact root: (a) MPCEv2 strict=False soft-barrier
+        # mode, where the one-sided penalty alpha * mdot^2 on a slightly
+        # reversed port cancels that row's Pt-continuity mismatch
         # (exposed by constant-K warm starts on the certified audit,
         # 2026-07-04: a merge feed reversed to -0.0035 kg/s while the
-        # strict residual raises at the same state). Demote such
-        # solutions to honest failures instead of reporting them.
+        # strict residual raises at the same state); (b) v1 MPCE mirror
+        # roots -- the impulse rows are even in the flows, so the
+        # sign-flipped image of any root is also exact, and the image of
+        # a physical root collects flow from low-Pt ports into a
+        # higher-Pt port (a passive junction manufacturing flow work).
+        # Each element's verify_solution_consistent encodes its own
+        # criterion; demote failures to honest non-convergence.
         if success:
             _sol_names = dict(zip(self.unknown_names, final_x, strict=False))
             _bad_junctions = [
@@ -2327,10 +2332,12 @@ class NetworkSolver:
             if _bad_junctions:
                 success = False
                 message = (
-                    "Converged to a wrong-direction artifact root at "
-                    f"junction(s) {_bad_junctions}: the soft-barrier "
-                    "penalty balanced the residual with reversed or zero "
-                    "port flow. Treating as non-converged; try "
+                    "Converged to an unphysical artifact root at "
+                    f"junction(s) {_bad_junctions}: the solution failed "
+                    "the junction's physical-consistency verification "
+                    "(wrong-direction port flow under a soft barrier, or "
+                    "an energy-inconsistent mirror root). Treating as "
+                    "non-converged; try "
                     "init_strategy='analytical_pt_prop' or a different "
                     "initial guess."
                 )

--- a/python/tests/test_multi_port_chamber.py
+++ b/python/tests/test_multi_port_chamber.py
@@ -99,10 +99,13 @@ def three_port_solution() -> tuple[NetworkSolver, dict]:
     (flow entering from the LOWEST-Pt sink and exiting to the highest --
     energetically impossible for a passive junction; the known v1
     joining-flow inconsistency). The plain cold start converges onto
-    that mirror root, and v1 has no direction/energy verification hook
-    to demote it (MPCEv2 does; GUI networks are v2). Since the
-    2026-07-07 residual-scale fix all init paths converge in seconds
-    (this net was previously the ~187 s "doomed primary" exemplar).
+    that mirror root; the v1 energy-consistency hook now demotes it and
+    the auto-retry self-heals onto the physical root (see
+    test_three_port_default_path_self_heals_from_mirror_root), but the
+    explicit seed keeps this shared fixture on the fast direct path.
+    Since the 2026-07-07 residual-scale fix all init paths converge in
+    seconds (this net was previously the ~187 s "doomed primary"
+    exemplar).
     """
     net = _three_port_net()
     solver = NetworkSolver(net)
@@ -142,6 +145,94 @@ def test_residual_scales_classify_mpce_impulse_rows_as_pressure():
     n_p_rows = int(np.sum(scales == ref_p))
     assert n_mdot_rows == 1, f"expected 1 ref_mdot row (junction sum-mass), got {n_mdot_rows}"
     assert n_p_rows == len(scales) - 1
+
+
+def _resolved_junction():
+    net = _three_port_net()
+    net.resolve_all_topology()
+    return net.elements["jct"]
+
+
+def _sol_dict(m_in: float, m_str: float, m_bra: float, pt_com: float, pt_str: float, pt_bra: float):
+    return {
+        "ch_in.m_dot": m_in,
+        "ch_str.m_dot": m_str,
+        "ch_bra.m_dot": m_bra,
+        "mc_com.Pt": pt_com,
+        "mc_str.Pt": pt_str,
+        "mc_bra.Pt": pt_bra,
+    }
+
+
+def test_v1_energy_check_rejects_mirror_root():
+    """Suppliers at ~2.0 bar feeding a ~2.11 bar collector: the exact
+    sign-flipped image of the physical root, energetically impossible
+    for a passive junction."""
+    jct = _resolved_junction()
+    mirror = _sol_dict(-0.43, 0.29, -0.72, 2.11e5, 2.05e5, 1.99e5)
+    assert jct.verify_solution_consistent(mirror) is False
+
+
+def test_v1_energy_check_accepts_physical_ejector_root():
+    """The 2.1 bar primary entrains the 2.05 bar straight arm and all
+    flow exits at the 2.0 bar branch: reversal at a port is physical
+    (Bassett 2001 Section 3). Two suppliers => joining mode => the
+    check is out of scope (and the state is energetically fine anyway)."""
+    jct = _resolved_junction()
+    ejector = _sol_dict(0.36, -0.21, 0.57, 2.09e5, 2.04e5, 2.02e5)
+    assert jct.verify_solution_consistent(ejector) is True
+
+
+def test_v1_energy_check_skips_joining_mode():
+    """>= 2 suppliers (joining) is out of scope even when a collector
+    exceeds every supplier Pt: the v1 impulse rows themselves can
+    manufacture flow work for joining flow (the documented deficiency
+    that motivated MPCEv2), so policing energy here would reject the
+    v1 merge model's own legitimate solutions."""
+    jct = _resolved_junction()
+    # Suppliers: the common port (element-frame +0.4, junction-convention
+    # -0.4) and the reversed straight arm (-0.25); collector: the branch
+    # at 2.2e5 Pa, above both supplier Pts (2.05e5 / 2.0e5).
+    joining = _sol_dict(0.4, -0.25, 0.65, 2.05e5, 2.0e5, 2.2e5)
+    assert jct.verify_solution_consistent(joining) is True
+
+
+def test_v1_energy_check_zero_flow_is_vacuous():
+    jct = _resolved_junction()
+    idle = _sol_dict(1e-12, -1e-12, 1e-12, 1.5e5, 1.5e5, 1.5e5)
+    assert jct.verify_solution_consistent(idle) is True
+
+
+def test_v1_energy_check_missing_keys_pass():
+    jct = _resolved_junction()
+    partial = {"ch_in.m_dot": -0.43, "mc_com.Pt": 2.11e5}
+    assert jct.verify_solution_consistent(partial) is True
+
+
+def test_v1_energy_check_tolerates_near_equal_pt():
+    """A collector within rel_tol of the max supplier Pt is numerical
+    noise, not manufactured work."""
+    jct = _resolved_junction()
+    near = _sol_dict(0.4, 0.2, 0.2, 2.0e5, 2.0e5 * (1.0 + 0.5e-4), 1.9e5)
+    assert jct.verify_solution_consistent(near) is True
+
+
+def test_three_port_default_path_self_heals_from_mirror_root():
+    """End-to-end payoff of the v1 energy hook: the plain cold solve on
+    this net converges onto the mirror root, the post-solve verification
+    demotes it, and the outlet-ref auto-retry then reaches the physical
+    ejector root -- success with forward common inflow, no manual
+    strategy selection needed.
+    """
+    net = _three_port_net()
+    solver = NetworkSolver(net)
+    with pytest.warns(UserWarning):
+        sol = solver.solve(timeout=120.0)
+    assert sol["__success__"], sol.get("__message__")
+    assert sol["ch_in.m_dot"] > 0.0, f"inlet reversed: {sol['ch_in.m_dot']}"
+    ssu = solver._diagnostic_data["solver_settings_used"]
+    assert ssu["init_strategy"] == "outletref_warmstart"
+    assert ssu.get("auto_retry") is True
 
 
 def test_stall_wiring_forced_detector(monkeypatch):


### PR DESCRIPTION
## Summary

Adds the energy-consistency verification hook to the v1 `MultiPortChamberElement`, closing the mirror-root exposure that #228 revealed: v1's impulse rows are even in the port flows, so the sign-flipped image of any root is also an exact root — and the image of a physical root is energetically impossible (a passive junction collecting flow from low-Pt ports into a higher-Pt port). Since #228 the fast cold path converges onto such mirrors and reported *success* (three-port net: the 2.0 bar branch "pumping" into the 2.1 bar reservoir).

## The criterion, and its deliberate scope

`verify_solution_consistent` on the v1 base class (MPCEv2 keeps its stricter direction-based override; GUI networks unaffected): **no collector port's total pressure may exceed the single supplier's** (1e-4 relative tolerance), plugged into the existing #215 post-solve gate.

Two constraints shaped it:

- **Direction cannot be checked** — v1 legitimately supports runtime reversal (ejector regimes, Bassett 2001 §3), and the *physical* root on the three-port net is itself an ejector (the 2.05 bar arm feeds the junction).
- **Separating mode only (exactly one supplier).** The first implementation policed all states, and the regression suite immediately demonstrated why that's wrong: in joining mode the v1 impulse rows *themselves* manufacture flow work — the documented deficiency that motivated MPCEv2 — so an energy bound there rejects the v1 merge model's own legitimate solutions (two certified regression tests converge to collector-above-suppliers states by model construction).

## End-to-end effect

New integration test: the plain cold `solve()` on the three-port net now **self-heals** — cold lands on the mirror, the hook demotes it to an honest failure, and the outlet-ref auto-retry converges to the physical ejector root with forward common inflow. Previously the same call returned the unphysical mirror as success.

The post-solve demotion message is generalized to name both verification kinds (soft-barrier wrong-direction and energy-inconsistent mirror); the `"artifact root"` substring that existing tests match is preserved.

## Verification

- 6 unit tests on the hook: mirror rejected, ejector accepted, joining-mode skip (with the manufactured-work state explicitly constructed), zero-flow vacuous, missing-keys pass, near-equal-Pt tolerance.
- Self-healing integration test (~7 s).
- Full suite 1568 passed / 28 skipped in 40 s; certified audit 32/32 (all MPCEv2 — untouched by the hook); style + pre-commit green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
