### PR TITLE
fix(ci): publish-gui.yml waits for matching combaero release on PyPI

### DIFF
--- a/.github/workflows/publish-gui.yml
+++ b/.github/workflows/publish-gui.yml
@@ -88,6 +88,27 @@ jobs:
           print("OK: wheel contents look good")
           EOF
 
+      - name: Wait for matching combaero release on PyPI
+        run: |
+          # combaero-gui and combaero share a tag/version (both derived via
+          # setuptools_scm from the same `v*` tag), but publish.yml builds
+          # wheels for 3 OSes and is slower than this workflow -- poll until
+          # the matching combaero version actually lands on the index instead
+          # of racing it (see #232 follow-up: first v0.4.0 attempt failed
+          # because "No solution found" resolving combaero>=0.4 too early).
+          GUI_WHEEL=$(ls dist/combaero_gui-*.whl)
+          VERSION=$(basename "$GUI_WHEEL" | cut -d- -f2)
+          echo "Waiting for combaero==$VERSION on PyPI..."
+          for i in $(seq 1 40); do
+            if curl -fsS "https://pypi.org/pypi/combaero/$VERSION/json" > /dev/null 2>&1; then
+              echo "Found combaero==$VERSION on PyPI after $((i - 1)) retries."
+              exit 0
+            fi
+            sleep 15
+          done
+          echo "FAIL: combaero==$VERSION did not appear on PyPI within 10 minutes"
+          exit 1
+
       - name: Install wheel and smoke-test server
         run: |
           uv venv .test-venv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **CI: `publish-gui.yml` no longer races `publish.yml` to PyPI.** Both
+  workflows trigger off the same `v*` tag, but the core `combaero` wheel
+  build (3 OSes via `cibuildwheel`) is slower than the GUI build; the
+  verify job's `uv pip install` could resolve before the matching
+  `combaero` version existed on the index ("No solution found" --
+  first hit on the v0.4.0 release). The verify job now polls PyPI for
+  the matching `combaero` version (up to 10 minutes) before installing.
+
 ## [0.4.0] - 2026-07-08
 
 ### Removed


### PR DESCRIPTION
## Summary
- The `v0.4.0` release exposed a race: `publish-gui.yml` and `publish.yml` both trigger off the same `v*` tag, but `publish.yml`'s `cibuildwheel` matrix (3 OSes) is slower than the GUI build. The GUI verify job's `uv pip install dist/combaero_gui-*.whl` resolved before the matching `combaero` version existed on PyPI (`combaero-gui` depends on `combaero~=<same version>`), failing with "No solution found ... only combaero<=0.3.1 is available" while `combaero==0.4.0` was still mid-build.
- Adds a "Wait for matching combaero release on PyPI" step to the verify job: polls `pypi.org/pypi/combaero/<version>/json` every 15s for up to 10 minutes before the install step runs.

## Test plan
- [x] `./scripts/check-python-style.sh --fix` -- N/A, no Python changes
- [ ] Next tagged release: confirm `publish-gui.yml`'s verify job waits out the core wheel build instead of failing the race

🤖 Generated with [Claude Code](https://claude.com/claude-code)
