### PR TITLE
docs(ejector): off-design validation sources + digitized Henry2007 Fig.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   behaviour change; `ejector_element.py`, `_ejector_huang1999.py`,
   `include/ejector.h`, and `validation/ejector/README.md` now cross-reference
   the note and record the current limitation.
+- **Identified and committed the off-design validation sources for the ejector
+  regime extension.** The design note's validation strategy
+  (`OPERATING_REGIMES_DESIGN.md` sec 4) now records that the subcritical-droop
+  branch has air-fluid experiment + CFD data in repo (Henry et al. 2007,
+  HEFAT2007; Akbarnejad & Ziabasharhagh 2025 for numeric `P_c*`/`P_b0`
+  anchors), while the unchoked jet-pump branch has no dataset and is validated
+  analytically (isentropic-nozzle exactness + conservation/continuity). Henry
+  et al. Fig. 5 (measured air-ejector characteristic omega(Pb/P2) at 4/5/6 bar
+  primary) is digitized and committed as
+  `validation/ejector/data/henry2007_fig5.py`, cross-checked against the source
+  figure. Corrects the earlier "Bartosiewicz 2004" citation (the source PDF is
+  HEFAT2007). No behaviour change.
 
 ## [0.4.2] - 2026-07-09
 

--- a/validation/ejector/OPERATING_REGIMES_DESIGN.md
+++ b/validation/ejector/OPERATING_REGIMES_DESIGN.md
@@ -240,18 +240,73 @@ residual.
 
 ## 4. Validation strategy
 
+Off-design validation data is **available in air for the subcritical branch**
+(regime 2's droop) and **absent for the unchoked jet-pump branch** (regime 1),
+which sets two different bars for the two branches.
+
+### 4.1 Subcritical droop -- validate against air experiment + CFD
+
+Two in-repo, air-fluid sources cover the plateau -> knee (`P_c*`) -> droop ->
+breakdown (`P_b0`) structure directly, so no refrigerant EOS / CoolProp is
+needed (unlike the R141b critical fixture):
+
+- **Henry et al. (2007), HEFAT2007** (`../../docs/ejector/Bartosiewicz_ejector_2004.pdf`;
+  filename predates the confirmed citation). Fig. 5 is the measured air-ejector
+  characteristic `omega(Pb/P2^0)` at three primary pressures (4/5/6 bar), each
+  showing the full plateau -> droop -> near-breakdown shape, with a reported
+  CFD-vs-experiment deviation < 10%. **Digitized and committed** as
+  `validation/ejector/data/henry2007_fig5.py` (cross-checked against the source
+  figure; see that module's docstring for the provenance + cross-check verdict).
+  This is the primary droop-*shape* target.
+- **Akbarnejad & Ziabasharhagh (2025)**, *Theoretical Model for Predicting
+  Performance of a Gas Ejector*, Thermal Engineering 72(1). Air runs (case E2;
+  E1 temperature sweep) with numeric **tables of both critical and breakdown
+  back pressures** across ~7 primary/secondary combinations -- directly
+  digitizable anchor values for `P_c*` and `P_b0` without curve tracing. The
+  anchor-pressure cross-check. *(Not yet digitized -- add when Phase 1 lands.)*
+
+Use these as **validation, not calibration**: check the model's droop shape and
+`P_c*`/`P_b0` anchors against them (trend + loose relative tolerance, in the
+spirit of the existing critical-mode `pc_rel_tol`); do not fit
+`recovery_efficiency` or any droop parameter to them. If the Tier-1 linear chord
+deviates materially from the Henry Fig. 5 droop, that deviation is the concrete
+trigger to implement Tier-2 (mixing-curve inversion), per sec 3.2.
+
+*(Galindo et al. (2020) has the richest fitted subcritical + breakdown surface
+but uses R1234yf -- outside combaero's air/combustion EOS, so it is a
+methodology reference only, not a usable fixture.)*
+
+### 4.2 Unchoked jet-pump branch -- validate analytically, no dataset needed
+
+None of the in-repo ejector references (nor the surveyed literature) report a
+measured `omega` characteristic for the unchoked-primary / subsonic jet-pump
+regime; only Lienhard/McGovern even name it, qualitatively. This branch does
+**not** require a bespoke dataset, because it rests on exact analytic relations
+rather than an empirical droop:
+
+- R0 is isentropic compressible-nozzle flow (choked/unchoked), already validated
+  in the suite via the compressible `OrificeElement` path R0 reuses (sec 3.1) --
+  the jet-pump branch **inherits** that validation.
+- The entrainment is fixed by mass/momentum/energy conservation across the
+  subsonic mixing section (sec 3.3), checkable by conservation + consistency
+  assertions rather than a fitted curve.
+
+So validate regime 1 by **analytical exactness + consistency checks**:
+`dp >= 0` for forward flow, mass/energy balance, and C1 continuity of the
+`omega(mp)` / `omega(Pb)` surfaces with the ejector branch at the choke
+threshold. (An external eductor/jet-pump reference such as ESDU 86030 would be a
+nice-to-have independent number, but is not required for the branch to be
+validated.)
+
+### 4.3 Golden-fixture + regression mechanics
+
 - Extend the golden fixture (`validation/ejector/data/huang1999_reference.json`
   + generated `.h`) with **subcritical rows** (a `Pb`-sweep at fixed inlet
   conditions across `P_c* -> P_b0`) and **unchoked jet-pump rows**, each with
   central-difference Jacobian targets, so the C++ analytic `(f, J)` is checked
   the same way the critical rows are today.
-- Cross-check the subcritical droop shape and `P_b0` against the air-ejector
-  CFD + experiment in `../../docs/ejector/Bartosiewicz_ejector_2004.pdf` and the
-  characteristic curves in Huang (1999).
 - Regression + trend checks (monotonicity of `omega` in `Pb`; continuity at
   `P_c*` and at the choke threshold; `dp >= 0` for forward flow).
-- Keep the calibration policy: anchor closures on analytical/CFD references, do
-  not fit `recovery_efficiency` or any droop parameter to a measurement set.
 
 ## 5. Open decisions (flagged, not yet locked)
 
@@ -293,7 +348,16 @@ new exported symbols, and the doc-hygiene rules).
 - Kracik, Dvorak (2016), *Development of an Analytical Method for Predicting
   Flow in a Supersonic Air Ejector*, EPJ Web Conf. 114:02059.
   `../../docs/ejector/Development_of_an_Analytical_Method_for.pdf`.
-- Bartosiewicz et al. (2004), air-ejector CFD + experiment (validation
-  cross-check). `../../docs/ejector/Bartosiewicz_ejector_2004.pdf`.
+- Henry, Leclaire, Hemidi, Seynhaeve, Bartosiewicz (2007), *Analysis of
+  Supersonic Ejector Operation: Experimental Validation and Two-Phase Aspects*,
+  HEFAT2007, Sun City, paper HF1 -- air-ejector experiment + CFD; Fig. 5 is the
+  subcritical-droop validation target. `../../docs/ejector/Bartosiewicz_ejector_2004.pdf`
+  (filename predates the confirmed citation). Digitized:
+  `validation/ejector/data/henry2007_fig5.py`.
+- Akbarnejad, Ziabasharhagh (2025), *Theoretical Model for Predicting
+  Performance of a Gas Ejector*, Thermal Engineering 72(1) -- air runs with
+  numeric critical + breakdown back-pressure tables (`P_c*`/`P_b0` anchors).
+- Galindo et al. (2020), R1234yf ejector (fitted subcritical + breakdown
+  surface) -- methodology reference only; refrigerant fluid, not an air fixture.
 - ESDU 86030, *Ejectors and jet pumps* (subcritical/breakdown characteristic
-  shape reference).
+  shape reference; optional independent jet-pump cross-check).

--- a/validation/ejector/data/henry2007_fig5.py
+++ b/validation/ejector/data/henry2007_fig5.py
@@ -1,0 +1,133 @@
+"""Digitized Figure 5 of Henry et al. (2007), HEFAT2007.
+
+Henry, Leclaire, Hemidi, Seynhaeve, Bartosiewicz (2007), "Analysis of
+Supersonic Ejector Operation: Experimental Validation and Two-Phase Aspects",
+5th International Conference on Heat Transfer, Fluid Mechanics and
+Thermodynamics (HEFAT2007), Sun City, South Africa, paper HF1. Source PDF:
+docs/ejector/Bartosiewicz_ejector_2004.pdf (filename predates the confirmed
+citation; the paper itself is HEFAT2007, Bartosiewicz corresponding author).
+
+Figure 5, "Ejector characteristics - Experimental results", is the measured
+ejector characteristic for an **air** ejector: entrainment ratio omega versus
+normalized back pressure Pb / P2^0, for three primary driving pressures
+P1^0 = 4, 5, 6 bar. P2^0 is the (roughly constant, near-ambient) secondary
+stagnation pressure; the paper reports a whole-range CFD-vs-experiment
+deviation below 10% for the k-epsilon model.
+
+Why this fixture matters for the operating-regime extension
+-----------------------------------------------------------
+This is the off-design **validation** target for the subcritical-droop model
+(see validation/ejector/OPERATING_REGIMES_DESIGN.md sec 3.2, 4). Each curve
+shows the full regime structure the Tier-1 model must reproduce:
+
+    plateau (critical, omega = omega_crit, flat)   Pb <= P_c*
+    -> knee at the critical back pressure P_c*
+    -> near-linear droop                           P_c* < Pb < P_b0
+    -> breakdown (omega -> 0)                       Pb -> P_b0
+
+and it is **air**, so it is directly comparable against combaero's EOS with no
+refrigerant / CoolProp dependency (unlike the R141b Huang critical fixture).
+It is used as a *validation* cross-check (trend + shape + anchor pressures),
+NOT for parameter fitting -- see the calibration policy in CLAUDE.md and the
+design doc.
+
+Trends across the three curves (all physically expected, and reproduced here):
+  - plateau omega DECREASES with primary pressure (0.760 -> 0.623 -> 0.504):
+    stronger motive flow, lower entrainment ratio.
+  - critical (knee) and breakdown back pressures INCREASE with primary
+    pressure: a stronger motive stream holds a higher back pressure.
+
+Digitization provenance and cross-check
+---------------------------------------
+Points were traced from the figure by hand (source: user, 2026-08-29) and
+cross-checked against docs/ejector/bartosiewicz_fig5.png. Verdict: faithful.
+Plateau values, knee locations, and breakdown endpoints all match the printed
+figure to within trace error. The three breakdown endpoints
+(1.587, 0.052) / (1.829, 0.073) / (2.047, 0.041) and the three plateaus
+(0.760 / 0.623 / 0.504) are the checkable anchors and all agree. The 4 bar
+point at Pb/P2 = 1.463 reads slightly low (omega ~ 0.43 vs ~ 0.45 in the
+figure) but is well within hand-trace tolerance and does not affect the
+plateau / knee / breakdown anchors used for validation.
+
+These are digitized numeric coordinates (facts), stored here in the tracked
+validation tree; the copyrighted source figure lives in the gitignored
+docs/ejector/ PDF directory.
+"""
+
+from __future__ import annotations
+
+# Measured entrainment characteristic omega(Pb / P2^0), air ejector.
+# Keyed by primary driving pressure P1^0 [bar]. Each value is a list of
+# (pb_over_p2, omega) points sorted by ascending normalized back pressure,
+# from the on-design plateau through the subcritical droop to breakdown.
+FIG5_OMEGA_VS_PB: dict[int, list[tuple[float, float]]] = {
+    4: [
+        (1.01784, 0.75929),
+        (1.11808, 0.75618),
+        (1.22182, 0.75784),
+        (1.26374, 0.75364),
+        (1.31762, 0.73344),
+        (1.34460, 0.70491),
+        (1.36490, 0.65866),
+        (1.41794, 0.53507),
+        (1.46277, 0.42732),
+        (1.51233, 0.31245),
+        (1.55957, 0.15760),
+        (1.58734, 0.05161),
+    ],
+    5: [
+        (1.02835, 0.62211),
+        (1.12335, 0.62321),
+        (1.22138, 0.62237),
+        (1.31811, 0.62299),
+        (1.42343, 0.62512),
+        (1.47463, 0.62176),
+        (1.50424, 0.62022),
+        (1.51903, 0.60522),
+        (1.54580, 0.57996),
+        (1.56880, 0.54929),
+        (1.58283, 0.52875),
+        (1.59127, 0.51077),
+        (1.61670, 0.47146),
+        (1.63390, 0.40273),
+        (1.64946, 0.37644),
+        (1.66242, 0.35099),
+        (1.68537, 0.31364),
+        (1.71283, 0.26617),
+        (1.74240, 0.24149),
+        (1.75865, 0.20643),
+        (1.79925, 0.13450),
+        (1.82893, 0.07313),
+    ],
+    6: [
+        (1.03566, 0.50472),
+        (1.13117, 0.50318),
+        (1.22718, 0.50365),
+        (1.31968, 0.50342),
+        (1.41903, 0.50180),
+        (1.48292, 0.50107),
+        (1.52466, 0.49845),
+        (1.60288, 0.48187),
+        (1.64185, 0.46718),
+        (1.71108, 0.43828),
+        (1.80151, 0.37706),
+        (1.89686, 0.31074),
+        (2.00005, 0.15148),
+        (2.04703, 0.04074),
+    ],
+}
+
+# Approximate anchor pressures read off each curve, in normalized units
+# (Pb / P2^0). omega_plateau is the flat critical entrainment ratio;
+# pb_knee is the critical back pressure P_c* (plateau end / start of droop);
+# pb_breakdown is the last measured point (omega near zero ~ P_b0). These are
+# eyeballed from the digitized curve for orientation only -- validation code
+# should derive P_c*/P_b0 from the data via a consistent rule (e.g. plateau
+# departure threshold and omega -> 0 extrapolation), not hard-code these.
+FIG5_ANCHORS: dict[int, dict[str, float]] = {
+    4: {"omega_plateau": 0.760, "pb_knee": 1.30, "pb_breakdown": 1.587},
+    5: {"omega_plateau": 0.623, "pb_knee": 1.51, "pb_breakdown": 1.829},
+    6: {"omega_plateau": 0.504, "pb_knee": 1.55, "pb_breakdown": 2.047},
+}
+
+PRIMARY_PRESSURES_BAR: tuple[int, ...] = (4, 5, 6)


### PR DESCRIPTION
## What

Answers the open question "does the ejector off-design feature need validation data, and does anything in repo come close?" by folding the identified sources into the design note and committing the digitized data.

## Findings (recorded in `OPERATING_REGIMES_DESIGN.md` sec 4)

**Subcritical droop (regime 2)** has good air-fluid data in repo -- not blocked:
- **Henry et al. (2007), HEFAT2007** Fig. 5 -- measured air-ejector characteristic omega(Pb/P2) at 4/5/6 bar primary, full plateau -> knee (P_c*) -> droop -> breakdown (P_b0); <10% CFD-vs-exp deviation. **Digitized and committed** as `validation/ejector/data/henry2007_fig5.py`.
- **Akbarnejad & Ziabasharhagh (2025)**, Thermal Engineering 72(1) -- air runs with numeric critical + breakdown back-pressure tables (direct P_c*/P_b0 anchors). Not yet digitized.

Being air, these need no CoolProp (unlike the R141b critical fixture). Used as **validation, not calibration**.

**Unchoked jet-pump branch (regime 1)** has **no dataset** in repo or the surveyed literature; it is validated **analytically** -- isentropic-nozzle exactness (inherited from the compressible `OrificeElement` path R0 reuses) + conservation + C1 continuity at the choke threshold. No bespoke dataset required.

Galindo 2020 (R1234yf) is structurally ideal but refrigerant -> methodology reference only.

## Digitization cross-check

Traced points cross-checked against `docs/ejector/bartosiewicz_fig5.png`. Plateaus (0.760 / 0.623 / 0.504), knees, and breakdown endpoints (1.587 / 1.829 / 2.047) all match the printed figure. 6-bar rows re-sorted to ascending Pb/P2; one 4-bar point (1.463 -> 0.427) reads slightly low but well within hand-trace tolerance and not on an anchor.

## Citation fix

The source PDF (`Bartosiewicz_ejector_2004.pdf`) is actually **Henry, Leclaire, Hemidi, Seynhaeve, Bartosiewicz (2007), HEFAT2007, paper HF1** -- corrected in the design note.

Docs / validation-data only; no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
