### PR TITLE
feat(network): wire EjectorElement onto the C++ (f,J) path via pybind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   entrained-flow choking plane. `recovery_efficiency` (default 1.0, no
   artificial loss) is intentionally not fitted to the validation dataset,
   per this project's calibration policy of anchoring on analytical models.
-  Jacobian is FD fallback except for the linear mass-conservation row
-  (analytic Jacobians are planned for the C++ port). The underlying
+  Residuals and their full analytic Jacobian are evaluated through a C++
+  `(f, J)` path (`include/ejector.h` / `src/ejector.cpp`, exposed via
+  pybind), per CLAUDE.md's Solver `(f, J)` rule. The underlying
   closed-form physics (`entrainment_ratio`, `critical_back_pressure`,
   `choked_mass_flow`, `EjectorGeometry`) now lives in
   `combaero.network._ejector_huang1999`, following the same
@@ -38,6 +39,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   it unchanged for existing validation scripts.
 
 ### Changed
+- **`EjectorElement` now evaluates its residuals and a FULL analytic
+  Jacobian (all four rows) through the C++ `(f, J)` path** rather than the
+  pure-Python reference physics plus a finite-difference Jacobian fallback.
+  The ejector closed forms and their analytic derivatives (added to
+  `include/ejector.h` / `src/ejector.cpp`) are exposed via pybind
+  (`combaero._solver_tools.ejector_*_and_jacobian`). The element's Jacobian
+  is exact w.r.t. the four Newton-solved thermodynamic inputs (primary and
+  secondary stagnation pressure and temperature); `gamma` and `r_gas` are
+  frozen coefficients (recomputed each residual call, so the converged root
+  is exact -- only the weak implicit `d(gamma)/d(Tt)` term is dropped from
+  the step). `combaero.network._ejector_huang1999` is now the validation
+  reference only.
 - **`MultiPortChamberElement` subclasses can now override
   `row_scale_kinds()`** to declare their own per-row scale-kind pattern
   ("p" or "mdot") for `solver.py`'s row-scaling vector, instead of the

--- a/python/combaero/_core.cpp
+++ b/python/combaero/_core.cpp
@@ -12,6 +12,7 @@
 #include "compressible.h"
 #include "cooling_correlations.h"
 #include "correlation_status.h"
+#include "ejector.h"
 #include "equilibrium.h"
 #include "friction.h"
 #include "geometry.h"
@@ -349,6 +350,106 @@ PYBIND11_MODULE(_core, m) {
         py::arg("Y_in"), py::arg("area"), py::arg("delta_geom"),
         "Border-Carnot turning loss: Pt_in - Pt_out - L*0.5*rho*u^2 = 0 with "
         "L = 4*(1 - cos((3/4)*delta_geom))^2 (Hager sharp-edge correction).");
+
+  // Ejector (critical-mode supersonic ejector on the MultiPortChamberElement
+  // topology). Physics + analytic Jacobians in include/ejector.h; Jacobians
+  // are w.r.t. the 4 thermodynamic inputs (p_g, t_g, p_e, t_e) only -- gamma,
+  // r_gas, geometry and recovery_efficiency are frozen coefficients here.
+  // Area ratios are passed as plain doubles (a lambda builds the internal
+  // EjectorGeometry), keeping the Python call flat like the other solver
+  // bindings.
+  py::class_<solver::EjectorEntrainmentResult>(
+      m, "EjectorEntrainmentResult",
+      "Value outputs of ejector_entrainment_ratio (Huang 1999 Eqs. 1-8)")
+      .def_readonly("omega", &solver::EjectorEntrainmentResult::omega)
+      .def_readonly("mach_nozzle_exit",
+                    &solver::EjectorEntrainmentResult::mach_nozzle_exit)
+      .def_readonly("mach_hypothetical_throat",
+                    &solver::EjectorEntrainmentResult::mach_hypothetical_throat)
+      .def_readonly("area_ratio_primary_core",
+                    &solver::EjectorEntrainmentResult::area_ratio_primary_core)
+      .def_readonly("area_ratio_entrained",
+                    &solver::EjectorEntrainmentResult::area_ratio_entrained)
+      .def_readonly("p_mixing_pa",
+                    &solver::EjectorEntrainmentResult::p_mixing_pa);
+
+  py::class_<solver::EjectorEntrainmentJacobian>(
+      m, "EjectorEntrainmentJacobian",
+      "Entrainment ratio value plus d(omega)/d(p_g, t_g, p_e, t_e)")
+      .def_readonly("value", &solver::EjectorEntrainmentJacobian::value)
+      .def_readonly("domega_dp_g",
+                    &solver::EjectorEntrainmentJacobian::domega_dp_g)
+      .def_readonly("domega_dt_g",
+                    &solver::EjectorEntrainmentJacobian::domega_dt_g)
+      .def_readonly("domega_dp_e",
+                    &solver::EjectorEntrainmentJacobian::domega_dp_e)
+      .def_readonly("domega_dt_e",
+                    &solver::EjectorEntrainmentJacobian::domega_dt_e);
+
+  py::class_<solver::EjectorCriticalPressureResult>(
+      m, "EjectorCriticalPressureResult",
+      "Value outputs of ejector_critical_back_pressure (Kracik & Dvorak "
+      "2016 Eqs. 7-13)")
+      .def_readonly("p_c_pa", &solver::EjectorCriticalPressureResult::p_c_pa)
+      .def_readonly(
+          "p_mixed_stagnation_pa",
+          &solver::EjectorCriticalPressureResult::p_mixed_stagnation_pa)
+      .def_readonly(
+          "temp_mixed_stagnation_k",
+          &solver::EjectorCriticalPressureResult::temp_mixed_stagnation_k)
+      .def_readonly("lambda_mixed",
+                    &solver::EjectorCriticalPressureResult::lambda_mixed)
+      .def_readonly("mach_mixed",
+                    &solver::EjectorCriticalPressureResult::mach_mixed);
+
+  py::class_<solver::EjectorCriticalPressureJacobian>(
+      m, "EjectorCriticalPressureJacobian",
+      "Critical back pressure value plus d(P_c*)/d(p_g, t_g, p_e, t_e)")
+      .def_readonly("value", &solver::EjectorCriticalPressureJacobian::value)
+      .def_readonly("dpc_dp_g",
+                    &solver::EjectorCriticalPressureJacobian::dpc_dp_g)
+      .def_readonly("dpc_dt_g",
+                    &solver::EjectorCriticalPressureJacobian::dpc_dt_g)
+      .def_readonly("dpc_dp_e",
+                    &solver::EjectorCriticalPressureJacobian::dpc_dp_e)
+      .def_readonly("dpc_dt_e",
+                    &solver::EjectorCriticalPressureJacobian::dpc_dt_e);
+
+  m.def("ejector_choked_mass_flow_and_jacobian",
+        &solver::ejector_choked_mass_flow_and_jacobian, py::arg("p0"),
+        py::arg("t0"), py::arg("area_throat"), py::arg("gamma"),
+        py::arg("r_gas"), py::arg("eta"),
+        "Choked (sonic-throat) mass flow (Huang 1999 Eqs. 1, 7).\n\n"
+        "Returns: (mdot, d_mdot_dp0, d_mdot_dt0)");
+
+  m.def(
+      "ejector_entrainment_ratio_and_jacobian",
+      [](double p_g, double t_g, double p_e, double t_e,
+         double area_ratio_nozzle, double area_ratio_mix, double gamma) {
+        return solver::ejector_entrainment_ratio_and_jacobian(
+            p_g, t_g, p_e, t_e,
+            solver::EjectorGeometry{area_ratio_nozzle, area_ratio_mix}, gamma);
+      },
+      py::arg("p_g"), py::arg("t_g"), py::arg("p_e"), py::arg("t_e"),
+      py::arg("area_ratio_nozzle"), py::arg("area_ratio_mix"), py::arg("gamma"),
+      "Critical-mode entrainment ratio omega with analytic Jacobian.\n\n"
+      "Returns: EjectorEntrainmentJacobian (value + domega_d{p_g,t_g,p_e,t_e})");
+
+  m.def(
+      "ejector_critical_back_pressure_and_jacobian",
+      [](double p_g, double t_g, double p_e, double t_e,
+         double area_ratio_nozzle, double area_ratio_mix, double gamma,
+         double r_gas, double recovery_efficiency) {
+        return solver::ejector_critical_back_pressure_and_jacobian(
+            p_g, t_g, p_e, t_e,
+            solver::EjectorGeometry{area_ratio_nozzle, area_ratio_mix}, gamma,
+            r_gas, recovery_efficiency);
+      },
+      py::arg("p_g"), py::arg("t_g"), py::arg("p_e"), py::arg("t_e"),
+      py::arg("area_ratio_nozzle"), py::arg("area_ratio_mix"), py::arg("gamma"),
+      py::arg("r_gas"), py::arg("recovery_efficiency"),
+      "Critical back pressure P_c* with analytic Jacobian.\n\n"
+      "Returns: EjectorCriticalPressureJacobian (value + dpc_d{p_g,t_g,p_e,t_e})");
 
   // Area change elements
   py::class_<combaero::AreaChangeResult>(

--- a/python/combaero/_solver_tools.py
+++ b/python/combaero/_solver_tools.py
@@ -28,6 +28,9 @@ density_and_jacobians = _core.density_and_jacobians
 dimple_friction_multiplier_and_jacobian = _core.dimple_friction_multiplier_and_jacobian
 dimple_nusselt_enhancement_and_jacobian = _core.dimple_nusselt_enhancement_and_jacobian
 effusion_effectiveness_and_jacobian = _core.effusion_effectiveness_and_jacobian
+ejector_choked_mass_flow_and_jacobian = _core.ejector_choked_mass_flow_and_jacobian
+ejector_critical_back_pressure_and_jacobian = _core.ejector_critical_back_pressure_and_jacobian
+ejector_entrainment_ratio_and_jacobian = _core.ejector_entrainment_ratio_and_jacobian
 enthalpy_and_jacobian = _core.enthalpy_and_jacobian
 film_cooling_effectiveness_and_jacobian = _core.film_cooling_effectiveness_and_jacobian
 friction_and_jacobian = _core.friction_and_jacobian
@@ -76,6 +79,9 @@ __all__ = [
     "dimple_friction_multiplier_and_jacobian",
     "dimple_nusselt_enhancement_and_jacobian",
     "effusion_effectiveness_and_jacobian",
+    "ejector_choked_mass_flow_and_jacobian",
+    "ejector_critical_back_pressure_and_jacobian",
+    "ejector_entrainment_ratio_and_jacobian",
     "enthalpy_and_jacobian",
     "film_cooling_effectiveness_and_jacobian",
     "friction_and_jacobian",

--- a/python/combaero/network/ejector_element.py
+++ b/python/combaero/network/ejector_element.py
@@ -40,11 +40,22 @@ post-solve by ``verify_solution_consistent`` (Pt_outlet must not exceed it --
 violation means the design point is subcritical, which this element does not
 model).
 
-Jacobian: FD fallback (``jac = {}`` for rows 0, 1, 3; row 2's mass
-conservation is linear so it gets an analytic entry). This mirrors
-``MPCEv2Element``'s own documented prototype pattern -- analytic
-(sympy-derived) Jacobians are planned for the C++ port, the next phase of
-this work, not this element.
+Jacobian: FULL analytic, all 4 rows, via the C++ (f, J) path
+(``combaero.network._ejector_huang1999`` is now only the validation
+reference; the hot path calls ``_solver_tools.ejector_*_and_jacobian``,
+i.e. ``include/ejector.h``/``src/ejector.cpp``). The C++ Jacobians are
+exact w.r.t. the four thermodynamic inputs (primary/secondary stagnation
+pressure and temperature) holding ``gamma`` and ``r_gas`` FROZEN. Here
+``gamma = choke_plane_gamma(secondary.Tt, ...)`` is a weak function of a
+Newton unknown and ``r_gas`` depends only on composition (not a solved
+unknown), so the element Jacobian is exact in the explicit (Pt, Tt)
+dependence and drops only the tiny implicit ``d gamma / d Tt`` term -- a
+standard frozen-property Jacobian. ``gamma`` is recomputed fresh every
+residual call, so the converged root is still exact; only the Newton step
+uses a slightly approximate slope. This matches the reference data's own
+convention (``generate_reference.py`` treats gamma as a separate Jacobian
+input, so its d/dt_e central-difference targets also hold gamma fixed).
+``choke_plane_gamma`` therefore stays in Python.
 """
 
 from __future__ import annotations
@@ -52,13 +63,8 @@ from __future__ import annotations
 from typing import Any
 
 import combaero as cb
-from combaero.network._ejector_huang1999 import (
-    ETA_P,
-    EjectorGeometry,
-    choked_mass_flow,
-    critical_back_pressure,
-    entrainment_ratio,
-)
+from combaero import _solver_tools
+from combaero.network._ejector_huang1999 import ETA_P, EjectorGeometry
 from combaero.network.components import MultiPortChamberElement, NetworkMixtureState
 
 
@@ -182,26 +188,37 @@ class EjectorElement(MultiPortChamberElement):
     ) -> tuple[list[float], dict[int, dict[str, float]]]:
         primary, secondary, _outlet = states
 
+        # gamma/r_gas: frozen coefficients (see module docstring). gamma is a
+        # weak function of secondary.Tt via the Python fixed point; r_gas is a
+        # pure function of composition (not a Newton unknown). Recomputed each
+        # call, so the converged root is exact; the C++ Jacobians below hold
+        # both fixed, dropping only the tiny implicit d(gamma)/d(Tt) term.
         gamma = choke_plane_gamma(secondary.Tt, secondary.X)
         r_gas = float(cb.specific_gas_constant(secondary.X))
-        geom = self.geometry
+        arn = self.area_ratio_nozzle
+        arm = self.area_ratio_mix
 
-        mp_choked = choked_mass_flow(
-            primary.Pt, primary.Tt, self.throat_area, gamma, r_gas, eta=ETA_P
+        mp_choked, dmp_choked_dp_g, dmp_choked_dt_g = (
+            _solver_tools.ejector_choked_mass_flow_and_jacobian(
+                primary.Pt, primary.Tt, self.throat_area, gamma, r_gas, ETA_P
+            )
         )
-        omega = entrainment_ratio(
-            primary.Pt, primary.Tt, secondary.Pt, secondary.Tt, geom, gamma
-        ).omega
-        pc_star = critical_back_pressure(
+        entr = _solver_tools.ejector_entrainment_ratio_and_jacobian(
+            primary.Pt, primary.Tt, secondary.Pt, secondary.Tt, arn, arm, gamma
+        )
+        omega = entr.value.omega
+        pc = _solver_tools.ejector_critical_back_pressure_and_jacobian(
             primary.Pt,
             primary.Tt,
             secondary.Pt,
             secondary.Tt,
-            geom,
+            arn,
+            arm,
             gamma,
             r_gas,
             self.recovery_efficiency,
-        ).p_c_pa
+        )
+        pc_star = pc.value.p_c_pa
 
         # port_mdots are junction-sign convention (positive = out of
         # junction); primary/secondary are inlets (sign -1), so their
@@ -215,15 +232,51 @@ class EjectorElement(MultiPortChamberElement):
         r2 = mdot_out - mp - ms  # == sum(port_mdots); mass conservation
         r3 = P_jct - pc_star
 
-        # Analytic Jacobian only for the linear mass row; rows 0/1/3 are FD
-        # fallback -- documented prototype pattern (see module docstring),
-        # analytic Jacobians land in the C++ port.
+        # Full analytic Jacobian. Column-name conventions (see solver.py's
+        # element jac-relay loop): port mass flows are direct unknowns keyed
+        # "{outer_id}.m_dot"; a physical port flow d(mp) = -_port_signs[i]
+        # because port_mdots[i] = _port_signs[i] * (that unknown). Port
+        # stagnation pressures "{node}.Pt" are direct unknowns; port
+        # stagnation temperatures are emitted as "{node}.T" and chained
+        # through the solver's temperature relay (same convention the
+        # compressible orifice uses: pass Tt, key the column .T). "{id}.P_jct"
+        # is this element's own direct unknown.
+        m_p = f"{self._port_element_ids[0]}.m_dot"
+        m_s = f"{self._port_element_ids[1]}.m_dot"
+        pn_pt = f"{self.primary_node}.Pt"
+        pn_t = f"{self.primary_node}.T"
+        sn_pt = f"{self.secondary_node}.Pt"
+        sn_t = f"{self.secondary_node}.T"
+        # d(mp)/d(m_p unknown) and d(ms)/d(m_s unknown).
+        d_mp = -self._port_signs[0]
+        d_ms = -self._port_signs[1]
+
+        row0 = {
+            m_p: d_mp,
+            pn_pt: -dmp_choked_dp_g,
+            pn_t: -dmp_choked_dt_g,
+        }
+        row1 = {
+            m_s: d_ms,
+            m_p: -omega * d_mp,
+            pn_pt: -mp * entr.domega_dp_g,
+            pn_t: -mp * entr.domega_dt_g,
+            sn_pt: -mp * entr.domega_dp_e,
+            sn_t: -mp * entr.domega_dt_e,
+        }
         mass_row: dict[str, float] = {}
         for i in range(self.N):
             mdot_var = f"{self._port_element_ids[i]}.m_dot"
             mass_row[mdot_var] = mass_row.get(mdot_var, 0.0) + self._port_signs[i]
+        row3 = {
+            f"{self.id}.P_jct": 1.0,
+            pn_pt: -pc.dpc_dp_g,
+            pn_t: -pc.dpc_dt_g,
+            sn_pt: -pc.dpc_dp_e,
+            sn_t: -pc.dpc_dt_e,
+        }
 
-        return [r0, r1, r2, r3], {2: mass_row}
+        return [r0, r1, r2, r3], {0: row0, 1: row1, 2: mass_row, 3: row3}
 
     def verify_solution_consistent(
         self,
@@ -257,12 +310,19 @@ class EjectorElement(MultiPortChamberElement):
 
         gamma = choke_plane_gamma(secondary.Tt, secondary.X)
         r_gas = float(cb.specific_gas_constant(secondary.X))
-        geom = self.geometry
-        entr = entrainment_ratio(primary.Pt, primary.Tt, secondary.Pt, secondary.Tt, geom, gamma)
+        entr = _solver_tools.ejector_entrainment_ratio_and_jacobian(
+            primary.Pt,
+            primary.Tt,
+            secondary.Pt,
+            secondary.Tt,
+            self.area_ratio_nozzle,
+            self.area_ratio_mix,
+            gamma,
+        )
 
         diag["gamma"] = gamma
         diag["r_gas"] = r_gas
-        diag["omega"] = entr.omega
+        diag["omega"] = entr.value.omega
         diag["p_c_star_pa"] = float(P_jct)
         diag["outlet_pt_pa"] = float(outlet.Pt)
         diag["critical_mode"] = 1.0 if float(outlet.Pt) <= float(P_jct) else 0.0

--- a/python/tests/test_ejector_bindings.py
+++ b/python/tests/test_ejector_bindings.py
@@ -1,0 +1,107 @@
+"""Central-difference accuracy checks for the pybind-exposed ejector C++
+(f, J) functions (combaero._solver_tools.ejector_*_and_jacobian, i.e.
+include/ejector.h / src/ejector.cpp).
+
+Mirrors test_jacobian_migration.py: call each binding once for the analytic
+result, then perturb each of the four thermodynamic inputs (p_g, t_g, p_e,
+t_e -- plus p0/t0 for the choked-mass-flow function) and confirm the
+analytic derivative fields match central finite differences. The C++ ctests
+(tests/test_ejector_jacobians.cpp) already validate the same Jacobians
+against the baked reference data; this is the Python-binding-surface guard,
+proving the pybind wiring and struct field names round-trip correctly.
+"""
+
+import pytest
+
+import combaero as cb
+
+# A representative critical-mode operating point (Huang 1999 case T3-EH),
+# air-like gamma/r_gas stand-ins are unnecessary -- these are the reference
+# R141b numbers, and the physics is input-parameterized on gamma/r_gas.
+P_G = 604000.0
+T_G = 368.15
+P_E = 40000.0
+T_E = 281.15
+ARN = 3.271
+ARM = 10.87
+GAMMA = 1.1121
+R_GAS = 71.094
+RECOVERY = 1.0
+THROAT_AREA = 3.14e-5
+ETA = 0.95
+
+REL = 1e-4
+
+
+def _cd(f, x0, i, eps_rel=1e-6):
+    """Central difference of scalar f(vec) w.r.t. component i of x0."""
+    eps = eps_rel * abs(x0[i]) if x0[i] != 0.0 else eps_rel
+    xp = list(x0)
+    xm = list(x0)
+    xp[i] += eps
+    xm[i] -= eps
+    return (f(xp) - f(xm)) / (2.0 * eps)
+
+
+def test_choked_mass_flow_jacobian_accuracy():
+    st = cb._solver_tools
+    x0 = [P_G, T_G]  # (p0, t0)
+
+    def mdot(x):
+        return st.ejector_choked_mass_flow_and_jacobian(x[0], x[1], THROAT_AREA, GAMMA, R_GAS, ETA)[
+            0
+        ]
+
+    val, d_dp0, d_dt0 = st.ejector_choked_mass_flow_and_jacobian(
+        P_G, T_G, THROAT_AREA, GAMMA, R_GAS, ETA
+    )
+    assert val > 0.0
+    assert d_dp0 == pytest.approx(_cd(mdot, x0, 0), rel=REL)
+    assert d_dt0 == pytest.approx(_cd(mdot, x0, 1), rel=REL)
+
+
+def test_entrainment_ratio_jacobian_accuracy():
+    st = cb._solver_tools
+    x0 = [P_G, T_G, P_E, T_E]
+
+    def omega(x):
+        return st.ejector_entrainment_ratio_and_jacobian(
+            x[0], x[1], x[2], x[3], ARN, ARM, GAMMA
+        ).value.omega
+
+    res = st.ejector_entrainment_ratio_and_jacobian(P_G, T_G, P_E, T_E, ARN, ARM, GAMMA)
+    assert res.domega_dp_g == pytest.approx(_cd(omega, x0, 0), rel=REL)
+    assert res.domega_dt_g == pytest.approx(_cd(omega, x0, 1), rel=REL)
+    assert res.domega_dp_e == pytest.approx(_cd(omega, x0, 2), rel=REL)
+    assert res.domega_dt_e == pytest.approx(_cd(omega, x0, 3), rel=REL)
+
+
+def test_critical_back_pressure_jacobian_accuracy():
+    st = cb._solver_tools
+    x0 = [P_G, T_G, P_E, T_E]
+
+    def pc(x):
+        return st.ejector_critical_back_pressure_and_jacobian(
+            x[0], x[1], x[2], x[3], ARN, ARM, GAMMA, R_GAS, RECOVERY
+        ).value.p_c_pa
+
+    res = st.ejector_critical_back_pressure_and_jacobian(
+        P_G, T_G, P_E, T_E, ARN, ARM, GAMMA, R_GAS, RECOVERY
+    )
+    assert res.dpc_dp_g == pytest.approx(_cd(pc, x0, 0), rel=REL)
+    assert res.dpc_dt_g == pytest.approx(_cd(pc, x0, 1), rel=REL)
+    assert res.dpc_dp_e == pytest.approx(_cd(pc, x0, 2), rel=REL)
+    assert res.dpc_dt_e == pytest.approx(_cd(pc, x0, 3), rel=REL)
+
+
+def test_recovery_efficiency_scales_p_c_linearly():
+    st = cb._solver_tools
+    base = st.ejector_critical_back_pressure_and_jacobian(
+        P_G, T_G, P_E, T_E, ARN, ARM, GAMMA, R_GAS, 1.0
+    ).value
+    half = st.ejector_critical_back_pressure_and_jacobian(
+        P_G, T_G, P_E, T_E, ARN, ARM, GAMMA, R_GAS, 0.5
+    ).value
+    # P_c* = recovery_efficiency * p03; p03 itself is recovery-independent.
+    assert half.p_c_pa == pytest.approx(0.5 * base.p_c_pa, rel=1e-12)
+    assert half.p_mixed_stagnation_pa == pytest.approx(base.p_mixed_stagnation_pa, rel=1e-12)

--- a/python/tests/test_ejector_element.py
+++ b/python/tests/test_ejector_element.py
@@ -135,7 +135,9 @@ def test_residuals_cross_check_against_reference_physics():
 
     res, jac = e.residuals([primary, secondary, outlet], P_jct_guess, port_mdots)
     assert len(res) == 4
-    assert set(jac.keys()) == {2}  # only the mass row is analytic
+    # All four rows are now analytic (full C++ (f,J) path); see
+    # test_residuals_jacobian_matches_finite_difference for the accuracy check.
+    assert set(jac.keys()) == {0, 1, 2, 3}
 
     gamma = choke_plane_gamma(secondary.Tt, secondary.X)
     r_gas = cb.specific_gas_constant(secondary.X)
@@ -183,6 +185,93 @@ def test_residuals_all_zero_at_the_converged_point():
     res, _jac = e.residuals([primary, secondary, outlet], pc, port_mdots)
     for r in res:
         assert r == pytest.approx(0.0, abs=1e-6)
+
+
+def test_residuals_jacobian_matches_finite_difference(monkeypatch):
+    """Central-difference-check every analytic jac-dict entry against
+    perturbed residuals() calls, at a non-converged operating point. This
+    directly proves the column-name / sign / relay mapping in residuals()
+    is correct (the error-prone part of the C++ (f,J) rewire).
+
+    gamma is monkeypatched to a constant so the FD holds it fixed, matching
+    the element's frozen-gamma Jacobian (see module docstring): only the
+    explicit (Pt, Tt) dependence is claimed analytic, and the dropped weak
+    d(gamma)/d(Tt) term would otherwise show up as spurious FD error on the
+    secondary-temperature column.
+    """
+    import dataclasses
+
+    import combaero.network.ejector_element as ejmod
+
+    e = _element()
+    e._port_element_ids = ["chan_p", "chan_s", "chan_o"]
+    primary, secondary, outlet = _states()
+
+    frozen_gamma = choke_plane_gamma(secondary.Tt, secondary.X)
+    monkeypatch.setattr(ejmod, "choke_plane_gamma", lambda t, x, **kw: frozen_gamma)
+
+    # A deliberately non-converged base point (residuals nonzero here, so the
+    # Jacobian is exercised away from R=0).
+    P_jct0 = 90000.0
+    port_mdots0 = [-0.070, -0.030, 0.100]
+    states0 = [primary, secondary, outlet]
+
+    _res0, jac = e.residuals(states0, P_jct0, port_mdots0)
+
+    def res_row(row_idx, *, P_jct=P_jct0, port_mdots=None, states=None):
+        pm = list(port_mdots0) if port_mdots is None else port_mdots
+        st = states0 if states is None else states
+        return e.residuals(st, P_jct, pm)[0][row_idx]
+
+    # Perturbation drivers keyed by jac column name. Each returns res_row as a
+    # function of the scalar unknown behind that column.
+    def perturb_mdot(port_i, sign):
+        # column "chan_x.m_dot" = raw unknown u; port_mdots[port_i] = sign*u.
+        def f(row_idx, u):
+            pm = list(port_mdots0)
+            pm[port_i] = sign * u
+            return res_row(row_idx, port_mdots=pm)
+
+        # base value of the raw unknown u = port_mdots[port_i]/sign
+        return f, port_mdots0[port_i] / sign
+
+    def perturb_state(idx, field):
+        def f(row_idx, v):
+            st = list(states0)
+            st[idx] = dataclasses.replace(states0[idx], **{field: v})
+            return res_row(row_idx, states=st)
+
+        return f, getattr(states0[idx], field)
+
+    def perturb_pjct(row_idx, v):
+        return res_row(row_idx, P_jct=v)
+
+    drivers = {
+        "chan_p.m_dot": perturb_mdot(0, e._port_signs[0]),
+        "chan_s.m_dot": perturb_mdot(1, e._port_signs[1]),
+        "chan_o.m_dot": perturb_mdot(2, e._port_signs[2]),
+        "p.Pt": perturb_state(0, "Pt"),
+        "p.T": perturb_state(0, "Tt"),
+        "s.Pt": perturb_state(1, "Pt"),
+        "s.T": perturb_state(1, "Tt"),
+        "ej1.P_jct": (perturb_pjct, P_jct0),
+    }
+
+    def central_diff(fn, row_idx, x0):
+        eps = 1e-6 * abs(x0) if x0 != 0.0 else 1e-6
+        return (fn(row_idx, x0 + eps) - fn(row_idx, x0 - eps)) / (2.0 * eps)
+
+    checked = 0
+    for row_idx, row in jac.items():
+        for col, analytic in row.items():
+            fn, x0 = drivers[col]
+            fd = central_diff(fn, row_idx, x0)
+            assert analytic == pytest.approx(fd, rel=1e-5, abs=1e-9), (
+                f"row {row_idx} col {col}: analytic {analytic} vs FD {fd}"
+            )
+            checked += 1
+    # Guard against a silently-empty jac dict masking a regression.
+    assert checked >= 12
 
 
 def test_diagnostics_reports_omega_and_critical_mode():
@@ -233,10 +322,10 @@ def test_choke_plane_gamma_matches_known_air_value():
 def _expected_operating_point() -> dict[str, float]:
     """mp / ms / mdot_out / P_c* for the network's boundary conditions, from
     the same reference physics the element itself uses -- a good Newton
-    starting point for a system with no analytic Jacobian yet (see the
-    FD-fallback note in ejector_element.py's module docstring). Port static
-    P/Pt are seeded at the boundary Pt (negligible drop expected over the
-    short, large-diameter test channels).
+    starting point (the element now has a full analytic Jacobian, but a
+    realistic seed still helps this stiff double-choked system converge fast).
+    Port static P/Pt are seeded at the boundary Pt (negligible drop expected
+    over the short, large-diameter test channels).
     """
     from combaero.network._ejector_huang1999 import (
         ETA_P,


### PR DESCRIPTION
## Summary
Phase 3 of the ejector work: expose the ejector C++ physics + analytic Jacobians (added in PR #253, `include/ejector.h` / `src/ejector.cpp`) through pybind and rewire `EjectorElement` to use them, completing CLAUDE.md's Solver `(f, J)` rule for this element.

- **`python/combaero/_core.cpp`** — bind the 4 ejector result/Jacobian structs + 3 `ejector_*_and_jacobian` functions (flat on the module; area ratios passed as plain doubles via a lambda that builds the internal `EjectorGeometry`, keeping the Python call flat like the other solver bindings).
- **`python/combaero/_solver_tools.py`** — re-export the 3 new functions.
- **`python/combaero/network/ejector_element.py`** — `residuals()` now sources physics from the C++ `(f,J)` path and returns a **full analytic Jacobian for all 4 rows** (was FD-fallback on 3 of 4); `diagnostics()` routed through the same binding. `combaero.network._ejector_huang1999` is now the validation reference only (the element keeps just `ETA_P` and the `EjectorGeometry` dataclass for its `.geometry` property).

## Design decision: frozen-gamma Jacobian
The element Jacobian is exact w.r.t. the 4 Newton-solved thermodynamic inputs (primary/secondary stagnation pressure and temperature). `gamma` and `r_gas` are frozen coefficients — recomputed each residual call (so the converged root is exact), with only the weak implicit `d(gamma)/d(Tt)` term dropped from the Newton step. This matches the reference data's own convention (which treats `gamma` as a separate Jacobian input), so `choke_plane_gamma` stays in Python.

## Test plan
- [x] New `test_ejector_bindings.py` — central-difference accuracy on the binding surface (`rel=1e-4`).
- [x] New `test_residuals_jacobian_matches_finite_difference` in `test_ejector_element.py` — proves the jac-dict column-name/sign/relay mapping against perturbed `residuals()` (gamma frozen to match the element's frozen-gamma Jacobian).
- [x] `uv run pytest python/tests/` — **1791 passed**, no regressions (incl. `test_units_sync`, `test_network_*`, full-network ejector solve).
- [x] `ctest` — C++ suite unaffected (only the known sandbox `/tmp` gtest-capture flake on `test_thermo_transport`, confirmed passing outside the sandbox).
- [x] Python + C++ style checks clean.

No `units_data.h` entry needed (bindings reached via `_solver_tools`, which `test_units_sync.py` ignores).

🤖 Generated with [Claude Code](https://claude.com/claude-code)