### PR TITLE
fix(gui): retire the deprecated incompressible warm-start from the dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+- **GUI: the deprecated "Incomp. Warmstart" init strategy is no longer
+  offered in the dropdown.** The inlet-referenced incompressible warm
+  start occasionally works (heavy MFB-driven nets), but its successor
+  -- the outlet-referenced variant, which tracks the compressible root
+  6-7x closer and remains selectable -- covers that niche, and the
+  auto-retry ladder still falls back to the inlet-referenced proxy
+  internally when the outlet-referenced one starves. Legacy save
+  files that stored the old strategy are migrated to
+  ``outletref_warmstart`` on load. The Python API still accepts
+  ``init_strategy="incompressible_warmstart"`` (with its
+  DeprecationWarning) for headless workflows.
+
 ### Added
 - **GUI/Network: constant-K junction model tier for the tee.** The
   tee Inspector gains a "Junction Model" selector: the default

--- a/gui/frontend/src/components/Sidebar.tsx
+++ b/gui/frontend/src/components/Sidebar.tsx
@@ -357,9 +357,6 @@ const Sidebar = () => {
 					>
 						<option value="default">Default Cold Start</option>
 						<option value="analytical_pt_prop">Analytical (Pt Prop.)</option>
-						<option value="incompressible_warmstart">
-							Incomp. Warmstart (deprecated)
-						</option>
 						<option value="outletref_warmstart">
 							Incomp. Warmstart (Outlet-ref)
 						</option>

--- a/gui/frontend/src/store/useStore.test.ts
+++ b/gui/frontend/src/store/useStore.test.ts
@@ -126,3 +126,33 @@ describe("useStore topology result invalidation", () => {
 		expect(solveResults).toBeNull();
 	});
 });
+
+describe("loadNetwork legacy migration", () => {
+	it("maps the retired incompressible_warmstart strategy to outletref_warmstart", () => {
+		useStore.getState().loadNetwork({
+			nodes: [nodeWithResult("n1")],
+			edges: [],
+			solverSettings: {
+				...useStore.getState().solverSettings,
+				init_strategy: "incompressible_warmstart",
+			},
+		});
+		expect(useStore.getState().solverSettings.init_strategy).toBe(
+			"outletref_warmstart",
+		);
+	});
+
+	it("leaves current strategies untouched", () => {
+		useStore.getState().loadNetwork({
+			nodes: [nodeWithResult("n1")],
+			edges: [],
+			solverSettings: {
+				...useStore.getState().solverSettings,
+				init_strategy: "analytical_pt_prop",
+			},
+		});
+		expect(useStore.getState().solverSettings.init_strategy).toBe(
+			"analytical_pt_prop",
+		);
+	});
+});

--- a/gui/frontend/src/store/useStore.ts
+++ b/gui/frontend/src/store/useStore.ts
@@ -58,7 +58,6 @@ export interface RFState {
 		init_strategy:
 			| "default"
 			| "analytical_pt_prop"
-			| "incompressible_warmstart"
 			| "outletref_warmstart"
 			| "homotopy"
 			| "continuation";
@@ -398,6 +397,15 @@ const useStore = create<RFState>((set, get) => ({
 
 	loadNetwork: (data: any) => {
 		if (data.nodes && data.edges) {
+			const loadedSettings = data.solverSettings || get().solverSettings;
+			// Legacy migration: the deprecated inlet-referenced incompressible
+			// warm start is no longer offered in the UI; its successor is the
+			// outlet-referenced variant (tracks the compressible root 6-7x
+			// closer). The backend still accepts the old value for headless
+			// workflows.
+			if (loadedSettings.init_strategy === "incompressible_warmstart") {
+				loadedSettings.init_strategy = "outletref_warmstart";
+			}
 			set({
 				nodes: data.nodes.map((n: any) => ({
 					...n,
@@ -407,7 +415,7 @@ const useStore = create<RFState>((set, get) => ({
 					...e,
 					data: e.data ? { ...e.data, result: undefined } : e.data,
 				})),
-				solverSettings: data.solverSettings || get().solverSettings,
+				solverSettings: loadedSettings,
 				solveResults: null,
 			});
 		}


### PR DESCRIPTION
## Summary

Retires the deprecated inlet-referenced "Incomp. Warmstart" init strategy from the GUI dropdown, resolving the open question from the #221 arc ("deprecating is not the best solution yet" — revisit after field experience).

**The verdict:** it does occasionally work (heavy MFB-driven nets), but its successor covers the niche — the outlet-referenced variant tracks the compressible root 6–7x closer and remains selectable — and the auto-retry ladder *still falls back to the inlet-referenced proxy internally* when the outlet-referenced one starves, so nothing is lost functionally.

## Changes

- Sidebar dropdown: "Incomp. Warmstart (deprecated)" removed; store type union drops the value.
- `loadNetwork` migrates legacy save files that stored the old strategy to `outletref_warmstart` (vitest-covered, plus a no-touch check for current strategies).
- Backend/solver deliberately unchanged: the GUI schema and Python API still accept `init_strategy="incompressible_warmstart"` (DeprecationWarning intact) for legacy files and headless workflows.

## Verification

13 vitest passed; biome + tsc build green; pre-commit green. After merge: restart backend + hard refresh — the dropdown shows Default / Analytical / Incomp. Warmstart (Outlet-ref) / Homotopy / Continuation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
