### PR TITLE
fix(ci): harden publish-gui.yml against two more PyPI publish races

### DIFF
--- a/.github/workflows/publish-gui.yml
+++ b/.github/workflows/publish-gui.yml
@@ -96,11 +96,18 @@ jobs:
           # the matching combaero version actually lands on the index instead
           # of racing it (see #232 follow-up: first v0.4.0 attempt failed
           # because "No solution found" resolving combaero>=0.4 too early).
+          #
+          # Poll the Simple Repository index (the endpoint `uv pip install`
+          # actually resolves against), not the JSON API: on the v0.4.1
+          # release the JSON API reported the new version several minutes
+          # before it was visible via /simple/ (separate CDN cache), so the
+          # install step below silently resolved the prior (broken) version
+          # instead of failing.
           GUI_WHEEL=$(ls dist/combaero_gui-*.whl)
           VERSION=$(basename "$GUI_WHEEL" | cut -d- -f2)
-          echo "Waiting for combaero==$VERSION on PyPI..."
+          echo "Waiting for combaero==$VERSION on the PyPI simple index..."
           for i in $(seq 1 40); do
-            if curl -fsS "https://pypi.org/pypi/combaero/$VERSION/json" > /dev/null 2>&1; then
+            if curl -fsS "https://pypi.org/simple/combaero/" 2>/dev/null | grep -q "combaero-$VERSION"; then
               echo "Found combaero==$VERSION on PyPI after $((i - 1)) retries."
               exit 0
             fi
@@ -116,7 +123,18 @@ jobs:
           uv pip install --python .test-venv dist/combaero_gui-*.whl
           .test-venv/bin/combaero-gui &
           SERVER_PID=$!
-          sleep 4
+          # poll instead of a fixed sleep -- a fixed 4s sleep flaked on the
+          # v0.4.1 release when server startup (heavier now with the MPCE
+          # junction models) took slightly longer than that.
+          for i in $(seq 1 20); do
+            curl -fsS http://localhost:8000/health > /dev/null 2>&1 && break
+            if [ "$i" -eq 20 ]; then
+              echo "FAIL: server did not respond on :8000/health within 10s"
+              kill $SERVER_PID
+              exit 1
+            fi
+            sleep 0.5
+          done
           # health endpoint must respond 200
           curl -fsS http://localhost:8000/health
           # root must serve HTML (index.html), not JSON

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-07-09
+
+### Fixed
+- **CI: `publish-gui.yml` verify job had two more release-blocking races,
+  both hit on the v0.4.1 release attempt.** (1) The "wait for combaero"
+  step polled PyPI's JSON API, which updated several minutes before the
+  Simple Repository index that `uv pip install` actually resolves
+  against (separate CDN caches); the install step silently resolved the
+  prior, broken `combaero` version instead of failing outright. Now
+  polls `/simple/combaero/` directly. (2) The smoke test's fixed `sleep
+  4` before the health-check `curl` flaked repeatedly once server
+  startup (heavier now with the MPCE junction models) crept past 4s;
+  replaced with a poll loop (up to 10s).
+
 ## [0.4.1] - 2026-07-08
 
 ### Fixed
@@ -1173,7 +1187,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - State property units mismatch in example runner
 - Solver stability under degenerate initial conditions
 
-[Unreleased]: https://github.com/thiemom/combaero/compare/v0.4.1...HEAD
+[Unreleased]: https://github.com/thiemom/combaero/compare/v0.4.2...HEAD
+[0.4.2]: https://github.com/thiemom/combaero/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/thiemom/combaero/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/thiemom/combaero/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/thiemom/combaero/compare/v0.3.0...v0.3.1


### PR DESCRIPTION
## Summary
The v0.4.1 `combaero-gui` publish job failed 3 times in a row after the version-race fix from #233, on two separate issues:

1. The "wait for combaero" step polled PyPI's **JSON API**, which reported `combaero==0.4.1` several minutes before it was visible on the **Simple Repository index** that `uv pip install` actually resolves against (separate CDN caches, different propagation delay). The install step didn't error -- it silently resolved the prior, broken `combaero==0.4.0` since it also satisfied the `~=0.4` pin. Now polls `/simple/combaero/` directly, the same endpoint the install step uses.
2. The smoke test's fixed `sleep 4` before the health-check `curl` flaked on all 3 re-runs once actual server startup crept to ~5s (heavier imports now with the MPCE junction models added in 0.4.0). Replaced with a poll loop (up to 10s, 0.5s interval) instead of a blind sleep.

Cuts `CHANGELOG.md` `[Unreleased]` into `[0.4.2]` -- this is workflow-only, no package source changed, but the monorepo shares one tag/version scheme across `combaero` and `combaero-gui`.

## Test plan
- [x] `./scripts/check-python-style.sh --fix` -- N/A, no Python changes
- [ ] After merge: tag `v0.4.2`, confirm `combaero-gui` publishes cleanly this time

🤖 Generated with [Claude Code](https://claude.com/claude-code)
