### PR TITLE
feat(network): port ejector physics to C++ with analytic Jacobians

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,10 @@ foreach(test_source ${TEST_SOURCES})
     get_filename_component(test_name ${test_source} NAME_WE)
     add_executable(${test_name} ${test_source})
     target_link_libraries(${test_name} PRIVATE combaero_core GTest::gtest_main)
+    # Repo root on the include path so tests can pull in golden data headers
+    # that live outside include/ (e.g. validation/*/data/*.h) without
+    # duplicating reference numbers into the test file itself.
+    target_include_directories(${test_name} PRIVATE ${CMAKE_SOURCE_DIR})
     add_test(NAME ${test_name} COMMAND ${test_name})
 endforeach()
 

--- a/include/ejector.h
+++ b/include/ejector.h
@@ -1,0 +1,160 @@
+#pragma once
+
+// -----------------------------------------------------------------------------
+// 1-D critical-mode supersonic ejector model.
+//
+// C++ port of python/combaero/network/_ejector_huang1999.py -- see that
+// module's docstring for the full paper-by-paper research narrative and
+// validation/ejector/README.md for the accuracy comparison against
+// alternative closures. Kept in exact correspondence with the Python
+// reference so the two can be cross-validated row-for-row against
+// validation/ejector/data/huang1999_reference_data.h (see
+// tests/test_ejector_physics.cpp, tests/test_ejector_jacobians.cpp).
+//
+// References
+// ----------
+// [Huang 1999] B.J. Huang, J.M. Chang, C.P. Wang, V.A. Petrenko,
+//     "A 1-D analysis of ejector performance",
+//     International Journal of Refrigeration 22 (1999) 354-364.
+//     Local copy: docs/ejector/Huang_1d_analysis_ejector.pdf
+//     Source of ejector_entrainment_ratio (Eqs. 1-8) and
+//     ejector_choked_mass_flow (Eqs. 1, 7).
+// [Kracik & Dvorak 2016] J. Kracik, V. Dvorak,
+//     "Development of an Analytical Method for Predicting Flow in a
+//     Supersonic Air Ejector", EPJ Web of Conferences 114, 02059 (2016),
+//     DOI: 10.1051/epjconf/201611402059.
+//     Local copy: docs/ejector/Development_of_an_Analytical_Method_for.pdf
+//     Source of the mixing closure ejector_critical_back_pressure
+//     implements (their Eqs. 7-13).
+//
+// Scope: critical (double-choked) operation only.
+//
+// Jacobian scope (this header): analytic derivatives w.r.t. the 4
+// thermodynamic inputs (p_g, t_g, p_e, t_e) only -- these are the only
+// inputs that are ever Newton-solved unknowns for the network element
+// consuming this module (EjectorElement). gamma, r_gas, geometry, and
+// recovery_efficiency are element parameters, not solved unknowns, so
+// their derivatives are intentionally not exposed here (deliberate scope
+// boundary, not an oversight -- validation/ejector/data/
+// huang1999_reference_data.h separately carries central-difference targets
+// for those too, for a possible future design-sensitivity extension).
+//
+// Key simplification that makes every derivative below exact analytic
+// chain rule (no implicit/root-finding differentiation needed anywhere):
+// the one internal root-find (ejector_mach_from_area_ratio_supersonic, a
+// bisection for the primary nozzle-exit Mach number M_p1) depends ONLY on
+// area_ratio_nozzle and gamma -- neither a Newton-solved unknown here -- so
+// M_p1 has a PROVABLY exact zero derivative w.r.t. p_g, t_g, p_e, t_e.  It
+// is computed once (bisection, same as Python) and then treated as a
+// precomputed constant throughout the rest of the (otherwise fully
+// closed-form) chain.
+// -----------------------------------------------------------------------------
+
+#include <tuple>
+
+namespace ejector {
+constexpr double eta_p = 0.95; // primary-nozzle isentropic efficiency (Huang 1999, Section 4)
+constexpr double eta_s = 0.85; // entrained-flow isentropic efficiency
+constexpr double phi_p = 0.88; // primary-core area-loss coefficient at section y-y (Eq. 5)
+} // namespace ejector
+
+namespace combaero::solver {
+
+struct EjectorGeometry {
+  double area_ratio_nozzle; // A_p1 / A_t
+  double area_ratio_mix;    // A_3 / A_t
+};
+
+// -----------------------------------------------------------------------------
+// Value-only functions (Python 1:1 parity; see tests/test_ejector_physics.cpp)
+// -----------------------------------------------------------------------------
+
+// Isentropic area ratio A/A* for a given Mach number.
+double ejector_area_over_astar(double mach, double gamma);
+
+// Supersonic root of A/A* = area_ratio by bisection (inverse of Eq. 2).
+// A/A* is monotonically increasing for M > 1, so bisection is
+// unconditionally convergent.
+double ejector_mach_from_area_ratio_supersonic(double area_ratio, double gamma);
+
+// Choked (sonic-throat) mass flow rate (Huang 1999 Eqs. 1 and 7).
+//
+// Method: Analytical Chain Rule (see ejector_choked_mass_flow_and_jacobian).
+double ejector_choked_mass_flow(double p0, double t0, double area_throat,
+                                double gamma, double r_gas, double eta);
+
+struct EjectorEntrainmentResult {
+  double omega;                     // entrainment ratio ms / mp
+  double mach_nozzle_exit;          // M_p1
+  double mach_hypothetical_throat;  // M_py
+  double area_ratio_primary_core;   // A_py / A_t
+  double area_ratio_entrained;      // A_sy / A_t
+  double p_mixing_pa;               // P_py = P_sy
+};
+
+// Critical-mode entrainment ratio omega (Huang 1999 Eqs. 1-8).
+//
+// Method: Analytical Chain Rule, composed around one precomputed bisection
+// root (M_p1) whose derivative w.r.t. p_g/t_g/p_e/t_e is exactly zero --
+// see the header comment above.
+EjectorEntrainmentResult ejector_entrainment_ratio(double p_g, double t_g,
+                                                    double p_e, double t_e,
+                                                    const EjectorGeometry& geom,
+                                                    double gamma);
+
+// Aerodynamic mass-flow function q(lambda) (Kracik & Dvorak Eq. 9).
+double ejector_q_lambda(double lam, double gamma);
+
+struct EjectorCriticalPressureResult {
+  double p_c_pa;                  // critical back pressure P_c*
+  double p_mixed_stagnation_pa;   // p03, lossless (recovery_efficiency=1) mixed stagnation pressure
+  double temp_mixed_stagnation_k; // T03
+  double lambda_mixed;            // lambda3, subsonic root
+  double mach_mixed;              // Mach number equivalent of lambda3
+};
+
+// Critical back pressure P_c* via Kracik & Dvorak's mixing closure
+// (their Eqs. 7-13), continuing from the entrainment-ratio state above.
+//
+// Method: Analytical Chain Rule (same M_p1 treatment as
+// ejector_entrainment_ratio).
+EjectorCriticalPressureResult ejector_critical_back_pressure(
+    double p_g, double t_g, double p_e, double t_e,
+    const EjectorGeometry& geom, double gamma, double r_gas,
+    double recovery_efficiency);
+
+// -----------------------------------------------------------------------------
+// Jacobian-carrying variants: (value, d/dp_g, d/dt_g, d/dp_e, d/dt_e).
+// -----------------------------------------------------------------------------
+
+// (m_dot, d_mdot_dp0, d_mdot_dt0)
+std::tuple<double, double, double>
+ejector_choked_mass_flow_and_jacobian(double p0, double t0, double area_throat,
+                                      double gamma, double r_gas, double eta);
+
+struct EjectorEntrainmentJacobian {
+  EjectorEntrainmentResult value;
+  double domega_dp_g;
+  double domega_dt_g;
+  double domega_dp_e;
+  double domega_dt_e;
+};
+
+EjectorEntrainmentJacobian ejector_entrainment_ratio_and_jacobian(
+    double p_g, double t_g, double p_e, double t_e,
+    const EjectorGeometry& geom, double gamma);
+
+struct EjectorCriticalPressureJacobian {
+  EjectorCriticalPressureResult value;
+  double dpc_dp_g;
+  double dpc_dt_g;
+  double dpc_dp_e;
+  double dpc_dt_e;
+};
+
+EjectorCriticalPressureJacobian ejector_critical_back_pressure_and_jacobian(
+    double p_g, double t_g, double p_e, double t_e,
+    const EjectorGeometry& geom, double gamma, double r_gas,
+    double recovery_efficiency);
+
+} // namespace combaero::solver

--- a/scripts/derive_ejector_jacobian.py
+++ b/scripts/derive_ejector_jacobian.py
@@ -1,0 +1,235 @@
+"""
+Symbolic derivation of the Huang (1999) / Kracik & Dvorak (2016) ejector
+Jacobian: d(omega)/d(p_g, t_g, p_e, t_e) and d(p03)/d(p_g, t_g, p_e, t_e),
+the two closed-form chains ported to C++ in include/ejector.h / src/ejector.cpp.
+
+Generates the step-by-step local derivatives used to hand-write the C++
+forward-mode accumulation (each C++ intermediate carries its value plus the
+4 running partials, mirroring solver_interface.cpp's
+orifice_compressible_mdot_and_jacobian style); the C++ code pastes in the
+resulting expressions (after manual simplification), same workflow as
+scripts/derive_mynard_jacobian.py.
+
+Run:
+    uv run python scripts/derive_ejector_jacobian.py
+
+Key simplification (see docs/ejector C++ port plan): `mach_p1` (the primary
+nozzle-exit Mach number) is the supersonic root of an isentropic area-Mach
+relation that depends ONLY on `area_ratio_nozzle` and `gamma` -- neither is
+a Newton-solved unknown for EjectorElement, so mach_p1 has an EXACT zero
+derivative w.r.t. p_g, t_g, p_e, t_e. It is therefore treated here as a
+precomputed constant symbol (`M_p1`), not differentiated -- no implicit/
+root-finding differentiation is needed anywhere in this derivation. Same
+treatment for gamma, r_gas, area_ratio_mix, recovery_efficiency, and the
+paper-calibrated coefficients (eta_p, eta_s, phi_p): all constants here.
+
+References: see python/combaero/network/_ejector_huang1999.py's docstring
+for full paper citations (Huang 1999 Eqs. 1-8; Kracik & Dvorak 2016
+Eqs. 7-13).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import sympy as sp
+
+# Differentiation variables (the 4 Newton-solved thermodynamic inputs).
+p_g, t_g, p_e, t_e = sp.symbols("p_g t_g p_e t_e", positive=True)
+
+# Constants for this derivation (precomputed once per residual evaluation;
+# NOT functions of p_g/t_g/p_e/t_e within this module's scope).
+M_p1, gamma, r_gas = sp.symbols("M_p1 gamma r_gas", positive=True)
+ar_mix = sp.symbols("ar_mix", positive=True)  # A_3 / A_t (area_ratio_mix)
+eta_p, eta_s, phi_p = sp.symbols("eta_p eta_s phi_p", positive=True)
+recovery_efficiency = sp.symbols("recovery_efficiency", positive=True)
+
+gm1 = gamma - 1
+gp1 = gamma + 1
+
+
+def area_over_astar(mach: sp.Expr, g: sp.Expr) -> sp.Expr:
+    """Isentropic area ratio A/A* (Huang Eq. 2's forward form)."""
+    return (1 / mach) * ((2 / (g + 1)) * (1 + sp.Rational(1, 2) * (g - 1) * mach**2)) ** (
+        (g + 1) / (2 * (g - 1))
+    )
+
+
+def q_lambda(lam: sp.Expr, g: sp.Expr) -> sp.Expr:
+    """Aerodynamic mass-flow function q(lambda) (Kracik & Dvorak Eq. 9)."""
+    return (1 - ((g - 1) / (g + 1)) * lam**2) ** (1 / (g - 1)) * ((g + 1) / 2) ** (
+        1 / (g - 1)
+    ) * lam
+
+
+# ---------------------------------------------------------------------------
+# entrainment_ratio (Huang Eqs. 1-8) -- mirrors _ejector_huang1999.py exactly.
+# ---------------------------------------------------------------------------
+
+p_p1 = p_g / (1 + sp.Rational(1, 2) * gm1 * M_p1**2) ** (gamma / gm1)
+p_sy = p_e / ((gp1 / 2) ** (gamma / gm1))
+p_py = p_sy
+
+core = (1 + sp.Rational(1, 2) * gm1 * M_p1**2) * (p_py / p_p1) ** (-gm1 / gamma)
+mach_py_sq = (core - 1) / (sp.Rational(1, 2) * gm1)  # unclamped branch (core > 1 assumed)
+mach_py = sp.sqrt(mach_py_sq)
+
+area_py = phi_p * area_over_astar(mach_py, gamma)
+area_sy = ar_mix - area_py
+
+omega = (p_e / p_g) * area_sy * sp.sqrt(t_g / t_e) * sp.sqrt(eta_s / eta_p)
+
+# ---------------------------------------------------------------------------
+# critical_back_pressure (Kracik & Dvorak Eqs. 7-13) -- continues from the
+# entrainment-ratio state above.
+# ---------------------------------------------------------------------------
+
+t_py = t_g / (1 + sp.Rational(1, 2) * gm1 * mach_py**2)
+t_sy = t_e / (gp1 / 2)
+v_py = mach_py * sp.sqrt(gamma * r_gas * t_py)
+v_sy = sp.sqrt(gamma * r_gas * t_sy)
+
+c1_star = sp.sqrt(2 * gamma / gp1 * r_gas * t_g)
+c2_star = sp.sqrt(2 * gamma / gp1 * r_gas * t_e)
+lambda1 = v_py / c1_star
+lambda2 = v_sy / c2_star
+
+theta21 = t_e / t_g
+gam = omega  # Kracik & Dvorak's Gamma = ms/mp, same definition as omega
+
+z1 = lambda1 + 1 / lambda1
+z2 = lambda2 + 1 / lambda2
+z3 = (z1 + gam * sp.sqrt(theta21) * z2) / sp.sqrt((1 + gam) * (1 + gam * theta21))
+lambda3 = (z3 - sp.sqrt(z3**2 - 4)) / 2  # subsonic root
+
+q1 = q_lambda(lambda1, gamma)
+q2 = q_lambda(lambda2, gamma)
+q3 = q_lambda(lambda3, gamma)
+
+p03 = (
+    p_g
+    * sp.sqrt((1 + gam) * (1 + gam * theta21))
+    / (1 + (p_g / p_e) * gam * sp.sqrt(theta21) * q1 / q2)
+    * q1
+    / q3
+)
+# p_c = recovery_efficiency * p03 -- trivial final scaling, not differentiated here.
+
+
+def show(name: str, expr: sp.Expr) -> sp.Expr:
+    """Print a derivative expression; returns it.
+
+    Deliberately NOT run through sp.simplify(): gamma is a free symbol, so
+    every power in this chain has a SYMBOLIC exponent (1/(gamma-1) etc.);
+    simplify's pattern matching on symbolic-exponent radicals is
+    pathologically slow here (didn't finish in minutes on the full z3/
+    lambda3 chain). The unsimplified diff is still exact and instant; the
+    numeric cross-check below is the real correctness gate, not the
+    printed form.
+    """
+    print(f"=== {name} ===")
+    print(expr)
+    print()
+    return expr
+
+
+VARS = [("p_g", p_g), ("t_g", t_g), ("p_e", p_e), ("t_e", t_e)]
+
+print("=" * 70)
+print("Ejector Jacobian: d(omega)/d(p_g,t_g,p_e,t_e)")
+print("=" * 70)
+domega = {}
+for name, var in VARS:
+    domega[name] = show(f"domega_d{name}", sp.diff(omega, var))
+
+print("=" * 70)
+print("Ejector Jacobian: d(p03)/d(p_g,t_g,p_e,t_e)")
+print("=" * 70)
+dp03 = {}
+for name, var in VARS:
+    dp03[name] = show(f"dp03_d{name}", sp.diff(p03, var))
+
+# ---------------------------------------------------------------------------
+# Numeric cross-check against validation/ejector/data/huang1999_reference.json
+# (central-difference Jacobian targets, h = 1e-6*|x|) -- catches derivation
+# mistakes here, before any C++ is written.
+# ---------------------------------------------------------------------------
+
+
+def mach_from_area_ratio_supersonic(area_ratio: float, g: float) -> float:
+    lo, hi = 1.0 + 1e-12, 50.0
+
+    def a_over_astar(m: float) -> float:
+        gm1_ = g - 1.0
+        gp1_ = g + 1.0
+        return (1.0 / m) * ((2.0 / gp1_) * (1.0 + 0.5 * gm1_ * m * m)) ** (gp1_ / (2.0 * gm1_))
+
+    for _ in range(200):
+        mid = 0.5 * (lo + hi)
+        if a_over_astar(mid) < area_ratio:
+            lo = mid
+        else:
+            hi = mid
+    return 0.5 * (lo + hi)
+
+
+def check_case(case: dict, omega_fns: dict, p03_fns: dict) -> None:
+    inp = case["inputs"]
+    jac = case["jacobian"]
+    ref = case["reference"]
+
+    subs = {
+        p_g: inp["p_g_pa"],
+        t_g: inp["t_g_k"],
+        p_e: inp["p_e_pa"],
+        t_e: inp["t_e_k"],
+        gamma: inp["gamma"],
+        r_gas: inp["r_gas"],
+        ar_mix: inp["area_ratio_mix"],
+        eta_p: 0.95,
+        eta_s: 0.85,
+        phi_p: 0.88,
+        M_p1: mach_from_area_ratio_supersonic(inp["area_ratio_nozzle"], inp["gamma"]),
+    }
+
+    print(f"--- {case['id']} ---")
+    ok = True
+    for name, _ in VARS:
+        analytic = float(domega[name].subs(subs))
+        target = jac[f"domega_d_{name}_pa" if name in ("p_g", "p_e") else f"domega_d_{name}_k"]
+        rel = abs(analytic - target) / (abs(target) + 1e-12)
+        status = "OK" if rel < 1e-4 else "MISMATCH"
+        ok = ok and status == "OK"
+        print(f"  domega_d{name}: analytic={analytic:.6e} target={target:.6e} rel={rel:.2e} {status}")
+
+    for name, _ in VARS:
+        analytic = float(dp03[name].subs(subs)) * inp["recovery_efficiency"]
+        key = f"dp_c_d_{name}_pa" if name in ("p_g", "p_e") else f"dp_c_d_{name}_k"
+        target = jac[key]
+        rel = abs(analytic - target) / (abs(target) + 1e-12)
+        status = "OK" if rel < 1e-4 else "MISMATCH"
+        ok = ok and status == "OK"
+        print(f"  dp_c_d{name}: analytic={analytic:.6e} target={target:.6e} rel={rel:.2e} {status}")
+
+    omega_val = float(omega.subs(subs))
+    p03_val = float(p03.subs(subs))
+    rel_omega = abs(omega_val - ref["omega"]) / abs(ref["omega"])
+    rel_p03 = abs(p03_val - ref["p_mixed_stagnation_pa"]) / abs(ref["p_mixed_stagnation_pa"])
+    print(f"  omega value: {omega_val:.6e} vs {ref['omega']:.6e} rel={rel_omega:.2e}")
+    print(f"  p03 value:   {p03_val:.6e} vs {ref['p_mixed_stagnation_pa']:.6e} rel={rel_p03:.2e}")
+    ok = ok and rel_omega < 1e-6 and rel_p03 < 1e-6
+    print("  ALL OK" if ok else "  *** FAILURES ABOVE ***")
+    print()
+
+
+if __name__ == "__main__":
+    ref_path = Path(__file__).resolve().parent.parent / "validation" / "ejector" / "data" / (
+        "huang1999_reference.json"
+    )
+    data = json.loads(ref_path.read_text())
+    print("=" * 70)
+    print("Numeric cross-check against huang1999_reference.json (CD targets)")
+    print("=" * 70)
+    for case in data["cases"][:3]:
+        check_case(case, domega, dp03)

--- a/src/ejector.cpp
+++ b/src/ejector.cpp
@@ -1,0 +1,250 @@
+// 1-D critical-mode supersonic ejector model. See include/ejector.h for
+// paper references and the Jacobian-scope note.
+
+#include "ejector.h"
+#include <cmath>
+
+namespace combaero::solver {
+
+double ejector_area_over_astar(double mach, double gamma) {
+  double gm1 = gamma - 1.0;
+  double gp1 = gamma + 1.0;
+  return (1.0 / mach) *
+         std::pow((2.0 / gp1) * (1.0 + 0.5 * gm1 * mach * mach), gp1 / (2.0 * gm1));
+}
+
+double ejector_mach_from_area_ratio_supersonic(double area_ratio, double gamma) {
+  double lo = 1.0 + 1e-12;
+  double hi = 50.0;
+  for (int i = 0; i < 200; ++i) {
+    double mid = 0.5 * (lo + hi);
+    if (ejector_area_over_astar(mid, gamma) < area_ratio) {
+      lo = mid;
+    } else {
+      hi = mid;
+    }
+  }
+  return 0.5 * (lo + hi);
+}
+
+double ejector_choked_mass_flow(double p0, double t0, double area_throat,
+                                double gamma, double r_gas, double eta) {
+  double gm1 = gamma - 1.0;
+  double gp1 = gamma + 1.0;
+  double choke_const = std::sqrt(gamma / r_gas * std::pow(2.0 / gp1, gp1 / gm1));
+  return (p0 * area_throat / std::sqrt(t0)) * choke_const * std::sqrt(eta);
+}
+
+std::tuple<double, double, double>
+ejector_choked_mass_flow_and_jacobian(double p0, double t0, double area_throat,
+                                      double gamma, double r_gas, double eta) {
+  double mdot = ejector_choked_mass_flow(p0, t0, area_throat, gamma, r_gas, eta);
+  // mdot = C * p0 / sqrt(t0)  =>  d/dp0 = mdot/p0,  d/dt0 = -mdot/(2*t0)
+  return {mdot, mdot / p0, -0.5 * mdot / t0};
+}
+
+double ejector_q_lambda(double lam, double gamma) {
+  double gm1 = gamma - 1.0;
+  double gp1 = gamma + 1.0;
+  return std::pow(1.0 - (gm1 / gp1) * lam * lam, 1.0 / gm1) * std::pow(gp1 / 2.0, 1.0 / gm1) * lam;
+}
+
+// -----------------------------------------------------------------------------
+// Forward-mode dual number carrying a value plus its 4 partial derivatives
+// w.r.t. (p_g, t_g, p_e, t_e). Every operator below implements the textbook
+// analytic differentiation rule (sum/product/quotient/chain rule) -- this is
+// bookkeeping for hand-derived-and-sympy-cross-checked analytic derivatives
+// (see scripts/derive_ejector_jacobian.py), not automatic differentiation
+// via a library and not finite differences. Writing the physics chain in
+// terms of Dual4 lets this mirror _ejector_huang1999.py's Python almost
+// line-for-line while the compiler enforces correct chain-rule composition
+// at every step, rather than 80+ individually hand-tracked partials.
+// -----------------------------------------------------------------------------
+namespace {
+
+struct Dual4 {
+  double v = 0.0;
+  double dpg = 0.0, dtg = 0.0, dpe = 0.0, dte = 0.0;
+
+  static Dual4 constant(double c) { return Dual4{c, 0.0, 0.0, 0.0, 0.0}; }
+};
+
+Dual4 operator+(const Dual4& a, const Dual4& b) {
+  return {a.v + b.v, a.dpg + b.dpg, a.dtg + b.dtg, a.dpe + b.dpe, a.dte + b.dte};
+}
+Dual4 operator+(const Dual4& a, double c) { return {a.v + c, a.dpg, a.dtg, a.dpe, a.dte}; }
+Dual4 operator+(double c, const Dual4& a) { return a + c; }
+
+Dual4 operator-(const Dual4& a, const Dual4& b) {
+  return {a.v - b.v, a.dpg - b.dpg, a.dtg - b.dtg, a.dpe - b.dpe, a.dte - b.dte};
+}
+Dual4 operator-(const Dual4& a, double c) { return {a.v - c, a.dpg, a.dtg, a.dpe, a.dte}; }
+Dual4 operator-(double c, const Dual4& a) { return {c - a.v, -a.dpg, -a.dtg, -a.dpe, -a.dte}; }
+
+Dual4 operator*(const Dual4& a, const Dual4& b) {
+  return {a.v * b.v, a.dpg * b.v + a.v * b.dpg, a.dtg * b.v + a.v * b.dtg,
+          a.dpe * b.v + a.v * b.dpe, a.dte * b.v + a.v * b.dte};
+}
+Dual4 operator*(const Dual4& a, double c) { return {a.v * c, a.dpg * c, a.dtg * c, a.dpe * c, a.dte * c}; }
+Dual4 operator*(double c, const Dual4& a) { return a * c; }
+
+Dual4 operator/(const Dual4& a, const Dual4& b) {
+  double inv = 1.0 / b.v;
+  double inv2 = inv * inv;
+  return {a.v * inv, (a.dpg * b.v - a.v * b.dpg) * inv2, (a.dtg * b.v - a.v * b.dtg) * inv2,
+          (a.dpe * b.v - a.v * b.dpe) * inv2, (a.dte * b.v - a.v * b.dte) * inv2};
+}
+Dual4 operator/(const Dual4& a, double c) { return a * (1.0 / c); }
+Dual4 operator/(double c, const Dual4& a) { return Dual4::constant(c) / a; }
+
+Dual4 dsqrt(const Dual4& a) {
+  double v = std::sqrt(a.v);
+  double coef = 0.5 / v;
+  return {v, a.dpg * coef, a.dtg * coef, a.dpe * coef, a.dte * coef};
+}
+
+// x^c for a CONSTANT real exponent c. Every exponent in this chain is a
+// function of gamma alone (a fixed parameter here, not a Newton unknown),
+// so this covers every power in the chain -- no Dual4^Dual4 is ever needed.
+Dual4 dpow(const Dual4& a, double c) {
+  double v = std::pow(a.v, c);
+  double coef = c * std::pow(a.v, c - 1.0);
+  return {v, a.dpg * coef, a.dtg * coef, a.dpe * coef, a.dte * coef};
+}
+
+} // namespace
+
+EjectorEntrainmentJacobian ejector_entrainment_ratio_and_jacobian(
+    double p_g_val, double t_g_val, double p_e_val, double t_e_val,
+    const EjectorGeometry& geom, double gamma) {
+  double gm1 = gamma - 1.0;
+  double gp1 = gamma + 1.0;
+  double g_over_gm1 = gamma / gm1;
+
+  Dual4 p_g{p_g_val, 1.0, 0.0, 0.0, 0.0};
+  Dual4 t_g{t_g_val, 0.0, 1.0, 0.0, 0.0};
+  Dual4 p_e{p_e_val, 0.0, 0.0, 1.0, 0.0};
+  Dual4 t_e{t_e_val, 0.0, 0.0, 0.0, 1.0};
+
+  // Primary flow: nozzle-exit Mach (Eq. 2) -- exact zero derivative w.r.t.
+  // p_g/t_g/p_e/t_e, see include/ejector.h's header comment.
+  double mach_p1_val = ejector_mach_from_area_ratio_supersonic(geom.area_ratio_nozzle, gamma);
+  Dual4 mach_p1 = Dual4::constant(mach_p1_val);
+
+  Dual4 p_p1 = p_g / dpow(1.0 + 0.5 * gm1 * mach_p1 * mach_p1, g_over_gm1);
+
+  // Entrained flow chokes at y-y (M_sy = 1); pressure matching P_py = P_sy.
+  double k2 = std::pow(gp1 / 2.0, g_over_gm1);
+  Dual4 p_sy = p_e / k2;
+  Dual4 p_py = p_sy;
+
+  // Invert Eq. 4 for the primary-core Mach at y-y.
+  Dual4 core = (1.0 + 0.5 * gm1 * mach_p1 * mach_p1) * dpow(p_py / p_p1, -gm1 / gamma);
+  Dual4 mach_py_sq = (core - 1.0) / (0.5 * gm1);
+  Dual4 mach_py = mach_py_sq.v > 0.0 ? dsqrt(mach_py_sq) : Dual4::constant(0.0);
+
+  // Areas at y-y (Eqs. 5, 8).
+  Dual4 area_py =
+      ejector::phi_p * (1.0 / mach_py) *
+      dpow(2.0 / gp1 * (1.0 + 0.5 * gm1 * mach_py * mach_py), gp1 / (2.0 * gm1));
+  Dual4 area_sy = geom.area_ratio_mix - area_py;
+
+  Dual4 omega = (p_e / p_g) * area_sy * dsqrt(t_g / t_e) * std::sqrt(ejector::eta_s / ejector::eta_p);
+
+  EjectorEntrainmentResult value{
+      omega.v,       mach_p1.v, mach_py.v, area_py.v, area_sy.v, p_py.v,
+  };
+  return {value, omega.dpg, omega.dtg, omega.dpe, omega.dte};
+}
+
+EjectorEntrainmentResult ejector_entrainment_ratio(double p_g, double t_g, double p_e,
+                                                    double t_e, const EjectorGeometry& geom,
+                                                    double gamma) {
+  return ejector_entrainment_ratio_and_jacobian(p_g, t_g, p_e, t_e, geom, gamma).value;
+}
+
+EjectorCriticalPressureJacobian ejector_critical_back_pressure_and_jacobian(
+    double p_g_val, double t_g_val, double p_e_val, double t_e_val,
+    const EjectorGeometry& geom, double gamma, double r_gas, double recovery_efficiency) {
+  double gm1 = gamma - 1.0;
+  double gp1 = gamma + 1.0;
+  double g_over_gm1 = gamma / gm1;
+
+  Dual4 p_g{p_g_val, 1.0, 0.0, 0.0, 0.0};
+  Dual4 t_g{t_g_val, 0.0, 1.0, 0.0, 0.0};
+  Dual4 p_e{p_e_val, 0.0, 0.0, 1.0, 0.0};
+  Dual4 t_e{t_e_val, 0.0, 0.0, 0.0, 1.0};
+
+  double mach_p1_val = ejector_mach_from_area_ratio_supersonic(geom.area_ratio_nozzle, gamma);
+  Dual4 mach_p1 = Dual4::constant(mach_p1_val);
+
+  Dual4 p_p1 = p_g / dpow(1.0 + 0.5 * gm1 * mach_p1 * mach_p1, g_over_gm1);
+  double k2 = std::pow(gp1 / 2.0, g_over_gm1);
+  Dual4 p_sy = p_e / k2;
+  Dual4 p_py = p_sy;
+
+  Dual4 core = (1.0 + 0.5 * gm1 * mach_p1 * mach_p1) * dpow(p_py / p_p1, -gm1 / gamma);
+  Dual4 mach_py_sq = (core - 1.0) / (0.5 * gm1);
+  Dual4 mach_py = mach_py_sq.v > 0.0 ? dsqrt(mach_py_sq) : Dual4::constant(0.0);
+
+  Dual4 area_py =
+      ejector::phi_p * (1.0 / mach_py) *
+      dpow(2.0 / gp1 * (1.0 + 0.5 * gm1 * mach_py * mach_py), gp1 / (2.0 * gm1));
+  Dual4 area_sy = geom.area_ratio_mix - area_py;
+
+  Dual4 omega = (p_e / p_g) * area_sy * dsqrt(t_g / t_e) * std::sqrt(ejector::eta_s / ejector::eta_p);
+
+  // Static temperatures and velocities at y-y (Huang Eqs. 9-10, 13-14).
+  Dual4 t_py = t_g / (1.0 + 0.5 * gm1 * mach_py * mach_py);
+  Dual4 t_sy = t_e / (gp1 / 2.0);
+  Dual4 v_py = mach_py * dsqrt(gamma * r_gas * t_py);
+  Dual4 v_sy = dsqrt(gamma * r_gas * t_sy); // M_sy = 1
+
+  Dual4 c1_star = dsqrt(2.0 * gamma / gp1 * r_gas * t_g);
+  Dual4 c2_star = dsqrt(2.0 * gamma / gp1 * r_gas * t_e);
+  Dual4 lambda1 = v_py / c1_star;
+  Dual4 lambda2 = v_sy / c2_star; // == 1 identically (M_sy = 1); kept computed for value parity
+
+  Dual4 theta21 = t_e / t_g;
+  Dual4 gam = omega;
+
+  Dual4 z1 = lambda1 + 1.0 / lambda1;
+  Dual4 z2 = lambda2 + 1.0 / lambda2;
+  Dual4 z3 = (z1 + gam * dsqrt(theta21) * z2) / dsqrt((1.0 + gam) * (1.0 + gam * theta21));
+  Dual4 lambda3 = (z3 - dsqrt(z3 * z3 - 4.0)) * 0.5; // subsonic root (Eq. 12)
+
+  double gm1_local = gm1;
+  double gp1_local = gp1;
+  double k7 = std::pow(gp1_local / 2.0, 1.0 / gm1_local);
+  auto q_of = [&](const Dual4& lam) {
+    Dual4 term = 1.0 - (gm1_local / gp1_local) * lam * lam;
+    return dpow(term, 1.0 / gm1_local) * k7 * lam;
+  };
+  Dual4 q1 = q_of(lambda1);
+  Dual4 q2 = q_of(lambda2); // == 1 identically (lambda2 == 1)
+  Dual4 q3 = q_of(lambda3);
+
+  // Mixed flow's stagnation pressure and temperature after mixing (Eqs. 7, 11).
+  Dual4 p03 = p_g * dsqrt((1.0 + gam) * (1.0 + gam * theta21)) /
+              (1.0 + (p_g / p_e) * gam * dsqrt(theta21) * q1 / q2) * q1 / q3;
+  Dual4 t03 = t_g * (1.0 + gam * theta21) / (1.0 + gam);
+
+  double mach3_sq = 2.0 * lambda3.v * lambda3.v / (gp1 - gm1 * lambda3.v * lambda3.v);
+  double mach3 = std::sqrt(mach3_sq);
+
+  EjectorCriticalPressureResult value{
+      recovery_efficiency * p03.v, p03.v, t03.v, lambda3.v, mach3,
+  };
+  return {value, recovery_efficiency * p03.dpg, recovery_efficiency * p03.dtg,
+          recovery_efficiency * p03.dpe, recovery_efficiency * p03.dte};
+}
+
+EjectorCriticalPressureResult ejector_critical_back_pressure(
+    double p_g, double t_g, double p_e, double t_e, const EjectorGeometry& geom,
+    double gamma, double r_gas, double recovery_efficiency) {
+  return ejector_critical_back_pressure_and_jacobian(p_g, t_g, p_e, t_e, geom, gamma, r_gas,
+                                                      recovery_efficiency)
+      .value;
+}
+
+} // namespace combaero::solver

--- a/tests/test_ejector_jacobians.cpp
+++ b/tests/test_ejector_jacobians.cpp
@@ -1,0 +1,87 @@
+// Jacobian-accuracy check for the ejector C++ port (include/ejector.h):
+// compares the analytic d/dp_g, d/dt_g, d/dp_e, d/dt_e against the
+// pre-baked central-difference targets (h = 1e-6*|x|) in
+// validation/ejector/data/huang1999_reference_data.h, for all 31 rows.
+// Mirrors tests/test_solver_jacobians.cpp's OrificeCompressibleDerivatives
+// EXPECT_NEAR idiom.
+
+#include "ejector.h"
+#include "validation/ejector/data/huang1999_reference_data.h"
+#include <cmath>
+#include <gtest/gtest.h>
+
+using namespace combaero::solver;
+using combaero::validation::ejector::kHuangCases;
+
+namespace {
+
+// Relative tolerance for analytic-vs-CD comparison. The reference file's
+// own CD step (h = 1e-6*|x|) has truncation/round-off noise around
+// 1e-8-1e-7 relative on these expressions (confirmed in
+// scripts/derive_ejector_jacobian.py's numeric cross-check); 1e-5 leaves
+// comfortable margin while still catching a real derivation error.
+constexpr double kRelTol = 1.0e-5;
+constexpr double kAbsFloor = 1.0e-9;
+
+void expect_jacobian_close(double analytic, double target, const char* what,
+                           const char* case_id) {
+  double tol = kRelTol * std::abs(target) + kAbsFloor;
+  EXPECT_NEAR(analytic, target, tol) << what << " mismatch for case " << case_id
+                                     << " (analytic=" << analytic << ", target=" << target << ")";
+}
+
+} // namespace
+
+TEST(EjectorJacobians, EntrainmentRatioMatchesCentralDifferenceForAllCases) {
+  for (const auto& c : kHuangCases) {
+    EjectorGeometry geom{c.area_ratio_nozzle, c.area_ratio_mix};
+    EjectorEntrainmentJacobian jac =
+        ejector_entrainment_ratio_and_jacobian(c.p_g_pa, c.t_g_k, c.p_e_pa, c.t_e_k, geom, c.gamma);
+
+    expect_jacobian_close(jac.domega_dp_g, c.domega_dp_g, "domega_dp_g", c.id);
+    expect_jacobian_close(jac.domega_dt_g, c.domega_dt_g, "domega_dt_g", c.id);
+    expect_jacobian_close(jac.domega_dp_e, c.domega_dp_e, "domega_dp_e", c.id);
+    expect_jacobian_close(jac.domega_dt_e, c.domega_dt_e, "domega_dt_e", c.id);
+  }
+}
+
+TEST(EjectorJacobians, CriticalBackPressureMatchesCentralDifferenceForAllCases) {
+  for (const auto& c : kHuangCases) {
+    EjectorGeometry geom{c.area_ratio_nozzle, c.area_ratio_mix};
+    EjectorCriticalPressureJacobian jac = ejector_critical_back_pressure_and_jacobian(
+        c.p_g_pa, c.t_g_k, c.p_e_pa, c.t_e_k, geom, c.gamma, c.r_gas, c.recovery_efficiency);
+
+    expect_jacobian_close(jac.dpc_dp_g, c.dpc_dp_g, "dpc_dp_g", c.id);
+    expect_jacobian_close(jac.dpc_dt_g, c.dpc_dt_g, "dpc_dt_g", c.id);
+    expect_jacobian_close(jac.dpc_dp_e, c.dpc_dp_e, "dpc_dp_e", c.id);
+    expect_jacobian_close(jac.dpc_dt_e, c.dpc_dt_e, "dpc_dt_e", c.id);
+  }
+}
+
+TEST(EjectorJacobians, ChokedMassFlowMatchesCentralDifference) {
+  // huang1999_reference_data.h has no column for choked_mass_flow (the
+  // reference model never needed the absolute mass flow, only the ratio
+  // form) -- CD spot-check computed directly here instead.
+  double gamma = 1.3;
+  double r_gas = 287.0;
+  double area_throat = 5.0e-5;
+  double eta = 0.95;
+
+  for (auto [p0, t0] : {std::pair{4.0e5, 400.0}, std::pair{1.2e5, 320.0}}) {
+    auto [mdot, d_dp0, d_dt0] =
+        ejector_choked_mass_flow_and_jacobian(p0, t0, area_throat, gamma, r_gas, eta);
+
+    double eps_p = 1.0e-6 * p0;
+    double fd_dp0 = (ejector_choked_mass_flow(p0 + eps_p, t0, area_throat, gamma, r_gas, eta) -
+                     ejector_choked_mass_flow(p0 - eps_p, t0, area_throat, gamma, r_gas, eta)) /
+                    (2.0 * eps_p);
+    double eps_t = 1.0e-6 * t0;
+    double fd_dt0 = (ejector_choked_mass_flow(p0, t0 + eps_t, area_throat, gamma, r_gas, eta) -
+                     ejector_choked_mass_flow(p0, t0 - eps_t, area_throat, gamma, r_gas, eta)) /
+                    (2.0 * eps_t);
+
+    EXPECT_NEAR(d_dp0, fd_dp0, std::abs(fd_dp0) * 1e-8 + 1e-12);
+    EXPECT_NEAR(d_dt0, fd_dt0, std::abs(fd_dt0) * 1e-8 + 1e-12);
+    EXPECT_GT(mdot, 0.0);
+  }
+}

--- a/tests/test_ejector_physics.cpp
+++ b/tests/test_ejector_physics.cpp
@@ -1,0 +1,85 @@
+// Value-parity check: the C++ port (include/ejector.h) must reproduce the
+// validated Python reference model's outputs for all 31 digitized Huang
+// (1999) Table 3/4 rows. This is a re-implementation check, not a physics
+// validation -- accuracy against Huang's published theory column was
+// already established in the Python reference model (see
+// validation/ejector/README.md).
+
+#include "ejector.h"
+#include "validation/ejector/data/huang1999_reference_data.h"
+#include <cmath>
+#include <gtest/gtest.h>
+
+using namespace combaero::solver;
+using combaero::validation::ejector::kHuangCases;
+
+namespace {
+
+void expect_close(double actual, double expected, double rel_tol, const char* what,
+                  const char* case_id) {
+  double tol = rel_tol * std::abs(expected) + 1e-12;
+  EXPECT_NEAR(actual, expected, tol) << what << " mismatch for case " << case_id;
+}
+
+} // namespace
+
+TEST(EjectorPhysics, EntrainmentRatioMatchesReferenceForAllCases) {
+  for (const auto& c : kHuangCases) {
+    EjectorGeometry geom{c.area_ratio_nozzle, c.area_ratio_mix};
+    EjectorEntrainmentResult res =
+        ejector_entrainment_ratio(c.p_g_pa, c.t_g_k, c.p_e_pa, c.t_e_k, geom, c.gamma);
+
+    expect_close(res.omega, c.omega, 1e-9, "omega", c.id);
+    expect_close(res.mach_nozzle_exit, c.mach_nozzle_exit, 1e-9, "mach_nozzle_exit", c.id);
+    expect_close(res.mach_hypothetical_throat, c.mach_hypothetical_throat, 1e-9,
+                "mach_hypothetical_throat", c.id);
+    expect_close(res.area_ratio_primary_core, c.area_ratio_primary_core, 1e-9,
+                "area_ratio_primary_core", c.id);
+    expect_close(res.area_ratio_entrained, c.area_ratio_entrained, 1e-9, "area_ratio_entrained",
+                c.id);
+  }
+}
+
+TEST(EjectorPhysics, CriticalBackPressureMatchesReferenceForAllCases) {
+  for (const auto& c : kHuangCases) {
+    EjectorGeometry geom{c.area_ratio_nozzle, c.area_ratio_mix};
+    EjectorCriticalPressureResult res = ejector_critical_back_pressure(
+        c.p_g_pa, c.t_g_k, c.p_e_pa, c.t_e_k, geom, c.gamma, c.r_gas, c.recovery_efficiency);
+
+    expect_close(res.p_c_pa, c.p_c_pa, 1e-9, "p_c_pa", c.id);
+    expect_close(res.p_mixed_stagnation_pa, c.p_mixed_stagnation_pa, 1e-9,
+                "p_mixed_stagnation_pa", c.id);
+    expect_close(res.temp_mixed_stagnation_k, c.temp_mixed_stagnation_k, 1e-9,
+                "temp_mixed_stagnation_k", c.id);
+    expect_close(res.lambda_mixed, c.lambda_mixed, 1e-9, "lambda_mixed", c.id);
+    expect_close(res.mach_mixed, c.mach_mixed, 1e-9, "mach_mixed", c.id);
+  }
+}
+
+TEST(EjectorPhysics, ChokedMassFlowScalesLinearlyWithPressureAndArea) {
+  // Sanity check independent of the reference table (choked_mass_flow has
+  // no dedicated reference column): mdot = C * p0 * area / sqrt(t0).
+  double gamma = 1.3;
+  double r_gas = 287.0;
+  double eta = 0.95;
+  double mdot1 = ejector_choked_mass_flow(1.0e5, 300.0, 1.0e-4, gamma, r_gas, eta);
+  double mdot2 = ejector_choked_mass_flow(2.0e5, 300.0, 1.0e-4, gamma, r_gas, eta);
+  double mdot3 = ejector_choked_mass_flow(1.0e5, 300.0, 2.0e-4, gamma, r_gas, eta);
+
+  EXPECT_NEAR(mdot2, 2.0 * mdot1, 1e-9 * mdot2);
+  EXPECT_NEAR(mdot3, 2.0 * mdot1, 1e-9 * mdot3);
+  EXPECT_GT(mdot1, 0.0);
+}
+
+TEST(EjectorPhysics, AreaOverAstarIsUnityAtMachOne) {
+  EXPECT_NEAR(ejector_area_over_astar(1.0, 1.4), 1.0, 1e-12);
+}
+
+TEST(EjectorPhysics, MachFromAreaRatioSupersonicInvertsAreaOverAstar) {
+  for (double area_ratio : {1.5, 2.0, 3.271, 8.0}) {
+    double gamma = 1.3;
+    double mach = ejector_mach_from_area_ratio_supersonic(area_ratio, gamma);
+    EXPECT_GT(mach, 1.0);
+    EXPECT_NEAR(ejector_area_over_astar(mach, gamma), area_ratio, 1e-8);
+  }
+}


### PR DESCRIPTION
## Summary
- Ports `python/combaero/network/_ejector_huang1999.py`'s closed-form physics (Huang 1999 entrainment ratio, Kracik & Dvorak 2016 critical back pressure closure) to `include/ejector.h` / `src/ejector.cpp`, with analytic `(value, d/dp_g, d/dt_g, d/dp_e, d/dt_e)` Jacobians -- the C++/pybind `(f, J)` rule this element was still owing.
- Key finding that simplifies the scope: the one internal root-find (the primary nozzle-exit Mach bisection) depends only on `area_ratio_nozzle` and `gamma`, neither a Newton-solved unknown for `EjectorElement`, so it has a provably exact zero derivative w.r.t. the 4 thermodynamic inputs. The rest of the chain is then fully closed-form, differentiated via a small internal forward-mode dual-number helper (textbook chain/product/quotient rules -- not finite differences, not an AD library).
- `scripts/derive_ejector_jacobian.py` (offline sympy script, follows `derive_mynard_jacobian.py`'s precedent) independently derives and numerically cross-checks the same chain against existing central-difference reference data before the C++ was written.
- `tests/test_ejector_physics.cpp` and `tests/test_ejector_jacobians.cpp` validate the port's values and Jacobians against all 31 rows of the existing `validation/ejector/data/huang1999_reference_data.h` golden data, reused via a small `CMakeLists.txt` include-path addition rather than duplicated.
- **Scope**: C++ physics + Jacobians + tests only, per the staged roadmap -- pybind exposure and `EjectorElement` rewiring land in a follow-up PR. No Python/CHANGELOG changes (no new public API surface yet).

## Test plan
- [x] `ctest` -- full C++ suite passes (19/19; one `/tmp`-sandbox-only gtest capture flake confirmed unrelated by re-running outside the sandbox)
- [x] `tests/test_ejector_physics.cpp` -- value parity vs. all 31 Huang rows at 1e-9 relative
- [x] `tests/test_ejector_jacobians.cpp` -- Jacobian accuracy vs. all 31 rows' central-difference targets at 1e-5 relative, plus a standalone CD spot-check for `choked_mass_flow`
- [x] `./scripts/check-source-style.sh` clean
- [x] `uv run pytest python/tests/` -- 1786 passed, no regressions (no Python files touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)