### PR TITLE
docs(changelog): note Biome 2.5.9 pin sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pressure row); the default matches prior hard-coded behaviour so
   existing subclasses (`ConstantKTeeElement`, `MPCEv2Element`) are
   unaffected.
+- **Dev tooling: Biome pinned to 2.5.9 across all three sources.** The
+  Dependabot frontend bump of `@biomejs/biome` (2.5.6 -> 2.5.9 in
+  `gui/frontend/package.json`) is now matched by the `biome.json` `$schema`
+  and the `.pre-commit-config.yaml` hook pin, per the frontend
+  version-sync checklist.
 
 ## [0.4.2] - 2026-07-09
 


### PR DESCRIPTION
Adds a CHANGELOG entry under [Unreleased] > Changed recording the dev-tooling change from the frontend Dependabot bump (#258): `@biomejs/biome` moved to 2.5.9 and the `biome.json` `$schema` plus the `.pre-commit-config.yaml` hook pin were realigned to match, per the frontend version-sync checklist.

Docs-only; no code or package changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
