### PR TITLE
chore(biome): sync biome.json + pre-commit pin to 2.5.10

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,5 +63,5 @@ repos:
     rev: v0.6.1
     hooks:
       - id: biome-check
-        additional_dependencies: ["@biomejs/biome@2.5.9"]
+        additional_dependencies: ["@biomejs/biome@2.5.10"]
         files: ^gui/frontend/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,9 +116,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pressure row); the default matches prior hard-coded behaviour so
   existing subclasses (`ConstantKTeeElement`, `MPCEv2Element`) are
   unaffected.
-- **Dev tooling: Biome pinned to 2.5.9 across all three sources.** The
-  Dependabot frontend bump of `@biomejs/biome` (2.5.6 -> 2.5.9 in
-  `gui/frontend/package.json`) is now matched by the `biome.json` `$schema`
+- **Dev tooling: Biome pinned to 2.5.10 across all three sources.** The
+  Dependabot frontend bumps of `@biomejs/biome` (2.5.6 -> 2.5.9 -> 2.5.10 in
+  `gui/frontend/package.json`) are matched by the `biome.json` `$schema`
   and the `.pre-commit-config.yaml` hook pin, per the frontend
   version-sync checklist.
 

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.5.9/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.10/schema.json",
 	"files": {
 		"ignoreUnknown": true,
 		"includes": ["gui/frontend/src/**"]


### PR DESCRIPTION
## What

Completes the frontend version-sync after #267 bumped `@biomejs/biome` to **2.5.10** in `gui/frontend/package.json`. Dependabot only edits npm manifests, so the other two pins in the CLAUDE.md version-sync checklist were left at 2.5.9:

- `biome.json` `$schema` → **2.5.10**
- `.pre-commit-config.yaml` hook pin → `@biomejs/biome@2.5.10`

Same pattern as the earlier 2.5.9 sync (#260). CHANGELOG's existing `[Unreleased]` biome note updated to the cumulative `2.5.6 → 2.5.9 → 2.5.10` range.

Config-only; no source or behaviour change. The other 7 bumps in #267 (axios, lucide-react, @types/*, eslint, typescript-eslint, eslint-plugin-react-refresh) are minor/patch and need no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
