### PR TITLE
docs(ejector): capture operating-regime findings and design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and the `.pre-commit-config.yaml` hook pin, per the frontend
   version-sync checklist.
 
+### Documentation
+- **Documented the ejector's operating-regime limitations and the planned
+  extension.** A new design note (`validation/ejector/OPERATING_REGIMES_DESIGN.md`)
+  diagnoses a real non-converging low-primary-flow case: the critical-only
+  `EjectorElement` hard-codes a choked primary in `R0` and converges to a
+  self-contradictory root (primary Pt *below* the back pressure) whenever the
+  forced primary flow is below the choke threshold, instead of the physical
+  unchoked/subsonic branch (primary Pt just *above* the back pressure,
+  `dp >= 0`). It proposes the fix -- a choked/unchoked `R0` reusing the
+  compressible-orifice nozzle `(f, J)`, a C1 smooth-min critical/subcritical
+  `R1` drooping omega between `P_c*` and the dead-head pressure `P_b0`, and a
+  subsonic jet-pump mode -- all in one Newton-solvable residual system. No
+  behaviour change; `ejector_element.py`, `_ejector_huang1999.py`,
+  `include/ejector.h`, and `validation/ejector/README.md` now cross-reference
+  the note and record the current limitation.
+
 ## [0.4.2] - 2026-07-09
 
 ### Fixed

--- a/include/ejector.h
+++ b/include/ejector.h
@@ -27,7 +27,11 @@
 //     Source of the mixing closure ejector_critical_back_pressure
 //     implements (their Eqs. 7-13).
 //
-// Scope: critical (double-choked) operation only.
+// Scope: critical (double-choked) operation only. The subcritical,
+// unchoked-primary, and back-flow regimes are not modeled here; their design
+// (choked/unchoked primary R0, subcritical omega droop to the dead-head
+// pressure P_b0, and a subsonic jet-pump mode) lives in
+// validation/ejector/OPERATING_REGIMES_DESIGN.md.
 //
 // Jacobian scope (this header): analytic derivatives w.r.t. the 4
 // thermodynamic inputs (p_g, t_g, p_e, t_e) only -- these are the only

--- a/python/combaero/network/_ejector_huang1999.py
+++ b/python/combaero/network/_ejector_huang1999.py
@@ -46,7 +46,13 @@ Scope
 Critical (double-choked) operation only: both the primary flow (choked at the
 nozzle throat) and the entrained flow (choked at the hypothetical throat y-y)
 are sonic, so the entrainment ratio omega is fixed and independent of back
-pressure. Subcritical / back-flow regimes are out of scope.
+pressure. Subcritical, unchoked-primary, and back-flow regimes are out of scope
+of THIS closed form; the extension that adds them (choked/unchoked primary,
+subcritical omega droop between P_c* and the dead-head pressure P_b0, and a
+subsonic jet-pump mode) is designed in
+``validation/ejector/OPERATING_REGIMES_DESIGN.md``. Note that ``critical_back_pressure``
+evaluated at omega = 0 already yields P_b0 (the zero-entrainment dead-head back
+pressure) with no new calibration constant -- an anchor that extension reuses.
 """
 
 from __future__ import annotations

--- a/python/combaero/network/ejector_element.py
+++ b/python/combaero/network/ejector_element.py
@@ -11,6 +11,23 @@ pressure, their Eqs. 7-13) -- see that module's docstring and
 and the accuracy comparison against three alternative closures that were
 also evaluated.
 
+Operating-regime scope and a known limitation. This element models the
+critical (double-choked) plateau ONLY: the primary is assumed choked and the
+entrained flow critical, so ``omega`` is back-pressure-independent. Two
+regimes are therefore NOT yet modeled -- (a) an UNCHOKED primary, which
+occurs when the forced primary mass flow is below the choke threshold
+``mdot_choked(P_back)``; the physical branch there floats the primary Pt to
+just ABOVE the back pressure (forward flow, ``dp >= 0``) and behaves as a
+subsonic jet pump, but ``R0 = mp - ejector_choked_mass_flow(...)`` hard-codes
+the choked branch and instead converges to a self-contradictory root with the
+primary Pt BELOW the back pressure (``verify_solution_consistent`` then demotes
+it) -- and (b) the SUBCRITICAL entrainment droop for ``P_c* < Pt_outlet <
+P_b0``. The full diagnosis (with the reported non-converging case) and the
+proposed extension -- a choked/unchoked ``R0`` reusing the compressible-orifice
+nozzle ``(f, J)``, a C1 smooth-min critical/subcritical ``R1``, and a subsonic
+jet-pump mode, all in one Newton-solvable residual system -- are in
+``validation/ejector/OPERATING_REGIMES_DESIGN.md``.
+
 Working fluid: combaero's real-fluid EOS covers combustion/air-relevant
 species only (N2, O2, Ar, CO2, H2O, light hydrocarbons, CO, H2, NH3) -- no
 halocarbon refrigerants. gamma and R are evaluated LIVE from that EOS at

--- a/validation/ejector/OPERATING_REGIMES_DESIGN.md
+++ b/validation/ejector/OPERATING_REGIMES_DESIGN.md
@@ -1,0 +1,299 @@
+# Ejector operating-regime extension: choked/unchoked primary, subcritical entrainment, and unchoked jet-pump mode
+
+Design + findings note for extending `EjectorElement` beyond the critical
+(double-choked) plateau. Written 2026-08-26. Audience: developers of the
+network module (not end users). Captures the diagnosis of a real
+non-converging low-primary-flow case and proposes the model extension that
+resolves it. Nothing here is implemented yet -- this is the spec that the
+implementation PRs will follow.
+
+Companion docs:
+- `README.md` (this directory) -- current (critical-mode) model, accuracy
+  comparison, golden-fixture contract.
+- `../../python/combaero/network/_ejector_huang1999.py` -- the closed-form
+  critical-mode physics (Huang 1999 + Kracik & Dvorak 2016).
+- `../../docs/ejector/handover.md` -- the original (2026-07-13) groundwork
+  handover (untracked, alongside the source PDFs; now largely superseded, kept
+  for history).
+
+---
+
+## 1. Motivation: a physically posed network that does not converge
+
+A GUI network (`gui/tmp/ejector_test_low_flow_not_converged.json`) drives an
+ejector with a **forced primary mass flow of 0.0051 kg/s** (a `mass_boundary`),
+a secondary suction reservoir at 101 325 Pa, and an outlet reservoir at
+101 325 Pa. The solver reaches a root (|F| ~ 2.5e-10) but `EjectorElement`'s
+`verify_solution_consistent` demotes it to non-converged (outlet Pt exceeds the
+computed critical back pressure P_c*). The user's intuition -- that a physical
+solution exists -- is correct. The failure is a **modeling-regime** limitation,
+not a solver bug, and the root cause is deeper than "subcritical back
+pressure": the current residual set has no branch for an **unchoked primary
+nozzle**, and picks a self-contradictory choked root.
+
+## 2. Findings
+
+### 2.1 R0 hard-codes the choked branch and lands on an unphysical root
+
+The element's primary-flow residual is (see `ejector_element.py`):
+
+    R0 = mp - ejector_choked_mass_flow(Pt_primary, Tt_primary, A_t, gamma, R, eta_p)
+
+`ejector_choked_mass_flow` is the **always-choked** (sonic-throat) relation:
+`mdot = const * Pt * A_t / sqrt(Tt)`, monotone in `Pt`. For the forced
+`mp = 0.0051 kg/s` it back-solves to `Pt_primary = 71 552 Pa`. But a nozzle can
+only be choked when `Pt/P_back >= ((gamma+1)/2)^(gamma/(gamma-1)) ~= 1.89`. At
+`Pt = 71 552 Pa` against a ~101 kPa mixing/back pressure the ratio is 0.71 --
+the root **asserts choked flow at a pressure that cannot choke**, and puts the
+"motive" stream *below* the pressure it is supposed to discharge against.
+
+The physically consistent root is the **unchoked / subsonic** one:
+
+| | Primary Pt | Pt/Pb | State | dp = Pt - Pb |
+|---|---|---|---|---|
+| R0 choked root (solver artifact) | 71 552 Pa | 0.71 | "choked" (impossible) | **-29 773 Pa** (backward) |
+| Physical subsonic root | ~102 435 Pa | 1.01 | unchoked, M_throat ~ 0.13 | **+1 110 Pa** |
+
+For forward flow the pressure drop is `>= 0` and the primary supply sits
+*slightly above* both the secondary and outlet pressures -- exactly what a weak
+forced flow through a subsonic nozzle requires. R0 has no unchoked branch, so
+Newton falls into the bogus low-pressure choked root.
+
+The choke threshold is sharp: at `Pb = 101 325 Pa` the choked mass flow is
+**0.00722 kg/s**. Any forced `mp` below that cannot choke and the primary Pt
+must float up to just above `Pb`; any `mp` above it chokes and Pt rises well
+above `Pb`. The observed "convergence returns" at `mp ~ 0.00722 kg/s` in a
+primary-flow sweep is this choke threshold, not a coincidence of P_c*.
+
+### 2.2 The regime hierarchy (ordered by forced primary mass flow)
+
+At fixed geometry, secondary condition, and back pressure `Pb`, the device
+passes through these regimes as the forced primary flow (equivalently, primary
+supply pressure) increases:
+
+1. **`mp < mdot_choked(Pb)` -> primary UNCHOKED.** No supersonic core; the
+   device is a **subsonic jet pump / mixing junction**. Primary Pt floats to
+   `~Pb + dynamic head`; entrainment is small. The double-choked ejector
+   construction (Huang Eqs. 1-8) does not apply.
+2. **`mp` large enough to choke -> supersonic ejector.** The primary chokes at
+   the throat and expands supersonically; the entrained flow's regime is then
+   set by the back pressure:
+   - **`Pb <= P_c*`** -> **critical** (double-choked): `omega = omega_crit`,
+     independent of `Pb`. *(modeled today)*
+   - **`P_c* < Pb < P_b0`** -> **subcritical**: `omega` droops from
+     `omega_crit` toward 0 as `Pb` rises. *(not modeled)*
+   - **`Pb >= P_b0`** -> **backflow/breakdown**: `omega <= 0`, secondary
+     reverses out the suction port. *(not modeled)*
+
+`P_b0` is the **zero-entrainment (dead-head) back pressure** -- the highest back
+pressure the ejector can hold with no secondary flow. It is computable from the
+*existing* Kracik & Dvorak mixing closure evaluated at `omega = 0` (their
+`gam = 0`): `z3 = z1`, `lambda3` = subsonic conjugate of `lambda1`, and
+`P_b0 = recovery * p_g * q(lambda1)/q(lambda3)`. No new calibration constant.
+
+So there are **two coupled branch selections**: R0 (choked <-> unchoked
+primary) *gates* R1 (critical <-> subcritical <-> backflow entrainment). The
+entrainment sub-branches only exist once the primary is choked.
+
+### 2.3 The `M_py < 1` degeneracy is a symptom of the mis-forced choked root
+
+When the secondary stagnation pressure approaches or exceeds the primary
+(`P_e >~ P_g`), the primary core is compressed back to **subsonic** at the
+mixing plane y-y (`M_py < 1`). In that state Huang's constant-pressure-mixing
+entrainment formula still returns a number, but a large and spurious one: the
+entrained area `A_sy = A_3/A_t - A_py/A_t` becomes almost the whole mixing
+chamber, so `omega` blows up. For the case in Section 2.4 this yields the
+nonsensical `omega_crit = 32.8` (a 0.0051 kg/s jet nominally entraining 33x its
+own mass). `M_py >= 1` (primary core still supersonic where the secondary
+chokes) is the true validity condition for the double-choked construction. In a
+healthy motive ejector (`P_g >> P_e`) `M_py > 1` and `P_b0 > P_c*` with a
+comfortable margin; the degenerate corner is exactly the weak/reversed-pressure
+case, and it coincides with the primary being unchoked -- i.e. it is the same
+regime-1 failure seen from the entrainment side.
+
+### 2.4 Worked example (the reported case)
+
+Geometry: `A_t = 3.14e-5`, `A_p1 = 1.0e-4`, `A_3 = 8.0e-4` m^2, so
+`A_p1/A_t = 3.185`, `A_3/A_t = 25.48`. Air, `gamma ~ 1.40`, `R ~ 288.1`.
+Forced `mp = 0.0051 kg/s`; `Pb = 101 325 Pa`.
+
+- R0 choked artifact: `Pt_primary = 71 552 Pa` (< Pb; cannot choke).
+- Physical subsonic branch: `Pt_primary ~ 102 435 Pa` (dp = +1 110 Pa).
+- Critical-mode outputs at the artifact state: `M_py = 0.66` (< 1, degenerate),
+  `omega_crit = 32.8`, `P_c* = 100 024 Pa`; outlet `Pb = 101 325 Pa > P_c*`.
+- Frozen-y-y dead-head collapses to `P_b0 = p_g = 71 552 Pa` (degenerate).
+
+Both the primary-flow branch (R0) and the entrainment branch (R1) are outside
+their modeled regimes. The correct model here is the **unchoked subsonic
+jet-pump**: primary Pt just above Pb, small forward entrainment, outlet =
+primary + secondary. Fixing R0 alone is necessary but not sufficient -- with Pt
+floated up to ~102 kPa the primary core is still subsonic at y-y, so the
+entrainment closure still needs its own regime handling.
+
+## 3. Proposed design
+
+Keep the residual **layout** (`P_jct` + N+1 rows on the `MultiPortChamberElement`
+topology) and the C++ `(f, J)` discipline. Only the **content** of R0 and R1
+changes, plus `verify_solution_consistent`. Recovery of a single self-consistent
+root across regimes is achieved with C1 blends, not discrete re-solves, matching
+the house soft-barrier idiom already used by `MPCEv2Element`
+(`alpha * max(0, -e_i * mdot_i)^2`, C1 at the kink).
+
+### 3.1 R0: choked/unchoked primary via the compressible-nozzle closure
+
+Replace `ejector_choked_mass_flow` with the **existing** compressible-orifice
+nozzle relation, which already implements isentropic nozzle flow with a *smooth
+choked transition* and an analytic Jacobian:
+
+    OrificeResult orifice_compressible_residuals_and_jacobian(
+        m_dot, P_total_up, T_up, Y_up, P_static_down, Cd, area, beta);
+
+(`include/solver_interface.h`; used by `OrificeElement(regime="compressible")`).
+Map: `P_total_up = Pt_primary`, `T_up = Tt_primary`, `area = A_t`,
+`P_static_down = P_py` (the common mixing-plane static pressure the entrainment
+construction already computes as `P_py = P_sy = P_e/((gamma+1)/2)^(gamma/(gamma-1))`),
+`Cd` from `eta_p` (or 1.0), `beta` the throat/upstream area ratio. When choked
+this reduces to the current relation (independent of `P_static_down`); when
+unchoked, `mp` depends on `P_py` and the root floats `Pt_primary` up to just
+above the back pressure -- the physical branch of Section 2.1. **Decision: use
+`P_py` (internal mixing-chamber pressure), not the outlet `Pb`, as the
+downstream pressure** (user-confirmed); `Pb` is a cheaper proxy retained only as
+a fallback if the `R0 <-> P_py` coupling hurts convergence.
+
+New Jacobian couplings introduced by R0: `d R0 / d P_py` (and `P_py`'s own
+dependence on `Pt_secondary`, `Tt_secondary` through the entrainment
+construction), on top of the existing `d R0 / d Pt_primary`, `d R0 / d Tt_primary`.
+
+### 3.2 R1: critical <-> subcritical entrainment via a C1 smooth-min
+
+Model the realized entrainment as the smaller of the choke-limited and the
+back-pressure-limited value:
+
+    omega_eff = smoothmin(omega_crit, omega_sub(Pb); eps)
+              = 0.5 * (omega_crit + omega_sub
+                       - sqrt((omega_crit - omega_sub)^2 + eps^2))
+
+    R1 = ms - omega_eff * mp
+
+- Below `P_c*`, `omega_sub > omega_crit` -> choke limits -> `omega_eff = omega_crit`
+  (the flat plateau, unchanged).
+- Above `P_c*`, `omega_sub < omega_crit` -> back pressure limits ->
+  `omega_eff = omega_sub(Pb)`, drooping to 0 at `P_b0`.
+- `eps` is a small fraction of `omega_crit` (e.g. `1e-3 * omega_crit`) so the
+  corner is rounded over a physically negligible width but the Jacobian is
+  smooth -- the same C-infinity `sqrt`-smoothing flavor as the MPCE penalty.
+
+**`omega_sub(Pb)` fidelity -- proposed Tier 1 (linear droop):**
+
+    omega_sub(Pb) = omega_crit * (P_b0 - Pb) / (P_b0 - P_c*)
+
+Uses only quantities the critical closure already produces (`omega_crit`,
+`P_c*`, and `P_b0` = the same `p03` formula at `omega = 0`). Exact at both
+physical anchors `(P_c*, omega_crit)` and `(P_b0, 0)`; monotone; clean analytic
+Jacobian; and the near-linear subcritical droop is well documented empirically
+(Huang's own characteristic, ESDU 86030, and multiple CFD studies). **Tier 2**
+(a later refinement) inverts the actual mixing curve `p03(omega) = Pb/recovery`
+for `omega` via a 1-D inner Newton (frozen y-y), giving the true curve rather
+than the chord, with the Jacobian via the implicit function theorem. Tier 1
+first; Tier 2 if validation shows the chord is too coarse.
+
+New Jacobian coupling introduced by R1: **`d R1 / d(outlet.Pt)`** (currently R1
+has no back-pressure dependence). This is the structural change that lets the
+subcritical branch exist as a network unknown.
+
+### 3.3 Unchoked regime = subsonic jet-pump closure (chosen behavior)
+
+When the primary is unchoked (regime 1), model the device as a **subsonic jet
+pump** rather than rejecting the point (user-confirmed choice). The primary Pt
+floats to `~Pb + dynamic head` via the R0 compressible-nozzle branch (3.1); the
+entrainment comes from a **subsonic mixing/momentum balance** (mass + momentum +
+energy across the constant-area mixing section with both streams subsonic and
+pressure-matched), giving a small physical `omega` instead of the spurious
+double-choked value. This closure blends into the choked-ejector closure at the
+choke threshold so the overall `omega(mp)` and `omega(Pb)` surfaces stay C1.
+(Selection between the jet-pump and ejector entrainment closures follows the
+same primary-choke smooth indicator that R0 already exposes -- to be finalized
+during implementation; the guiding constraint is a single C1 residual, one
+solve, no discrete regime detection.)
+
+### 3.4 `verify_solution_consistent` changes
+
+Today it rejects `outlet.Pt > P_c*` outright (treats every subcritical point as
+unphysical). Under this design:
+- Subcritical points `P_c* < Pb < P_b0` become **valid** (the model now covers
+  them) -- no longer rejected.
+- Retain a guard only for genuinely unmodeled states: `Pb >= P_b0` (backflow,
+  if that phase is deferred) and any residual non-physical corner, with a clear
+  diagnostic naming the regime rather than a bare "artifact root".
+- The unchoked jet-pump regime becomes a **valid converged state**, not a
+  demotion.
+
+### 3.5 Interop: one unified residual set, one solve
+
+The two smooth blends (R0 choke transition; R1 critical/subcritical/jet-pump
+selection) make the whole element a single C1 residual system that Newton solves
+in one pass across all regimes -- no outer regime detection, no two-phase
+re-solve, no chatter across the boundary. This is the "critical <-> subcritical
+interop" requirement, and it mirrors how `OrificeElement` already spans
+choked/unchoked and how `MPCEv2Element` spans merge/branch within one C1
+residual.
+
+## 4. Validation strategy
+
+- Extend the golden fixture (`validation/ejector/data/huang1999_reference.json`
+  + generated `.h`) with **subcritical rows** (a `Pb`-sweep at fixed inlet
+  conditions across `P_c* -> P_b0`) and **unchoked jet-pump rows**, each with
+  central-difference Jacobian targets, so the C++ analytic `(f, J)` is checked
+  the same way the critical rows are today.
+- Cross-check the subcritical droop shape and `P_b0` against the air-ejector
+  CFD + experiment in `../../docs/ejector/Bartosiewicz_ejector_2004.pdf` and the
+  characteristic curves in Huang (1999).
+- Regression + trend checks (monotonicity of `omega` in `Pb`; continuity at
+  `P_c*` and at the choke threshold; `dp >= 0` for forward flow).
+- Keep the calibration policy: anchor closures on analytical/CFD references, do
+  not fit `recovery_efficiency` or any droop parameter to a measurement set.
+
+## 5. Open decisions (flagged, not yet locked)
+
+1. **Backflow coverage.** Implement subcritical droop + unchoked jet-pump now,
+   defer true backflow (`omega < 0`, sign-aware suction port) to a later phase
+   behind a guard? (Recommended: yes, defer backflow.)
+2. **Subcritical fidelity.** Ship Tier 1 (linear droop) first, add Tier 2
+   (mixing-curve inversion) only if validation demands it? (Recommended: yes.)
+3. **R0 downstream pressure resolution.** `P_py` (chosen) vs `Pb` proxy if the
+   `R0 <-> P_py` coupling degrades Newton robustness -- to be confirmed
+   empirically during implementation.
+
+## 6. Phased implementation plan
+
+Each phase carries the mandatory syncs from `CLAUDE.md` (units_data.h,
+API_PYTHON.md / API_CPP.md, CHANGELOG `[Unreleased]`, `test_units_sync.py` for
+new exported symbols, and the doc-hygiene rules).
+
+1. **Reference model** (`validation/ejector/` + `_ejector_huang1999.py`): add
+   `P_b0` (dead-head), `omega_sub` (Tier 1), the subsonic jet-pump entrainment,
+   and the smooth-min blend as pure closed forms. Extend the golden fixture.
+2. **Production `EjectorElement`**: new R0 (compressible-nozzle, `P_py`
+   downstream) and R1 (smooth-min); updated `verify_solution_consistent`;
+   analytic `(f, J)` including the new `d R0/d P_py` and `d R1/d(outlet.Pt)`
+   couplings. Regression against the reported case: it must converge to the
+   subsonic jet-pump root (`Pt_primary ~ 102 kPa`, `dp >= 0`, small `omega`).
+3. **C++ port** (`include/ejector.h` / `src/ejector.cpp`): analytic Jacobians
+   (sympy cross-check where useful), ctests consuming the extended fixture. Reuse
+   the compressible-orifice C++ path for R0 where possible.
+4. **pybind bindings** (separate PR), same fixture.
+5. **GUI**: surface the operating regime (critical / subcritical / jet-pump /
+   backflow) as an ejector diagnostic; validate the reported network converges.
+
+## 7. References
+
+- Huang, Chang, Wang, Petrenko (1999), *A 1-D analysis of ejector performance*,
+  Int. J. Refrigeration 22:354-364.
+  `../../docs/ejector/Huang_1d_analysis_ejector.pdf`.
+- Kracik, Dvorak (2016), *Development of an Analytical Method for Predicting
+  Flow in a Supersonic Air Ejector*, EPJ Web Conf. 114:02059.
+  `../../docs/ejector/Development_of_an_Analytical_Method_for.pdf`.
+- Bartosiewicz et al. (2004), air-ejector CFD + experiment (validation
+  cross-check). `../../docs/ejector/Bartosiewicz_ejector_2004.pdf`.
+- ESDU 86030, *Ejectors and jet pumps* (subcritical/breakdown characteristic
+  shape reference).

--- a/validation/ejector/README.md
+++ b/validation/ejector/README.md
@@ -61,7 +61,20 @@ invariant to count, while A_3/A_t shrinks as count grows, since the aggregate
 throat area scales with count but the shared mixing chamber does not.
 `count=1` reduces exactly to the direct constructor.
 
-Out of scope for now (roadmap): the subcritical / back-flow branches.
+Out of scope for the *current* model: the subcritical, unchoked-primary, and
+back-flow branches. These are designed in
+`OPERATING_REGIMES_DESIGN.md`, which diagnoses a real
+non-converging low-primary-flow case and proposes the extension. In brief, the
+device passes through these regimes as the forced primary flow rises: (1)
+`mp < mdot_choked(Pb)` -> primary **unchoked**, a subsonic jet pump (primary Pt
+floats just above the back pressure); (2) primary **choked** -> supersonic
+ejector, whose entrained flow is then **critical** (`Pb <= P_c*`, modeled here),
+**subcritical** (`P_c* < Pb < P_b0`, drooping omega), or **backflow**
+(`Pb >= P_b0`). A known limitation of the current critical-only model: a
+forced-primary flow below the choke threshold converges to a self-contradictory
+choked-branch root (primary Pt *below* the back pressure) and is demoted by
+`verify_solution_consistent` -- see the design doc for the fix (choked/unchoked
+R0 + subcritical R1 + jet-pump mode).
 
 ## gamma provenance (the only CoolProp step)
 
@@ -202,10 +215,16 @@ one dataset. `test_ejector_huang.py` checks P_c* by regression, by trend
 1. ~~Add the P_c* / critical-back-pressure chain to the reference model.~~
    Done -- see Accuracy above; uses Kracik & Dvorak's closure, not Huang's
    original Eqs. 9-18.
-2. Draft the production 3-port `EjectorElement` (primary-in, secondary-in,
-   outlet) in `python/combaero/network/`, real-fluid thermo, analytic `(f, J)`.
-3. Port to C++ with analytic Jacobians (derived symbolically with sympy where
+2. ~~Draft the production 3-port `EjectorElement` (primary-in, secondary-in,
+   outlet) in `python/combaero/network/`, real-fluid thermo, analytic `(f, J)`.~~
+   Done (PR #252).
+3. ~~Port to C++ with analytic Jacobians (derived symbolically with sympy where
    useful) and ctests consuming `huang1999_reference_data.h`'s central-
-   difference Jacobian columns to tight tolerance.
-4. pybind bindings, in a separate PR.
-5. GUI work and validation, last.
+   difference Jacobian columns to tight tolerance.~~ Done (PR #253).
+4. ~~pybind bindings, in a separate PR.~~ Done (PR #254).
+5. ~~GUI work and validation.~~ Done (PR #259).
+6. **Operating-regime extension (next):** choked/unchoked primary (R0),
+   subcritical entrainment droop (R1), and the unchoked subsonic jet-pump mode,
+   in one C1 residual system so critical <-> subcritical <-> jet-pump solve in a
+   single Newton pass. Full findings and design in
+   `OPERATING_REGIMES_DESIGN.md`.


### PR DESCRIPTION
## Summary

Doc-only PR. Captures the diagnosis of a real non-converging ejector network and the proposed design for extending `EjectorElement` beyond the critical (double-choked) plateau. **No behaviour change** — no code paths are modified.

## The finding

A GUI network (`gui/tmp/ejector_test_low_flow_not_converged.json`) drives an ejector with a forced primary mass flow of **0.0051 kg/s**, secondary and outlet reservoirs both at 101 325 Pa. The solver reaches a root (|F| ~ 2.5e-10) but `verify_solution_consistent` demotes it. Root cause:

- `R0 = mp - ejector_choked_mass_flow(...)` **hard-codes the choked primary branch**. For the forced flow it back-solves to primary Pt = **71 552 Pa** — but at that pressure the nozzle *cannot* be choked (needs Pt/Pb ≥ 1.89), so the root is self-contradictory and puts the "motive" stream *below* the pressure it discharges against.
- The physically consistent root is **unchoked / subsonic**: primary Pt ≈ **102 435 Pa**, just *above* the back pressure (dp ≈ +1 110 Pa ≥ 0), behaving as a subsonic jet pump.
- The choke threshold is sharp: at Pb = 101 325 Pa the choked mass flow is **0.00722 kg/s**; any forced mp below that is unchoked.

| | Primary Pt | Pt/Pb | dp = Pt − Pb |
|---|---|---|---|
| R0 choked root (artifact) | 71 552 Pa | 0.71 | −29 773 Pa (backward) |
| Physical subsonic root | ~102 435 Pa | 1.01 | +1 110 Pa |

## The proposal

`validation/ejector/OPERATING_REGIMES_DESIGN.md` lays out a single Newton-solvable residual system covering all regimes:

- **R0** — choked/unchoked primary via the existing compressible-orifice nozzle `(f, J)` (`orifice_compressible_residuals_and_jacobian`), with the mixing-plane pressure `P_py` as the downstream pressure.
- **R1** — a C¹ `smoothmin(omega_crit, omega_sub(Pb))`, drooping omega between `P_c*` and the dead-head pressure `P_b0` (= the existing Kracik & Dvorak closure at `omega = 0`, **no new calibration constant**).
- **Unchoked regime** — modeled as a subsonic jet pump (not rejected).

The interop is one C¹ residual, one solve — mirroring how `OrificeElement` already spans choked/unchoked and `MPCEv2Element` spans merge/branch.

## Changes (docs only)

- **Add** `validation/ejector/OPERATING_REGIMES_DESIGN.md` — findings, regime hierarchy, worked example, proposed design, validation strategy, phased plan, open decisions.
- **Cross-reference** it and record the current limitation in `ejector_element.py`, `_ejector_huang1999.py`, `include/ejector.h`, and `validation/ejector/README.md` (scope + roadmap; shipped phases marked done).
- **CHANGELOG** — a `### Documentation` note under `[Unreleased]`.

## Follow-up

Implementation is deliberately **not** in this PR (per request: capture findings/proposals first). The phased plan (reference model → production element → C++ (f, J) → pybind → GUI) is in the design doc. Two decisions locked with the reporter: **jet-pump model** for the unchoked regime, and **P_py** as R0's downstream pressure. Backflow coverage and Tier-1-vs-Tier-2 subcritical fidelity remain flagged-open in the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
