### PR TITLE
feat(gui): wire EjectorElement end-to-end into the GUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   topology (primary/secondary inlets, one outlet); `P_jct` is repurposed
   as a diagnostic critical back pressure P_c*, not the outlet's actual
   pressure, since critical-mode entrainment ratio is independent of back
-  pressure by definition. gamma/R evaluated live from combaero's own
+  pressure by definition. Supplies its own port-face areas from geometry
+  (primary = nozzle exit, secondary = mixing - nozzle exit, outlet =
+  mixing), so it resolves even when fed by a bare boundary/connection with
+  no channel to infer an area from (unlike a generic tee, which must infer
+  or be given `port_areas`). gamma/R evaluated live from combaero's own
   real-fluid EOS (combustion/air-relevant species only) at the
   entrained-flow choking plane. `recovery_efficiency` (default 1.0, no
   artificial loss) is intentionally not fitted to the validation dataset,
@@ -37,6 +41,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   since `python/combaero/` must never import from the dev-only
   `validation/` tree; `validation/ejector/models/huang1999.py` re-exports
   it unchanged for existing validation scripts.
+- **GUI: `EjectorElement` is wired end-to-end as a draggable "Ejector"
+  element** (Wind icon). Sidebar palette entry, a 3-port node card (primary
+  + secondary inlets, one outlet), an inspector form for the three areas
+  (throat / nozzle-exit / mixing) and `recovery_efficiency`, drop-time
+  defaults, and client-side geometry validation. The backend
+  `graph_builder` translates an `ejector` node into an `EjectorElement`,
+  reusing the tee's named-port resolution and per-port
+  `MomentumChamberNode` auto-insertion (generalized from `tee_ids` to a
+  shared `junction_ids`); solved diagnostics (entrainment ratio omega,
+  critical back pressure P_c*, gamma) surface through the generic
+  `ElementResult` path. `graph_builder` also warm-starts each ejector: it
+  traces each port to its feeding boundary, runs the ejector's own
+  closed-form physics for a consistent operating point, and seeds the port
+  MomentumChamberNode pressures and `P_jct` (only where the user provided
+  none) so the stiff double-choked solve converges from cold -- which it
+  does not otherwise (no solver init strategy cracks it without the seed).
 
 ### Changed
 - **`EjectorElement` now evaluates its residuals and a FULL analytic

--- a/docs/GUI_TECHNICAL.md
+++ b/docs/GUI_TECHNICAL.md
@@ -56,6 +56,18 @@ Elements are defined by edges in the graph but carry their own physical paramete
 - `roughness`: Surface roughness [m]
 - `surface`: Surface model (smooth, ribbed, dimpled, pin_fin, impingement).
 
+#### Ejector Element (`ejector`)
+Critical-mode supersonic ejector (3 ports: `primary` + `secondary` inlets,
+one `outlet`; handle ids `port-{primary,secondary,outlet}-{target,source}`).
+- `throat_area`: Primary nozzle throat area A_t [m^2].
+- `nozzle_exit_area`: Primary nozzle exit area A_p1 [m^2] (must exceed throat).
+- `mixing_area`: Constant-area mixing-section area A_3 [m^2] (must exceed nozzle exit).
+- `recovery_efficiency`: Multiplies the lossless mixed stagnation pressure to
+  give the critical back pressure P_c* (default 1.0 = no artificial loss).
+
+Diagnostics returned on solve include `omega` (entrainment ratio),
+`p_c_star_pa` (critical back pressure), and `gamma`.
+
 ## Solver Settings
 ```json
 {

--- a/gui/backend/graph_builder.py
+++ b/gui/backend/graph_builder.py
@@ -27,6 +27,7 @@ from combaero.network import (
     WallLayer,
     WallNode,
 )
+from combaero.network.ejector_element import EjectorElement
 from combaero.network.mpce_v2_element import ConstantKTeeElement, MPCEv2Element
 
 from .schemas import (
@@ -38,6 +39,7 @@ from .schemas import (
     ConstantHeadLossData,
     DimpledModelData,
     DiscreteLossData,
+    EjectorData,
     ImpingementModelData,
     LinearThetaFractionLossData,
     LinearThetaHeadLossData,
@@ -344,29 +346,32 @@ def _port_from_handle(handle: str | None) -> str | None:
     return None
 
 
-def _find_tee_port(
+def _find_junction_port(
     edges: list,
-    tee_id: str,
+    junction_id: str,
     port: str,
     nodes_map: dict,
     tee_port_node_map: dict | None = None,
     wall_edge_remap: dict | None = None,
+    all_ports: tuple[str, ...] = ("common", "straight", "branch"),
 ) -> str:
-    """Return the physical-node ID connected to a named tee port.
+    """Return the physical-node ID connected to a named junction port.
 
-    Checks both edge directions: tee as source (sourceHandle == port-X-source)
-    and tee as target (targetHandle == port-X-target).
+    Shared by the tee (ports common/straight/branch) and the ejector (ports
+    primary/secondary/outlet); ``all_ports`` only shapes the error message.
+    Checks both edge directions: junction as source (sourceHandle ==
+    port-X-source) and junction as target (targetHandle == port-X-target).
     Falls back to *tee_port_node_map* for auto-created junction nodes when an
-    element is connected directly to a tee port without an explicit plenum.
+    element is connected directly to a port without an explicit plenum.
     """
     src_handle = f"port-{port}-source"
     tgt_handle = f"port-{port}-target"
     for edge in edges:
         if edge.data and edge.data.get("type") == "thermal":
             continue
-        if edge.source == tee_id and edge.sourceHandle == src_handle:
+        if edge.source == junction_id and edge.sourceHandle == src_handle:
             nid = edge.target
-        elif edge.target == tee_id and edge.targetHandle == tgt_handle:
+        elif edge.target == junction_id and edge.targetHandle == tgt_handle:
             nid = edge.source
         else:
             continue
@@ -374,17 +379,135 @@ def _find_tee_port(
             if wall_edge_remap and edge.id in wall_edge_remap:
                 return wall_edge_remap[edge.id]
             return nid
-        if tee_port_node_map and (tee_id, port) in tee_port_node_map:
-            return tee_port_node_map[(tee_id, port)]
+        if tee_port_node_map and (junction_id, port) in tee_port_node_map:
+            return tee_port_node_map[(junction_id, port)]
         raise ValueError(
-            f"Tee '{tee_id}' port '{port}' connects to '{nid}', which is not a "
-            "physical node (plenum or boundary). All tee ports must connect directly "
-            "to plena or boundaries."
+            f"Junction '{junction_id}' port '{port}' connects to '{nid}', which is "
+            "not a physical node (plenum or boundary). All junction ports must "
+            "connect directly to plena or boundaries."
         )
     raise ValueError(
-        f"Tee '{tee_id}' port '{port}' is not connected. "
-        "All three tee ports (common, straight, branch) must be wired to a node."
+        f"Junction '{junction_id}' port '{port}' is not connected. All ports "
+        f"({', '.join(all_ports)}) must be wired to a node."
     )
+
+
+def _trace_boundary(
+    port_id: str, junction_id: str, edges: list, nodes_map: dict, max_hops: int = 8
+):
+    """BFS outward from a junction port (never through the junction itself) to
+    the first boundary node reached. Returns the boundary node object (a
+    PressureBoundary or MassFlowBoundary) or None. Used only to derive a
+    warm-start; a miss just means no seed for that port.
+    """
+    seen = {port_id}
+    frontier = [port_id]
+    for _ in range(max_hops):
+        nxt: list[str] = []
+        for nid in frontier:
+            for edge in edges:
+                if edge.data and edge.data.get("type") == "thermal":
+                    continue
+                if edge.source == nid and edge.target != junction_id:
+                    other = edge.target
+                elif edge.target == nid and edge.source != junction_id:
+                    other = edge.source
+                else:
+                    continue
+                if other in seen:
+                    continue
+                seen.add(other)
+                node = nodes_map.get(other)
+                if isinstance(node, (PressureBoundary, MassFlowBoundary)):
+                    return node
+                nxt.append(other)
+        frontier = nxt
+    return None
+
+
+def _seed_ejector_warmstart(
+    net: FlowNetwork,
+    ejector: EjectorElement,
+    port_ids: tuple[str, str, str],
+    edges: list,
+    nodes_map: dict,
+) -> None:
+    """Warm-start a GUI-built ejector so the (stiff, double-choked) solve
+    converges without the user hand-seeding interior nodes.
+
+    The port momentum-chambers' stagnation pressures start far from their
+    feeding-boundary values, which puts the cold Newton start outside the
+    ejector's narrow convergence basin (confirmed: no init_strategy cracks it
+    cold). Here we trace each port to its boundary, run the ejector's own
+    closed-form physics to get a consistent operating point, and seed the port
+    MCN P/Pt plus the element's P_jct (== P_c*). Only seeds values the user did
+    not already provide; best-effort (any failure leaves the seed unset).
+    """
+    import combaero as _cb
+    from combaero.network._ejector_huang1999 import (
+        ETA_P,
+        EjectorGeometry,
+        choked_mass_flow,
+        critical_back_pressure,
+    )
+    from combaero.network.ejector_element import choke_plane_gamma
+
+    primary_id, secondary_id, outlet_id = port_ids
+    pb = _trace_boundary(primary_id, ejector.id, edges, nodes_map)
+    sb = _trace_boundary(secondary_id, ejector.id, edges, nodes_map)
+    ob = _trace_boundary(outlet_id, ejector.id, edges, nodes_map)
+
+    # Nominal air properties for the SEED only (exact gamma/R not needed here).
+    X = _cb.species.dry_air()
+    t_g = float(getattr(pb, "Tt", 440.0))
+    t_e = float(getattr(sb, "Tt", 280.0))
+    try:
+        gamma = choke_plane_gamma(t_e, X)
+    except Exception:
+        gamma = 1.4
+    r_gas = float(_cb.specific_gas_constant(X))
+
+    # Primary stagnation: direct for a pressure boundary; inverse choked-flow
+    # for a mass boundary (mdot is linear in p0).
+    p_g = None
+    if isinstance(pb, PressureBoundary):
+        p_g = float(pb.Pt)
+    elif isinstance(pb, MassFlowBoundary):
+        unit = choked_mass_flow(1.0, t_g, ejector.throat_area, gamma, r_gas, eta=ETA_P)
+        if unit > 0.0:
+            p_g = float(pb.m_dot) / unit
+    p_e = float(sb.Pt) if isinstance(sb, PressureBoundary) else None
+    p_o = float(ob.Pt) if isinstance(ob, PressureBoundary) else None
+
+    def _seed_node(node_id: str, value: float | None) -> None:
+        if value is None or value <= 0.0:
+            return
+        node = net.nodes.get(node_id)
+        if node is None:
+            return
+        existing = dict(getattr(node, "initial_guess", {}) or {})
+        if any(k.endswith(".P") or k.endswith(".Pt") for k in existing):
+            return  # user already seeded this port
+        existing[f"{node_id}.P"] = float(value)
+        existing[f"{node_id}.Pt"] = float(value)
+        node.initial_guess = existing
+
+    _seed_node(primary_id, p_g)
+    _seed_node(secondary_id, p_e)
+    _seed_node(outlet_id, p_o)
+
+    if p_g and p_e:
+        try:
+            geom = EjectorGeometry(ejector.area_ratio_nozzle, ejector.area_ratio_mix)
+            pc = critical_back_pressure(
+                p_g, t_g, p_e, t_e, geom, gamma, r_gas, ejector.recovery_efficiency
+            ).p_c_pa
+            guess = dict(getattr(ejector, "initial_guess", {}) or {})
+            if not any(k.endswith(".P_jct") for k in guess):
+                guess[f"{ejector.id}.P_jct"] = float(pc)
+                ejector.initial_guess = guess
+        except Exception:
+            pass
 
 
 def build_network_from_schema(schema: NetworkGraphSchema) -> FlowNetwork:
@@ -476,21 +599,24 @@ def build_network_from_schema(schema: NetworkGraphSchema) -> FlowNetwork:
             element_nodes.append(node_schema)
 
     element_ids = {node.id for node in element_nodes}
-    tee_ids = {node.id for node in element_nodes if node.type == "mpce_tee"}
+    # Junction elements with named handle ports (common/straight/branch for
+    # the tee; primary/secondary/outlet for the ejector). Both get the same
+    # per-port MomentumChamberNode auto-insertion below.
+    junction_ids = {node.id for node in element_nodes if node.type in ("mpce_tee", "ejector")}
 
     # 1b. Create implicit junction nodes for element -> element visual links.
     # For direct element<->element connections we auto-insert a MomentumChamberNode.
     # For direct element<->tee-port connections we auto-insert a PlenumNode so that
     # users don't need to manually place a plenum on every tee arm.
     edge_junction_map: dict[tuple[str, str], str] = {}
-    tee_port_node_map: dict[tuple[str, str], str] = {}  # (tee_id, port) -> node_id
+    tee_port_node_map: dict[tuple[str, str], str] = {}  # (junction_id, port) -> node_id
     for edge in schema.edges:
         if edge.data and edge.data.get("type") == "thermal":
             continue
         src_elem = edge.source in element_ids
         tgt_elem = edge.target in element_ids
-        src_tee = edge.source in tee_ids
-        tgt_tee = edge.target in tee_ids
+        src_tee = edge.source in junction_ids
+        tgt_tee = edge.target in junction_ids
 
         if src_elem and tgt_elem and not src_tee and not tgt_tee:
             # Standard element-to-element: auto-insert MomentumChamberNode
@@ -502,8 +628,8 @@ def build_network_from_schema(schema: NetworkGraphSchema) -> FlowNetwork:
             edge_junction_map[(edge.source, edge.target)] = junction_id
 
         elif src_tee and tgt_elem:
-            # Tee port → element (e.g. tee.common-source → channel): auto-insert MomentumChamberNode
-            # so that Pt != P_static and velocity is correctly accounted for.
+            # Junction port → element (e.g. tee.common-source → channel): auto-insert
+            # MomentumChamberNode so that Pt != P_static and velocity is accounted for.
             port = _port_from_handle(edge.sourceHandle)
             if port and (edge.source, port) not in tee_port_node_map:
                 jid = f"__tee_jct__{edge.source}_{port}"
@@ -515,7 +641,7 @@ def build_network_from_schema(schema: NetworkGraphSchema) -> FlowNetwork:
                 edge_junction_map[(edge.source, edge.target)] = jid
 
         elif src_elem and tgt_tee:
-            # Element → tee port (e.g. channel → tee.straight-target): auto-insert MomentumChamberNode
+            # Element → junction port (e.g. channel → tee.straight-target): auto-insert MomentumChamberNode
             port = _port_from_handle(edge.targetHandle)
             if port and (edge.target, port) not in tee_port_node_map:
                 jid = f"__tee_jct__{edge.target}_{port}"
@@ -566,13 +692,13 @@ def build_network_from_schema(schema: NetworkGraphSchema) -> FlowNetwork:
                 psi_fallback=_md.psi,
             )
 
-            _common = _find_tee_port(
+            _common = _find_junction_port(
                 schema.edges, elem_id, "common", nodes_map, tee_port_node_map, _wall_edge_remap
             )
-            _straight = _find_tee_port(
+            _straight = _find_junction_port(
                 schema.edges, elem_id, "straight", nodes_map, tee_port_node_map, _wall_edge_remap
             )
-            _branch = _find_tee_port(
+            _branch = _find_junction_port(
                 schema.edges, elem_id, "branch", nodes_map, tee_port_node_map, _wall_edge_remap
             )
 
@@ -634,6 +760,61 @@ def build_network_from_schema(schema: NetworkGraphSchema) -> FlowNetwork:
             if not _mpce.initial_guess:
                 _mpce.initial_guess = _guess_from_prior_result(elem_data, elem_id)
             net.add_element(_mpce)
+            continue
+
+        # Ejector: 3-port MultiPortChamberElement with fixed roles (primary +
+        # secondary inlets, one outlet). Reuses the same named-port resolution
+        # and per-port MomentumChamberNode auto-insertion as the tee.
+        if elem_type == "ejector":
+            _ed = EjectorData(**elem_data)
+            _ports = ("primary", "secondary", "outlet")
+            _primary = _find_junction_port(
+                schema.edges,
+                elem_id,
+                "primary",
+                nodes_map,
+                tee_port_node_map,
+                _wall_edge_remap,
+                all_ports=_ports,
+            )
+            _secondary = _find_junction_port(
+                schema.edges,
+                elem_id,
+                "secondary",
+                nodes_map,
+                tee_port_node_map,
+                _wall_edge_remap,
+                all_ports=_ports,
+            )
+            _outlet = _find_junction_port(
+                schema.edges,
+                elem_id,
+                "outlet",
+                nodes_map,
+                tee_port_node_map,
+                _wall_edge_remap,
+                all_ports=_ports,
+            )
+            _ejector = EjectorElement(
+                id=elem_id,
+                primary_node=_primary,
+                secondary_node=_secondary,
+                outlet_node=_outlet,
+                throat_area=_ed.throat_area,
+                nozzle_exit_area=_ed.nozzle_exit_area,
+                mixing_area=_ed.mixing_area,
+                recovery_efficiency=_ed.recovery_efficiency,
+            )
+            _ejector.initial_guess = _expand_initial_guess(_ed.initial_guess, elem_id)
+            if not _ejector.initial_guess:
+                _ejector.initial_guess = _guess_from_prior_result(elem_data, elem_id)
+            net.add_element(_ejector)
+            # Warm-start the port MCN pressures + P_jct from the feeding
+            # boundaries so this stiff double-choked element converges cold
+            # (only fills in guesses the user did not provide).
+            _seed_ejector_warmstart(
+                net, _ejector, (_primary, _secondary, _outlet), schema.edges, nodes_map
+            )
             continue
 
         source_id = None

--- a/gui/backend/runner.py
+++ b/gui/backend/runner.py
@@ -108,7 +108,16 @@ def _build_result_objects(
     elem_diags = result.get("__element_diag__", {})
     for elem_id in net.elements:
         diag = elem_diags.get(elem_id, {}).copy()
-        m_dot = float(result.get(f"{elem_id}.m_dot", diag.get("m_dot_com", 0.0)))
+        # Junction elements have no own `.m_dot` unknown (flows live on the
+        # connecting elements). Report a representative through-flow from their
+        # diagnostics: the tee's common leg (`m_dot_com`), or the ejector's
+        # total outlet flow (`m_dot_outlet`).
+        m_dot = float(
+            result.get(
+                f"{elem_id}.m_dot",
+                diag.get("m_dot_com", diag.get("m_dot_outlet", 0.0)),
+            )
+        )
         diag.pop("m_dot", None)
         element_results[elem_id] = ElementResult(m_dot=m_dot, success=success, **diag)
 

--- a/gui/backend/schemas.py
+++ b/gui/backend/schemas.py
@@ -241,6 +241,27 @@ class MPCETeeData(BaseModel):
     initial_guess: dict[str, float] = Field(default_factory=dict)
 
 
+class EjectorData(BaseModel):
+    """Critical-mode supersonic ejector (3-port: primary + secondary inlets,
+    one outlet). Wraps ``combaero.network.ejector_element.EjectorElement``.
+
+    Geometry is three absolute areas (the ratios are computed by the
+    element). Validation (throat > 0, nozzle_exit > throat, mixing >
+    nozzle_exit, recovery_efficiency > 0) is enforced by the element
+    constructor at build time; the frontend mirrors it for early feedback.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+    label: str | None = None
+    throat_area: float = 3.14e-5  # primary nozzle throat area A_t [m^2]
+    nozzle_exit_area: float = 1.0e-4  # primary nozzle exit area A_p1 [m^2], > throat
+    mixing_area: float = 8.0e-4  # constant-area mixing section A_3 [m^2], > nozzle_exit
+    # Multiplies the lossless mixed stagnation pressure to give the critical
+    # back pressure P_c*. 1.0 = no artificial loss (not fitted to data).
+    recovery_efficiency: float = 1.0
+    initial_guess: dict[str, float] = Field(default_factory=dict)
+
+
 class VortexData(BaseModel):
     model_config = ConfigDict(extra="ignore")
     label: str | None = None

--- a/gui/frontend/src/components/Inspector.tsx
+++ b/gui/frontend/src/components/Inspector.tsx
@@ -1850,6 +1850,75 @@ const Inspector = () => {
 					</div>
 				)}
 
+				{selectedNode.type === "ejector" && (
+					<div className="flex flex-col gap-4">
+						<AreaInput
+							id={`throat_area_${selectedNode.id}`}
+							label="Throat Area A_t"
+							value={selectedNode.data.throat_area ?? 3.14e-5}
+							onChange={(val) =>
+								updateNodeData(selectedNode.id, { throat_area: val })
+							}
+						/>
+						<AreaInput
+							id={`nozzle_exit_area_${selectedNode.id}`}
+							label="Nozzle Exit Area A_p1"
+							value={selectedNode.data.nozzle_exit_area ?? 1.0e-4}
+							onChange={(val) =>
+								updateNodeData(selectedNode.id, { nozzle_exit_area: val })
+							}
+						/>
+						<AreaInput
+							id={`mixing_area_${selectedNode.id}`}
+							label="Mixing Area A_3"
+							value={selectedNode.data.mixing_area ?? 8.0e-4}
+							onChange={(val) =>
+								updateNodeData(selectedNode.id, { mixing_area: val })
+							}
+						/>
+						<div className="flex flex-col gap-1">
+							<label className="text-xs font-bold text-gray-500 uppercase">
+								Recovery Efficiency
+							</label>
+							<NumericInput
+								id={`recovery_efficiency_${selectedNode.id}`}
+								className="p-1 border rounded text-xs bg-white h-7 outline-none focus:ring-1 focus:ring-stone-200"
+								value={selectedNode.data.recovery_efficiency ?? 1.0}
+								onChange={(val) =>
+									updateNodeData(selectedNode.id, { recovery_efficiency: val })
+								}
+								min={0}
+								placeholder="1.0"
+							/>
+							<span className="text-[9px] text-stone-400">
+								Multiplies mixed stagnation P to give P_c*; 1.0 = no loss
+							</span>
+						</div>
+						{selectedNode.data.result && (
+							<div className="rounded border border-stone-200 bg-stone-50 px-3 py-2 text-xs">
+								<div className="font-bold uppercase text-stone-400 mb-1 text-[9px]">
+									Result
+								</div>
+								<div className="flex justify-between">
+									<span className="text-stone-500">ω (entrainment)</span>
+									<span className="font-mono font-bold">
+										{(selectedNode.data.result.omega ?? 0).toFixed(4)}
+									</span>
+								</div>
+								<div className="flex justify-between">
+									<span className="text-stone-500">P_c*</span>
+									<span className="font-mono font-bold">
+										{(
+											(selectedNode.data.result.p_c_star_pa ?? 0) / 1000
+										).toFixed(2)}{" "}
+										kPa
+									</span>
+								</div>
+							</div>
+						)}
+					</div>
+				)}
+
 				{selectedNode.type === "discrete_loss" &&
 					(() => {
 						// Compute default area from upstream node or channel element
@@ -3118,6 +3187,9 @@ const InitialGuessEditor = ({ node }: { node: any }) => {
 		// pressure (legacy slot named P_jct; MPCE-v2 stores Pt there). Warm-
 		// starting Pt_jct is the most useful nudge for the slower MPCE solve.
 		mpce_tee: [{ key: "P_jct", unit: "Pa" }],
+		// Ejector: element-owned unknown is P_jct (repurposed as the critical
+		// back pressure P_c*); warm-starting it helps this stiff solve.
+		ejector: [{ key: "P_jct", unit: "Pa" }],
 		vortex: [{ key: "m_dot", unit: "kg/s" }],
 	};
 	const guessFields = FIELDS_BY_TYPE[node.type as string] ?? [];

--- a/gui/frontend/src/components/NetworkCanvas.tsx
+++ b/gui/frontend/src/components/NetworkCanvas.tsx
@@ -101,6 +101,14 @@ const NetworkCanvas = () => {
 					flow_direction: "branch",
 					theta_deg: 90,
 				} as any;
+			} else if (type === "ejector") {
+				data = {
+					...data,
+					throat_area: 3.14e-5,
+					nozzle_exit_area: 1.0e-4,
+					mixing_area: 8.0e-4,
+					recovery_efficiency: 1.0,
+				} as any;
 			} else if (type === "vortex") {
 				data = {
 					...data,

--- a/gui/frontend/src/components/Sidebar.tsx
+++ b/gui/frontend/src/components/Sidebar.tsx
@@ -299,6 +299,16 @@ const Sidebar = () => {
 			<button
 				type="button"
 				className="flex items-center gap-2 p-2 border rounded cursor-grab hover:bg-stone-50 transition-colors w-full text-left bg-white"
+				onDragStart={(event) => onDragStart(event, "ejector")}
+				draggable
+			>
+				<Wind size={18} className="text-sky-500" />
+				<span>Ejector</span>
+			</button>
+
+			<button
+				type="button"
+				className="flex items-center gap-2 p-2 border rounded cursor-grab hover:bg-stone-50 transition-colors w-full text-left bg-white"
 				onDragStart={(event) => onDragStart(event, "vortex")}
 				draggable
 			>

--- a/gui/frontend/src/components/flowTypes.ts
+++ b/gui/frontend/src/components/flowTypes.ts
@@ -3,6 +3,7 @@ import AreaChangeNode from "./nodes/AreaChangeNode";
 import ChannelNode from "./nodes/ChannelNode";
 import CombustorNode from "./nodes/CombustorNode.tsx";
 import DiscreteLossNode from "./nodes/DiscreteLossNode";
+import EjectorNode from "./nodes/EjectorNode";
 import LosslessNode from "./nodes/LosslessNode";
 import MassBoundaryNode from "./nodes/MassBoundaryNode";
 import MomentumChamberNode from "./nodes/MomentumChamberNode.tsx";
@@ -28,6 +29,7 @@ export const nodeTypes = {
 	probe: ProbeNode,
 	area_change: AreaChangeNode,
 	mpce_tee: MPCETeeNode,
+	ejector: EjectorNode,
 	vortex: VortexNode,
 	wall: WallNode,
 };

--- a/gui/frontend/src/components/nodes/EjectorNode.tsx
+++ b/gui/frontend/src/components/nodes/EjectorNode.tsx
@@ -1,0 +1,119 @@
+import { Wind } from "lucide-react";
+import { useEffect } from "react";
+import {
+	Handle,
+	type NodeProps,
+	Position,
+	useUpdateNodeInternals,
+} from "reactflow";
+import { handleStyle, rotPos } from "../../utils/nodeUtils";
+import { NodeDiagRows } from "../NodeDiagRows";
+
+// Port colours: blue = inlet, green = outlet (matches handle triangle colours).
+const INLET = "#3b82f6";
+const OUTLET = "#22c55e";
+
+// Critical-mode supersonic ejector: fixed 3-port topology (no merge/branch
+// flip). Primary (motive) + secondary (suction) are inlets; one outlet.
+//   Primary  -> left  (target)
+//   Secondary-> bottom(target)
+//   Outlet   -> right (source)
+const EjectorNode = ({ id, data, selected }: NodeProps) => {
+	const rotation = data.rotation || 0;
+	const isSolved = !!data.result;
+	const updateNodeInternals = useUpdateNodeInternals();
+	const textRotation = rotation === 90 || rotation === 180 ? 180 : 0;
+
+	const primaryBase = Position.Left;
+	const secondaryBase = Position.Bottom;
+	const outletBase = Position.Right;
+	const primaryPos = rotPos(primaryBase, rotation);
+	const secondaryPos = rotPos(secondaryBase, rotation);
+	const outletPos = rotPos(outletBase, rotation);
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: rotation triggers handle re-measurement
+	useEffect(() => {
+		updateNodeInternals(id);
+	}, [id, rotation, updateNodeInternals]);
+
+	return (
+		<div
+			className={`shadow-sm rounded bg-stone-50 border-2 flex items-center gap-2 px-3 py-1 ${
+				selected
+					? "border-blue-500 shadow-blue-100"
+					: isSolved
+						? "border-green-400"
+						: "border-stone-300"
+			}`}
+			style={{
+				width: 140,
+				height: 56,
+				transform: `rotate(${rotation}deg)`,
+				transformOrigin: "center center",
+			}}
+		>
+			<div className="flex items-center justify-center p-1 rounded border shrink-0 bg-sky-50 border-sky-200 text-sky-500">
+				<Wind size={16} />
+			</div>
+
+			<div
+				className="flex flex-col items-start flex-1 min-w-0"
+				style={{ transform: `rotate(${textRotation}deg)` }}
+			>
+				<div className="text-[10px] font-bold uppercase leading-none whitespace-nowrap">
+					{data.label ? data.label : "Ejector"}
+				</div>
+				<div className="text-[9px] font-mono whitespace-nowrap text-sky-500">
+					{isSolved && data.result?.omega != null
+						? `ω ${Number(data.result.omega).toFixed(3)}`
+						: "critical"}
+				</div>
+				{isSolved && <NodeDiagRows result={data.result} maxRows={1} />}
+			</div>
+
+			{/* Port labels: P (primary) left, S (secondary) bottom, O (outlet) right. */}
+			<div
+				className="absolute -left-3 top-1/2 -translate-y-1/2 text-[7px] font-extrabold leading-none select-none pointer-events-none bg-white/70 rounded-sm px-0.5"
+				style={{ color: INLET, transform: `rotate(${-rotation}deg)` }}
+			>
+				P
+			</div>
+			<div
+				className="absolute -bottom-3 left-1/2 -translate-x-1/2 text-[7px] font-extrabold leading-none select-none pointer-events-none bg-white/70 rounded-sm px-0.5"
+				style={{ color: INLET, transform: `rotate(${-rotation}deg)` }}
+			>
+				S
+			</div>
+			<div
+				className="absolute -right-3 top-1/2 -translate-y-1/2 text-[7px] font-extrabold leading-none select-none pointer-events-none bg-white/70 rounded-sm px-0.5"
+				style={{ color: OUTLET, transform: `rotate(${-rotation}deg)` }}
+			>
+				O
+			</div>
+
+			{/* Primary inlet (motive) -- left */}
+			<Handle
+				type="target"
+				position={primaryPos}
+				style={handleStyle(primaryBase, rotation)}
+				id="port-primary-target"
+			/>
+			{/* Secondary inlet (suction) -- bottom */}
+			<Handle
+				type="target"
+				position={secondaryPos}
+				style={handleStyle(secondaryBase, rotation)}
+				id="port-secondary-target"
+			/>
+			{/* Outlet -- right */}
+			<Handle
+				type="source"
+				position={outletPos}
+				style={handleStyle(outletBase, rotation)}
+				id="port-outlet-source"
+			/>
+		</div>
+	);
+};
+
+export default EjectorNode;

--- a/gui/frontend/src/utils/validation.ts
+++ b/gui/frontend/src/utils/validation.ts
@@ -101,6 +101,25 @@ export function validateNetwork(nodes: Node[]): string[] {
 			if ((node.data.psi ?? 1) <= 0)
 				errors.push(`${node.id}: Tee area ratio psi must be > 0`);
 		}
+		if (node.type === "ejector") {
+			// Mirrors EjectorElement.__init__ validation (see
+			// python/combaero/network/ejector_element.py).
+			const At = node.data.throat_area ?? 0;
+			const Ap1 = node.data.nozzle_exit_area ?? 0;
+			const A3 = node.data.mixing_area ?? 0;
+			const eta = node.data.recovery_efficiency ?? 1;
+			if (At <= 0) errors.push(`${node.id}: Ejector throat_area must be > 0`);
+			if (Ap1 <= At)
+				errors.push(
+					`${node.id}: Ejector nozzle_exit_area must exceed throat_area`,
+				);
+			if (A3 <= Ap1)
+				errors.push(
+					`${node.id}: Ejector mixing_area must exceed nozzle_exit_area`,
+				);
+			if (eta <= 0)
+				errors.push(`${node.id}: Ejector recovery_efficiency must be > 0`);
+		}
 		if (node.type === "area_change") {
 			// null F0/F1 means "inherit from connected channels" — only flag explicit non-positive values
 			if (node.data.F0 != null && node.data.F0 <= 0)

--- a/python/combaero/network/ejector_element.py
+++ b/python/combaero/network/ejector_element.py
@@ -126,11 +126,8 @@ class EjectorElement(MultiPortChamberElement):
                 ``_ejector_huang1999``'s docstrings for why that default is
                 not fitted to any reference dataset.
         """
-        super().__init__(
-            id,
-            inlet_nodes=[primary_node, secondary_node],
-            outlet_nodes=[outlet_node],
-        )
+        # Validate geometry BEFORE super().__init__ so the port-face areas
+        # passed below are guaranteed positive.
         if throat_area <= 0.0:
             raise ValueError(f"EjectorElement '{id}': throat_area must be positive.")
         if nozzle_exit_area <= throat_area:
@@ -150,6 +147,28 @@ class EjectorElement(MultiPortChamberElement):
                 f"EjectorElement '{id}': recovery_efficiency must be positive, "
                 f"got {recovery_efficiency}."
             )
+        # Port-face areas from the ejector's OWN geometry (ordered
+        # inlet_nodes + outlet_nodes = [primary, secondary, outlet]). Unlike a
+        # generic tee, the ejector always knows these, so it supplies them
+        # rather than relying on the base class inferring them from a
+        # connecting ChannelElement -- an ejector can be fed by a bare
+        # boundary + connection with no channel/diameter to infer from.
+        # These set the port-MCN dynamic-head (Pt = P + 0.5*rho*v^2) only;
+        # the ejector's own residuals use throat/nozzle_exit/mixing directly.
+        #   primary  -> nozzle exit A_p1 (motive jet plane)
+        #   secondary-> annular suction A_3 - A_p1
+        #   outlet   -> mixing/diffuser duct A_3
+        port_areas = [
+            float(nozzle_exit_area),
+            float(mixing_area - nozzle_exit_area),
+            float(mixing_area),
+        ]
+        super().__init__(
+            id,
+            inlet_nodes=[primary_node, secondary_node],
+            outlet_nodes=[outlet_node],
+            port_areas=port_areas,
+        )
         self.primary_node = primary_node
         self.secondary_node = secondary_node
         self.outlet_node = outlet_node

--- a/python/tests/test_ejector_element.py
+++ b/python/tests/test_ejector_element.py
@@ -101,6 +101,18 @@ def test_ports_are_primary_then_secondary_then_outlet():
     assert e._port_signs == [-1.0, -1.0, 1.0]
 
 
+def test_port_areas_derived_from_geometry():
+    # The ejector supplies its own port-face areas from geometry (ordered
+    # primary, secondary, outlet) so the base class never needs to infer them
+    # from a connecting channel -- an ejector can be fed by a bare boundary.
+    e = _element()
+    assert e.port_areas == [
+        _NOZZLE_EXIT_AREA,
+        _MIXING_AREA - _NOZZLE_EXIT_AREA,
+        _MIXING_AREA,
+    ]
+
+
 def test_row_scale_kinds_is_mdot_mdot_mdot_p():
     # Opposite of the base class's own N-pressure-rows + 1-mass-row pattern
     # -- see solver.py's scaling block and the module docstring.

--- a/python/tests/test_gui_ejector.py
+++ b/python/tests/test_gui_ejector.py
@@ -1,0 +1,261 @@
+"""GUI wiring tests for the ejector element type.
+
+Covers (1) the EjectorData schema, (2) that graph_builder converts an
+`ejector` node into an EjectorElement with correct primary/secondary/outlet
+wiring, and (3) an end-to-end runner solve whose element diagnostics
+(omega, p_c_star_pa) round-trip through the ElementResult serialization.
+Mirrors test_gui_mpce_tee.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from combaero.network.components import MultiPortChamberElement
+from combaero.network.ejector_element import EjectorElement
+from gui.backend.graph_builder import build_network_from_schema
+from gui.backend.runner import NetworkRunner
+from gui.backend.schemas import EjectorData, NetworkGraphSchema
+
+_THROAT = 3.14e-5
+_NOZZLE_EXIT = 1.0e-4
+_MIXING = 8.0e-4
+
+
+def _node(nid, ntype, data, x=0, y=0):
+    return {"id": nid, "type": ntype, "position": {"x": x, "y": y}, "data": data}
+
+
+def _edge(eid, src, tgt, src_handle=None, tgt_handle=None):
+    e = {"id": eid, "source": src, "target": tgt, "data": {}}
+    if src_handle:
+        e["sourceHandle"] = src_handle
+    if tgt_handle:
+        e["targetHandle"] = tgt_handle
+    return e
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+
+def test_ejector_data_defaults():
+    d = EjectorData()
+    assert d.recovery_efficiency == 1.0
+    assert d.throat_area > 0.0
+    assert d.nozzle_exit_area > d.throat_area
+    assert d.mixing_area > d.nozzle_exit_area
+    assert d.initial_guess == {}
+
+
+def test_ejector_data_ignores_unknown_keys():
+    # extra="ignore" so stray GUI fields (e.g. a stale param) do not crash.
+    d = EjectorData(throat_area=2e-5, bogus_field=123, label="ej")
+    assert d.throat_area == 2e-5
+    assert d.label == "ej"
+    assert not hasattr(d, "bogus_field")
+
+
+# ---------------------------------------------------------------------------
+# Dispatch / wiring
+# ---------------------------------------------------------------------------
+
+
+def _three_plenum_ejector_schema() -> NetworkGraphSchema:
+    """Three plena on the ejector's ports (primary/secondary inlets, outlet).
+    Plena connect directly to the port handles, so no auto-MCN is inserted and
+    the port node ids are exactly the plenum ids -- easy to assert."""
+    return NetworkGraphSchema(
+        nodes=[
+            _node("p_pri", "plenum", {}),
+            _node("p_sec", "plenum", {}, y=200),
+            _node("p_out", "plenum", {}, x=400),
+            _node(
+                "ej1",
+                "ejector",
+                {
+                    "throat_area": _THROAT,
+                    "nozzle_exit_area": _NOZZLE_EXIT,
+                    "mixing_area": _MIXING,
+                },
+                x=200,
+            ),
+        ],
+        edges=[
+            _edge("e_pri", "p_pri", "ej1", tgt_handle="port-primary-target"),
+            _edge("e_sec", "p_sec", "ej1", tgt_handle="port-secondary-target"),
+            _edge("e_out", "ej1", "p_out", src_handle="port-outlet-source"),
+        ],
+    )
+
+
+def test_ejector_dispatch_builds_element_with_correct_ports():
+    net = build_network_from_schema(_three_plenum_ejector_schema())
+    e = net.elements["ej1"]
+    assert isinstance(e, EjectorElement)
+    assert isinstance(e, MultiPortChamberElement)
+    assert e.primary_node == "p_pri"
+    assert e.secondary_node == "p_sec"
+    assert e.outlet_node == "p_out"
+    assert e.inlet_nodes == ["p_pri", "p_sec"]
+    assert e.outlet_nodes == ["p_out"]
+    assert e.throat_area == _THROAT
+    assert e.nozzle_exit_area == _NOZZLE_EXIT
+    assert e.mixing_area == _MIXING
+    assert e.recovery_efficiency == 1.0
+
+
+def test_ejector_resolves_with_bare_boundary_fed_port_mcns():
+    """The ejector supplies its own port_areas from geometry, so a network
+    whose ports are explicit MomentumChamberNodes fed straight from
+    boundaries (via the GUI's auto lossless connection -- no ChannelElement
+    with a diameter to infer an area from) still resolves. Regression for the
+    "could not infer area at port" failure."""
+    schema = NetworkGraphSchema(
+        nodes=[
+            _node("mb_p", "mass_boundary", {"m_dot": 0.04, "Tt": 440.0}),
+            _node("pb_s", "pressure_boundary", {"Pt": 22850.0, "Tt": 280.0}, y=200),
+            _node("pb_o", "pressure_boundary", {"Pt": 40000.0, "Tt": 300.0}, x=400),
+            _node("mc_p", "momentum_chamber", {"area": 0.1}, x=100),
+            _node("mc_s", "momentum_chamber", {"area": 0.1}, x=100, y=200),
+            _node("mc_o", "momentum_chamber", {"area": 0.15}, x=300),
+            _node(
+                "ej1",
+                "ejector",
+                {
+                    "throat_area": _THROAT,
+                    "nozzle_exit_area": _NOZZLE_EXIT,
+                    "mixing_area": _MIXING,
+                },
+                x=200,
+            ),
+        ],
+        edges=[
+            _edge("e1", "mb_p", "mc_p"),
+            _edge("e2", "mc_p", "ej1", tgt_handle="port-primary-target"),
+            _edge("e3", "pb_s", "mc_s"),
+            _edge("e4", "mc_s", "ej1", tgt_handle="port-secondary-target"),
+            _edge("e5", "ej1", "mc_o", src_handle="port-outlet-source"),
+            _edge("e6", "mc_o", "pb_o"),
+        ],
+    )
+    net = build_network_from_schema(schema)
+    net.resolve_all_topology()  # would raise "could not infer area" before the fix
+    e = net.elements["ej1"]
+    assert e.port_areas == [_NOZZLE_EXIT, _MIXING - _NOZZLE_EXIT, _MIXING]
+
+
+def test_ejector_dispatch_auto_inserts_port_momentum_chambers():
+    """When a channel (element) connects to an ejector port, an implicit
+    MomentumChamberNode is auto-inserted at that port -- the same behaviour
+    the tee relies on, generalized to the ejector's junction_ids."""
+    schema = NetworkGraphSchema(
+        nodes=[
+            _node("pb_p", "pressure_boundary", {"Pt": 7e5, "Tt": 440.0}),
+            _node("p_sec", "plenum", {}, y=200),
+            _node("p_out", "plenum", {}, x=400),
+            _node("ch_p", "channel", {"L": 0.2, "D": 0.05}, x=100),
+            _node(
+                "ej1",
+                "ejector",
+                {
+                    "throat_area": _THROAT,
+                    "nozzle_exit_area": _NOZZLE_EXIT,
+                    "mixing_area": _MIXING,
+                },
+                x=200,
+            ),
+        ],
+        edges=[
+            _edge("e1", "pb_p", "ch_p"),
+            _edge("e2", "ch_p", "ej1", tgt_handle="port-primary-target"),
+            _edge("e_sec", "p_sec", "ej1", tgt_handle="port-secondary-target"),
+            _edge("e_out", "ej1", "p_out", src_handle="port-outlet-source"),
+        ],
+    )
+    net = build_network_from_schema(schema)
+    e = net.elements["ej1"]
+    # primary port resolves to the auto-inserted MomentumChamberNode, not the channel.
+    assert e.primary_node == "__tee_jct__ej1_primary"
+    assert e.primary_node in net.nodes
+
+
+# ---------------------------------------------------------------------------
+# End-to-end runner solve: diagnostics serialize through ElementResult.
+# ---------------------------------------------------------------------------
+
+
+def _solvable_ejector_schema() -> dict:
+    """Cold reference network (boundary -> port MCN -> ejector), the Huang
+    T3-EH operating point, with NO manual initial guesses. graph_builder's
+    ejector warm-start seeds the port pressures + P_jct so the stiff
+    double-choked solve converges from cold -- which it does NOT without the
+    seed (confirmed: no init_strategy cracks it cold)."""
+    return {
+        "nodes": [
+            _node("pb_p", "pressure_boundary", {"Pt": 7e5, "Tt": 440.0}),
+            _node("pb_s", "pressure_boundary", {"Pt": 22850.0, "Tt": 280.0}, y=200),
+            _node("pb_o", "pressure_boundary", {"Pt": 40000.0, "Tt": 300.0}, x=600),
+            _node("mc_p", "momentum_chamber", {"area": 0.05}, x=150),
+            _node("mc_s", "momentum_chamber", {"area": 0.05}, x=150, y=200),
+            _node("mc_o", "momentum_chamber", {"area": 0.05}, x=450),
+            _node(
+                "ej1",
+                "ejector",
+                {
+                    "throat_area": _THROAT,
+                    "nozzle_exit_area": _NOZZLE_EXIT,
+                    "mixing_area": _MIXING,
+                },
+                x=300,
+            ),
+        ],
+        "edges": [
+            _edge("e1", "pb_p", "mc_p"),
+            _edge("e2", "mc_p", "ej1", tgt_handle="port-primary-target"),
+            _edge("e3", "pb_s", "mc_s"),
+            _edge("e4", "mc_s", "ej1", tgt_handle="port-secondary-target"),
+            _edge("e5", "ej1", "mc_o", src_handle="port-outlet-source"),
+            _edge("e6", "mc_o", "pb_o"),
+        ],
+    }
+
+
+def test_ejector_warmstart_seeds_port_pressures():
+    """graph_builder should seed the port MCN pressures from the feeding
+    boundaries (primary=700k, secondary=22.85k, outlet=40k) when the user
+    provided none."""
+    net = build_network_from_schema(NetworkGraphSchema(**_solvable_ejector_schema()))
+    assert net.nodes["mc_p"].initial_guess.get("mc_p.Pt") == 7e5
+    assert net.nodes["mc_s"].initial_guess.get("mc_s.Pt") == 22850.0
+    assert net.nodes["mc_o"].initial_guess.get("mc_o.Pt") == 40000.0
+    # P_jct (== P_c*) seeded on the element from the ejector's own physics.
+    assert net.elements["ej1"].initial_guess.get("ej1.P_jct", 0.0) > 0.0
+
+
+def test_ejector_runner_solve_converges_cold_and_exposes_diagnostics():
+    runner = NetworkRunner.from_dict(_solvable_ejector_schema())
+    result = runner.solve(timeout=120.0)
+    df = result.to_dataframe()
+    row = df[df["id"] == "ej1"]
+    assert not row.empty, "ejector element row missing from results"
+    assert "omega" in df.columns and "p_c_star_pa" in df.columns
+    assert bool(row["success"].iloc[0]), "cold ejector solve did not converge"
+    omega = float(row["omega"].iloc[0])
+    p_c = float(row["p_c_star_pa"].iloc[0])
+    assert 0.0 < omega < 3.0
+    assert p_c > 0.0
+
+
+def test_ejector_element_m_dot_reports_total_throughflow():
+    """The ejector has no own `.m_dot` unknown (a junction). Its ElementResult
+    m_dot -- shown on the node card and telemetry -- must report the total
+    outlet flow (mp + ms), not 0.0 (the old fallback only knew the tee's
+    `m_dot_com`)."""
+    result = NetworkRunner.from_dict(_solvable_ejector_schema()).solve(timeout=120.0)
+    er = result._element_results["ej1"]
+    d = er.model_dump()
+    assert er.m_dot > 0.0
+    assert er.m_dot == pytest.approx(d["m_dot_outlet"], rel=1e-9)
+    assert er.m_dot == pytest.approx(d["m_dot_primary"] + d["m_dot_secondary"], rel=1e-6)


### PR DESCRIPTION
## Summary
Phase 4 (final) of the ejector roadmap: adds the ejector as a first-class draggable **Ejector** element (Wind icon) in the GUI, following the `mpce_tee` precedent — plus the fixes needed to make it actually usable.

**Frontend**
- New `EjectorNode.tsx` (3 fixed ports: primary + secondary inlets, one outlet); registered in `flowTypes.ts`; `Sidebar` palette entry; drop-time defaults in `NetworkCanvas.tsx`; client-side geometry validation in `validation.ts`; inspector form (three areas + `recovery_efficiency`, result panel) and `P_jct` warm-start field.

**Backend (graph_builder / schemas)**
- `EjectorData` schema + an `ejector` dispatch that builds an `EjectorElement`, reusing the tee's named-port resolution and per-port `MomentumChamberNode` auto-insertion (generalized `tee_ids` → shared `junction_ids`, `_find_tee_port` → `_find_junction_port`). Diagnostics flow through the generic `ElementResult` path.

**Fixes found during GUI testing**
- **Geometry-derived port areas:** `EjectorElement` supplies its own port-face areas (primary = nozzle exit, secondary = mixing − nozzle exit, outlet = mixing), so it resolves even when fed by a bare boundary/connection with no channel diameter to infer from (a generic tee can't — no area basis).
- **Cold-start warm-seeding:** `graph_builder` traces each port to its feeding boundary, runs the ejector's own closed-form physics for a consistent operating point, and seeds the port MCN pressures + `P_jct` (only where the user gave none). Without this the stiff double-choked solve won't converge cold (no init strategy cracks it); with it the reference and mass-boundary-driven cases converge from cold.
- **`m_dot` reporting:** the runner reports a junction element's `m_dot` from `m_dot_com` (tee) OR `m_dot_outlet` (ejector's total throughflow) instead of 0.0 for the ejector, which has no own `.m_dot` unknown.

## Test plan
- [x] `python/tests/test_gui_ejector.py` — schema, dispatch, auto-MCN insertion, bare-boundary resolve, **cold** convergence, and `m_dot` reporting.
- [x] `test_port_areas_derived_from_geometry` (element).
- [x] `uv run pytest python/tests/` — **1800 passed**, no regressions (incl. `test_gui_mpce_tee`; tee `m_dot_com` path unchanged).
- [x] Frontend: `tsc -b` + `vite build` + vitest green; `check-gui-style.sh` (biome) clean.
- [x] `check-python-style.sh` clean.

## Known follow-ups (deferred, out of scope)
- A broader tee+ejector junction-port UX audit (boundary-directly-on-port → clearer error / optional auto-inject of a connection element), as discussed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)