### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-07-08
+
 ### Removed
 - **GUI: the deprecated "Incomp. Warmstart" init strategy is no longer
   offered in the dropdown.** The inlet-referenced incompressible warm
@@ -1147,7 +1149,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - State property units mismatch in example runner
 - Solver stability under degenerate initial conditions
 
-[Unreleased]: https://github.com/thiemom/combaero/compare/v0.2.6...HEAD
+[Unreleased]: https://github.com/thiemom/combaero/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/thiemom/combaero/compare/v0.3.1...v0.4.0
+[0.3.1]: https://github.com/thiemom/combaero/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/thiemom/combaero/compare/v0.2.6...v0.3.0
 [0.2.6]: https://github.com/thiemom/combaero/compare/v0.2.4...v0.2.6
 [0.2.4]: https://github.com/thiemom/combaero/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/thiemom/combaero/compare/v0.2.2...v0.2.3

--- a/gui/pyproject.toml
+++ b/gui/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "uvicorn",
     "pydantic",
     "pandas",
-    "combaero~=0.3",
+    "combaero~=0.4",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- Cuts `[Unreleased]` (68 commits since v0.3.1) into `[0.4.0] - 2026-07-08`: MPCE v1/v2 junction framework, constant-K and Mynard tee junction models, solver stall-detection/auto-retry hardening, energy-consistency root verification, validation-dataset infrastructure, plus assorted GUI fixes.
- Bumps `combaero-gui`'s `combaero` dependency pin from `~=0.3` to `~=0.4` -- this is the same failure mode that forced the v0.3.1 hotfix (#156): an unbumped pin lets `combaero-gui` resolve a stale `combaero` from PyPI that predates classes added in this release (e.g. `ConstantKTeeElement`), causing an `ImportError` at startup.
- Backfills the `[0.3.0]`/`[0.3.1]` compare-links at the bottom of the changelog, which were never added when those versions were released.

## Test plan
- [x] `./scripts/check-python-style.sh --fix` -- all checks pass (pre-existing mypy warnings only, unrelated to this diff)
- [x] CI green on `main` at the commit this branches from (cc13976)
- [ ] After merge: tag `v0.4.0` on `main` to trigger `publish.yml` (combaero core wheels/sdist) and `publish-gui.yml` (combaero-gui)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
