### PR TITLE
feat(ejector): all-regime EjectorElement with whole-element C++ (f,J)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Ejector operating-regime extension wired into `EjectorElement` (Phase 2).**
+  The network `EjectorElement` now resolves all three physical regimes in one
+  C1 Newton-solvable residual system instead of the critical (double-choked)
+  plateau only: critical, subcritical droop, and the unchoked-primary subsonic
+  jet pump. A previously non-converging network -- a low primary mass flow
+  (below the choke threshold at its back pressure) drawing suction against
+  atmospheric -- now converges to the physical jet-pump root (primary Pt floats
+  to ~the back pressure, `dp >= 0`, entrainment ratio `omega ~ 7`) instead of
+  failing or landing on a spurious double-choked root with the primary pressure
+  below the back pressure. The regime is selected smoothly by two smootherstep
+  weights (`s_choke` on `mp / mdot_choked`, `s_sub` on `outlet.Pt / P_c*`) with
+  no branching discontinuity, all four residual rows keep a full analytic
+  Jacobian via the C++ `(f, J)` path, and the critical regime is exactly the
+  limit of the new blend so existing critical-mode behaviour is unchanged.
+  `diagnostics()` now reports the ACTUAL entrainment ratio (`omega = ms/mp`,
+  regime-independent), a `critical_mode` regime flag, the mixing-plane pressure
+  `p_py_pa`, and suppresses the critical-only `p_c_star_pa`/`omega_critical`
+  when the primary is unchoked. `verify_solution_consistent` no longer demotes
+  subcritical/jet-pump solutions (all regimes are now modeled). The GUI ejector
+  warm-start seeds the jet-pump operating point when the primary cannot choke.
+  See `validation/ejector/OPERATING_REGIMES_DESIGN.md` sec 6c/8.3.
 - **Ejector unchoked-primary jet-pump reference closure (Phase 1B of the
   operating-regime extension).** `jet_pump_entrainment_ratio` in
   `combaero.network._ejector_huang1999` (re-exported from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   failing or landing on a spurious double-choked root with the primary pressure
   below the back pressure. The regime is selected smoothly by two smootherstep
   weights (`s_choke` on `mp / mdot_choked`, `s_sub` on `outlet.Pt / P_c*`) with
-  no branching discontinuity, all four residual rows keep a full analytic
-  Jacobian via the C++ `(f, J)` path, and the critical regime is exactly the
-  limit of the new blend so existing critical-mode behaviour is unchanged.
+  no branching discontinuity, and the whole 4-row residual system plus its
+  analytic Jacobian are assembled in C++ (a single
+  `ejector_element_residuals_and_jacobian` chaining the scalar closures through
+  a forward-mode `DualN<9>`), matching the whole-element `(f, J)` practice of
+  the base `MultiPortChamberElement`/`TeeJunctionElement`; the Python element is
+  a thin relabeling shim. The critical regime is exactly the limit of the new
+  blend so existing critical-mode behaviour is unchanged.
   `diagnostics()` now reports the ACTUAL entrainment ratio (`omega = ms/mp`,
   regime-independent), a `critical_mode` regime flag, the mixing-plane pressure
   `p_py_pa`, and suppresses the critical-only `p_c_star_pa`/`omega_critical`

--- a/docs/API_PYTHON.md
+++ b/docs/API_PYTHON.md
@@ -527,27 +527,32 @@ vortex = VortexElement(
 # Diagnostics include: m_dot, omega_rpm, dP_vortex [Pa], Pt_in, Pt_out.
 # If omega_rpm=0 the element is lossless (transparent); r_in=0 omits the on-axis term.
 
-# Supersonic ejector, critical (double-choked) mode only (Huang 1999 entrainment
-# ratio + Kracik & Dvorak 2016 mixing closure for the critical back pressure;
-# see validation/ejector/README.md for derivation, references, and accuracy).
+# Supersonic ejector across all operating regimes -- critical (double-choked),
+# subcritical droop, and unchoked-primary subsonic jet pump -- in one C1 residual
+# system (Huang 1999 entrainment ratio + Kracik & Dvorak 2016 mixing closure;
+# see validation/ejector/README.md and OPERATING_REGIMES_DESIGN.md).
 from combaero.network.ejector_element import EjectorElement
 ejector = EjectorElement(
     "ej1", primary_node="mc_primary", secondary_node="mc_secondary", outlet_node="mc_outlet",
     throat_area=3.14e-5,      # primary nozzle throat area A_t [m^2]
     nozzle_exit_area=1.0e-4,  # primary nozzle exit area A_p1 [m^2], must exceed throat_area
     mixing_area=8.0e-4,       # constant-area mixing section A_3 [m^2], must exceed nozzle_exit_area
-    recovery_efficiency=1.0,  # multiplies the lossless mixed stagnation pressure -> P_c*; not fitted to data
+    recovery_efficiency=1.0,  # multiplies the lossless mixed stagnation pressure; not fitted to data
 )
-# Solved unknowns: ej1.P_jct, repurposed as the critical back pressure P_c* (a
-# diagnostic upper bound, NOT the outlet's actual pressure -- entrainment ratio
-# is by definition independent of back pressure in critical mode). Residuals:
-# choked primary mass flow, entrainment-ratio closure, mass conservation,
-# P_jct - P_c* = 0. Working fluid: combaero's real-fluid EOS (combustion/air
-# species only, no halocarbon refrigerants); gamma/R evaluated live at the
-# entrained-flow choking plane. Jacobian is FD fallback except for the linear
-# mass-conservation row (analytic Jacobians land in the planned C++ port).
-# Use ejector.verify_solution_consistent(sol) post-solve to confirm the
-# operating point is actually critical (outlet Pt <= P_c*).
+# Solved unknowns: the three port mass flows + ej1.P_jct, the single owned scalar,
+# repurposed as the mixing-plane static pressure P_py. Four residual rows: primary
+# C-D nozzle (choked or unchoked), blended entrainment, mass conservation, and a
+# regime-dependent outlet/discharge closure. The regime is picked smoothly by two
+# smootherstep weights (s_choke on mp/mdot_choked, s_sub on outlet.Pt/P_c*): in
+# critical mode the outlet floats free below P_c* and P_jct is the diagnostic
+# recovered stagnation; in the subcritical/jet-pump regimes the outlet is pinned
+# to the ejector's discharge and P_py floats. Working fluid: combaero's real-fluid
+# EOS (combustion/air species only, no halocarbon refrigerants); gamma/R evaluated
+# live at the entrained-flow choking plane. The whole 4-row (f, J) is assembled in
+# C++ (full analytic Jacobian, no FD fallback). diagnostics() reports the actual
+# omega = ms/mp, a critical_mode flag, and (in critical mode) p_c_star_pa.
+# verify_solution_consistent(sol) returns True unconditionally now that every
+# regime is modeled.
 ```
 
 ### Combustion Integration

--- a/gui/backend/graph_builder.py
+++ b/gui/backend/graph_builder.py
@@ -479,6 +479,21 @@ def _seed_ejector_warmstart(
     p_e = float(sb.Pt) if isinstance(sb, PressureBoundary) else None
     p_o = float(ob.Pt) if isinstance(ob, PressureBoundary) else None
 
+    # Regime discriminator for the SEED. The choked-inverse p_g above is the
+    # primary stagnation the mass flow WOULD need to reach sonic at the throat.
+    # If that is below the outlet back pressure, the primary cannot choke (the
+    # forced mass flow is below choked_mass_flow(p_back)); the physical branch
+    # is the subsonic jet pump, where the primary Pt floats to ~the back
+    # pressure and the mixing pressure P_py sits just below it. Seeding the
+    # choked-inverse value there parks Newton in the (spurious) double-choked
+    # basin with Pt_primary < Pb, from which it stalls to nan. Detect that and
+    # seed the jet-pump operating point instead.
+    jetpump_seed = (
+        isinstance(pb, MassFlowBoundary) and p_g is not None and p_o is not None and p_g < p_o
+    )
+    if jetpump_seed:
+        p_g = p_o  # primary floats up to the back pressure (dp ~ 0)
+
     def _seed_node(node_id: str, value: float | None) -> None:
         if value is None or value <= 0.0:
             return
@@ -496,18 +511,28 @@ def _seed_ejector_warmstart(
     _seed_node(secondary_id, p_e)
     _seed_node(outlet_id, p_o)
 
-    if p_g and p_e:
+    # Seed the owned unknown P_jct (repurposed as the mixing-plane pressure
+    # P_py). In the jet-pump regime it sits just below the back pressure; in
+    # the critical regime the diagnostic critical back pressure P_c* is the
+    # right neighbourhood.
+    p_jct_seed: float | None = None
+    if jetpump_seed and p_o is not None:
+        p_jct_seed = 0.99 * p_o
+    elif p_g and p_e:
         try:
             geom = EjectorGeometry(ejector.area_ratio_nozzle, ejector.area_ratio_mix)
-            pc = critical_back_pressure(
-                p_g, t_g, p_e, t_e, geom, gamma, r_gas, ejector.recovery_efficiency
-            ).p_c_pa
-            guess = dict(getattr(ejector, "initial_guess", {}) or {})
-            if not any(k.endswith(".P_jct") for k in guess):
-                guess[f"{ejector.id}.P_jct"] = float(pc)
-                ejector.initial_guess = guess
+            p_jct_seed = float(
+                critical_back_pressure(
+                    p_g, t_g, p_e, t_e, geom, gamma, r_gas, ejector.recovery_efficiency
+                ).p_c_pa
+            )
         except Exception:
-            pass
+            p_jct_seed = None
+    if p_jct_seed is not None and p_jct_seed > 0.0:
+        guess = dict(getattr(ejector, "initial_guess", {}) or {})
+        if not any(k.endswith(".P_jct") for k in guess):
+            guess[f"{ejector.id}.P_jct"] = p_jct_seed
+            ejector.initial_guess = guess
 
 
 def build_network_from_schema(schema: NetworkGraphSchema) -> FlowNetwork:

--- a/include/ejector.h
+++ b/include/ejector.h
@@ -158,9 +158,31 @@ struct EjectorCDNozzleJacobian {
 // C-D nozzle mass flow with its analytic Jacobian w.r.t. the three inputs that
 // are Newton-solved unknowns for EjectorElement (p0 = primary Pt, t0 = primary
 // Tt, p_static_down = P_py). gamma/r_gas/geometry/eta are frozen parameters.
+// The secondary entrained flux reuses this with area_throat = area_exit = A_s.
 EjectorCDNozzleJacobian ejector_cd_nozzle_mass_flow_and_jacobian(
     double p0, double t0, double p_static_down, double area_throat,
     double area_exit, double gamma, double r_gas, double eta, double eps_frac);
+
+struct EjectorJetPumpDischargeJacobian {
+  double p03;      // recovery_efficiency * mixed stagnation pressure
+  double dp03_dp_g;
+  double dp03_dt_g;
+  double dp03_dp_e;
+  double dp03_dt_e;
+  double dp03_dp_py; // d/d(mixing static pressure P_py)
+  double dp03_domega; // d/d(entrainment ratio -- the R1 unknown feeding the mix)
+};
+
+// Jet-pump mixed-flow discharge stagnation: the Kracik & Dvorak mixing closure
+// (reused from the critical path, ejector_critical_back_pressure) evaluated at
+// the SUBSONIC-primary jet-pump state -- both streams expand to the common
+// mixing static P_py (lambda1/lambda2 from that expansion), mixed at ratio
+// omega. The R3 (outlet-pin) building block for the operating-regime element;
+// 1:1 with _mixed_flow_stagnation in _ejector_huang1999.py fed jet-pump
+// lambdas. r_gas cancels (lambda/q are dimensionless), so it is not an input.
+EjectorJetPumpDischargeJacobian ejector_jetpump_discharge_and_jacobian(
+    double p_g, double t_g, double p_e, double t_e, double p_py, double omega,
+    double gamma, double recovery_efficiency);
 
 struct EjectorEntrainmentJacobian {
   EjectorEntrainmentResult value;

--- a/include/ejector.h
+++ b/include/ejector.h
@@ -87,6 +87,18 @@ double ejector_mach_from_area_ratio_supersonic(double area_ratio, double gamma);
 double ejector_choked_mass_flow(double p0, double t0, double area_throat,
                                 double gamma, double r_gas, double eta);
 
+// Converging-diverging nozzle mass flow spanning choked and unchoked, the R0
+// primary residual of the operating-regime extension (see
+// validation/ejector/OPERATING_REGIMES_DESIGN.md sec 3.1). Subsonic exit flux
+// (area_exit, exit static p_static_down) smooth-min'd with the sonic-throat cap
+// (area_throat); the two are equal at the choke threshold so the min is
+// continuous, and the C1 sqrt-smoothing (eps = eps_frac * cap) rounds the
+// corner. 1:1 with cd_nozzle_mass_flow in _ejector_huang1999.py.
+double ejector_cd_nozzle_mass_flow(double p0, double t0, double p_static_down,
+                                   double area_throat, double area_exit,
+                                   double gamma, double r_gas, double eta,
+                                   double eps_frac);
+
 struct EjectorEntrainmentResult {
   double omega;                     // entrainment ratio ms / mp
   double mach_nozzle_exit;          // M_p1
@@ -135,6 +147,20 @@ EjectorCriticalPressureResult ejector_critical_back_pressure(
 std::tuple<double, double, double>
 ejector_choked_mass_flow_and_jacobian(double p0, double t0, double area_throat,
                                       double gamma, double r_gas, double eta);
+
+struct EjectorCDNozzleJacobian {
+  double mdot;        // == ejector_cd_nozzle_mass_flow
+  double dmdot_dp0;   // d/d(primary stagnation pressure)
+  double dmdot_dt0;   // d/d(primary stagnation temperature)
+  double dmdot_dp_py; // d/d(exit/mixing static pressure P_py)
+};
+
+// C-D nozzle mass flow with its analytic Jacobian w.r.t. the three inputs that
+// are Newton-solved unknowns for EjectorElement (p0 = primary Pt, t0 = primary
+// Tt, p_static_down = P_py). gamma/r_gas/geometry/eta are frozen parameters.
+EjectorCDNozzleJacobian ejector_cd_nozzle_mass_flow_and_jacobian(
+    double p0, double t0, double p_static_down, double area_throat,
+    double area_exit, double gamma, double r_gas, double eta, double eps_frac);
 
 struct EjectorEntrainmentJacobian {
   EjectorEntrainmentResult value;

--- a/include/ejector.h
+++ b/include/ejector.h
@@ -27,24 +27,28 @@
 //     Source of the mixing closure ejector_critical_back_pressure
 //     implements (their Eqs. 7-13).
 //
-// Scope: critical (double-choked) operation only. The subcritical,
-// unchoked-primary, and back-flow regimes are not modeled here; their design
-// (choked/unchoked primary R0, subcritical omega droop to the dead-head
-// pressure P_b0, and a subsonic jet-pump mode) lives in
-// validation/ejector/OPERATING_REGIMES_DESIGN.md.
+// Scope. The critical-mode scalar closures (ejector_entrainment_ratio,
+// ejector_critical_back_pressure and their Jacobians) model double-choked
+// operation only; the additional operating-regime closures below
+// (ejector_cd_nozzle_mass_flow, ejector_jetpump_discharge, ...) extend to the
+// subcritical-droop and unchoked-primary jet-pump regimes, and
+// ejector_element_residuals_and_jacobian composes ALL of them into the
+// network element's full 4-row residual system spanning every regime. Design
+// + provenance: validation/ejector/OPERATING_REGIMES_DESIGN.md.
 //
-// Jacobian scope (this header): analytic derivatives w.r.t. the 4
-// thermodynamic inputs (p_g, t_g, p_e, t_e) only -- these are the only
-// inputs that are ever Newton-solved unknowns for the network element
-// consuming this module (EjectorElement). gamma, r_gas, geometry, and
-// recovery_efficiency are element parameters, not solved unknowns, so
-// their derivatives are intentionally not exposed here (deliberate scope
+// Jacobian scope. The critical-mode scalar closures expose derivatives w.r.t.
+// the 4 thermodynamic inputs (p_g, t_g, p_e, t_e) only -- the Newton-solved
+// unknowns for the choked-plateau path; gamma, r_gas, geometry, and
+// recovery_efficiency are frozen element parameters (deliberate scope
 // boundary, not an oversight -- validation/ejector/data/
 // huang1999_reference_data.h separately carries central-difference targets
-// for those too, for a possible future design-sensitivity extension).
+// for those too, for a possible future design-sensitivity extension). The
+// operating-regime closures additionally carry the P_py / omega / m_dot
+// partials the extended element needs, and the whole-element function returns
+// the full Jacobian w.r.t. all nine element unknowns.
 //
-// Key simplification that makes every derivative below exact analytic
-// chain rule (no implicit/root-finding differentiation needed anywhere):
+// Key simplification that makes every critical-mode derivative below exact
+// analytic chain rule (no implicit/root-finding differentiation needed there):
 // the one internal root-find (ejector_mach_from_area_ratio_supersonic, a
 // bisection for the primary nozzle-exit Mach number M_p1) depends ONLY on
 // area_ratio_nozzle and gamma -- neither a Newton-solved unknown here -- so
@@ -54,6 +58,7 @@
 // closed-form) chain.
 // -----------------------------------------------------------------------------
 
+#include <array>
 #include <tuple>
 
 namespace ejector {
@@ -225,5 +230,42 @@ EjectorCriticalPressureJacobian ejector_critical_back_pressure_and_jacobian(
     double p_g, double t_g, double p_e, double t_e,
     const EjectorGeometry& geom, double gamma, double r_gas,
     double recovery_efficiency);
+
+// -----------------------------------------------------------------------------
+// Whole-element (f, J): the 4-row operating-regime residual system.
+//
+// Composes the scalar closures above (choked/C-D nozzle mass flow, critical
+// entrainment + back pressure, jet-pump discharge) into the four coupled rows
+// the network EjectorElement solves, blending the critical/subcritical/unchoked
+// regimes by two smootherstep weights, and returns all four residuals with
+// their analytic Jacobian w.r.t. the nine Newton unknowns -- forward-mode dual
+// (DualN<9>) through the whole blend. This is the C++ home of the assembly
+// (matching the whole-element (f, J) practice of MultiPortChamberElement /
+// TeeJunctionElement); the Python EjectorElement is a thin relabeling shim.
+// 1:1 with EjectorElement.residuals() in ejector_element.py. Full derivation
+// and provenance: validation/ejector/OPERATING_REGIMES_DESIGN.md sec 6c/8.3.
+//
+// Unknown (seed) order -- both `jac` columns and the physical-flow convention:
+//   0 mp        primary mass flow (physical, = -port_mdot_primary)
+//   1 ms        secondary (entrained) mass flow (physical)
+//   2 mdot_out  outlet mass flow (physical)
+//   3 p_g       primary stagnation pressure   Pt_primary
+//   4 t_g       primary stagnation temperature Tt_primary
+//   5 p_e       secondary stagnation pressure  Pt_secondary
+//   6 t_e       secondary stagnation temperature Tt_secondary
+//   7 p_out     outlet-node stagnation pressure Pt_outlet
+//   8 p_py      the owned unknown, repurposed as the mixing-plane static P_py
+struct EjectorElementResidualJacobian {
+  std::array<double, 4> residuals;               // R0..R3
+  std::array<std::array<double, 9>, 4> jacobian; // jacobian[row][seed]
+};
+
+EjectorElementResidualJacobian ejector_element_residuals_and_jacobian(
+    double mp, double ms, double mdot_out, double p_g, double t_g, double p_e,
+    double t_e, double p_out, double p_py, const EjectorGeometry& geom,
+    double area_throat, double area_nozzle_exit, double area_secondary,
+    double gamma, double r_gas, double eta_primary, double eta_secondary,
+    double recovery_efficiency, double eps_frac, double s_choke_lo,
+    double s_choke_hi, double s_sub_lo, double s_sub_hi);
 
 } // namespace combaero::solver

--- a/include/ejector.h
+++ b/include/ejector.h
@@ -163,6 +163,23 @@ EjectorCDNozzleJacobian ejector_cd_nozzle_mass_flow_and_jacobian(
     double p0, double t0, double p_static_down, double area_throat,
     double area_exit, double gamma, double r_gas, double eta, double eps_frac);
 
+struct EjectorCDExitStaticJacobian {
+  double p_py;         // exit static that passes m_dot (== cd_nozzle_exit_static)
+  double dp_py_dm_dot; // d/d(mass flow)
+  double dp_py_dp0;    // d/d(primary stagnation pressure)
+  double dp_py_dt0;    // d/d(primary stagnation temperature)
+};
+
+// Inverse of the C-D nozzle: the exit static P_py that passes m_dot, with its
+// implicit-function-theorem Jacobian. The derived mixing pressure of the
+// operating-regime element's unchoked branch (OPERATING_REGIMES_DESIGN.md sec
+// 6b); 1:1 with cd_nozzle_exit_static in _ejector_huang1999.py. The partials
+// are ratios of the C-D nozzle's own Jacobian at the solved P_py:
+//   dP_py/dm_dot = 1/(dmdot/dP_py),  dP_py/dp0 = -(dmdot/dp0)/(dmdot/dP_py), ...
+EjectorCDExitStaticJacobian ejector_cd_nozzle_exit_static_and_jacobian(
+    double m_dot, double p0, double t0, double area_throat, double area_exit,
+    double gamma, double r_gas, double eta, double eps_frac);
+
 struct EjectorJetPumpDischargeJacobian {
   double p03;      // recovery_efficiency * mixed stagnation pressure
   double dp03_dp_g;

--- a/python/combaero/_core.cpp
+++ b/python/combaero/_core.cpp
@@ -423,6 +423,14 @@ PYBIND11_MODULE(_core, m) {
       .def_readonly("dmdot_dt0", &solver::EjectorCDNozzleJacobian::dmdot_dt0)
       .def_readonly("dmdot_dp_py", &solver::EjectorCDNozzleJacobian::dmdot_dp_py);
 
+  py::class_<solver::EjectorCDExitStaticJacobian>(
+      m, "EjectorCDExitStaticJacobian",
+      "C-D nozzle exit static P_py plus d(P_py)/d(m_dot, p0, t0)")
+      .def_readonly("p_py", &solver::EjectorCDExitStaticJacobian::p_py)
+      .def_readonly("dp_py_dm_dot", &solver::EjectorCDExitStaticJacobian::dp_py_dm_dot)
+      .def_readonly("dp_py_dp0", &solver::EjectorCDExitStaticJacobian::dp_py_dp0)
+      .def_readonly("dp_py_dt0", &solver::EjectorCDExitStaticJacobian::dp_py_dt0);
+
   py::class_<solver::EjectorJetPumpDischargeJacobian>(
       m, "EjectorJetPumpDischargeJacobian",
       "Jet-pump discharge stagnation plus d(p03)/d(p_g, t_g, p_e, t_e, P_py, omega)")
@@ -448,6 +456,13 @@ PYBIND11_MODULE(_core, m) {
         py::arg("eps_frac"),
         "C-D nozzle mass flow (choked/unchoked) with analytic Jacobian.\n\n"
         "Returns: EjectorCDNozzleJacobian (mdot + dmdot_d{p0,t0,p_py})");
+
+  m.def("ejector_cd_nozzle_exit_static_and_jacobian",
+        &solver::ejector_cd_nozzle_exit_static_and_jacobian, py::arg("m_dot"),
+        py::arg("p0"), py::arg("t0"), py::arg("area_throat"), py::arg("area_exit"),
+        py::arg("gamma"), py::arg("r_gas"), py::arg("eta"), py::arg("eps_frac"),
+        "C-D nozzle exit static P_py that passes m_dot, with implicit Jacobian.\n\n"
+        "Returns: EjectorCDExitStaticJacobian (p_py + dp_py_d{m_dot,p0,t0})");
 
   m.def("ejector_jetpump_discharge_and_jacobian",
         &solver::ejector_jetpump_discharge_and_jacobian, py::arg("p_g"),

--- a/python/combaero/_core.cpp
+++ b/python/combaero/_core.cpp
@@ -415,12 +415,46 @@ PYBIND11_MODULE(_core, m) {
       .def_readonly("dpc_dt_e",
                     &solver::EjectorCriticalPressureJacobian::dpc_dt_e);
 
+  py::class_<solver::EjectorCDNozzleJacobian>(
+      m, "EjectorCDNozzleJacobian",
+      "C-D nozzle mass flow plus d(mdot)/d(p0, t0, P_py)")
+      .def_readonly("mdot", &solver::EjectorCDNozzleJacobian::mdot)
+      .def_readonly("dmdot_dp0", &solver::EjectorCDNozzleJacobian::dmdot_dp0)
+      .def_readonly("dmdot_dt0", &solver::EjectorCDNozzleJacobian::dmdot_dt0)
+      .def_readonly("dmdot_dp_py", &solver::EjectorCDNozzleJacobian::dmdot_dp_py);
+
+  py::class_<solver::EjectorJetPumpDischargeJacobian>(
+      m, "EjectorJetPumpDischargeJacobian",
+      "Jet-pump discharge stagnation plus d(p03)/d(p_g, t_g, p_e, t_e, P_py, omega)")
+      .def_readonly("p03", &solver::EjectorJetPumpDischargeJacobian::p03)
+      .def_readonly("dp03_dp_g", &solver::EjectorJetPumpDischargeJacobian::dp03_dp_g)
+      .def_readonly("dp03_dt_g", &solver::EjectorJetPumpDischargeJacobian::dp03_dt_g)
+      .def_readonly("dp03_dp_e", &solver::EjectorJetPumpDischargeJacobian::dp03_dp_e)
+      .def_readonly("dp03_dt_e", &solver::EjectorJetPumpDischargeJacobian::dp03_dt_e)
+      .def_readonly("dp03_dp_py", &solver::EjectorJetPumpDischargeJacobian::dp03_dp_py)
+      .def_readonly("dp03_domega", &solver::EjectorJetPumpDischargeJacobian::dp03_domega);
+
   m.def("ejector_choked_mass_flow_and_jacobian",
         &solver::ejector_choked_mass_flow_and_jacobian, py::arg("p0"),
         py::arg("t0"), py::arg("area_throat"), py::arg("gamma"),
         py::arg("r_gas"), py::arg("eta"),
         "Choked (sonic-throat) mass flow (Huang 1999 Eqs. 1, 7).\n\n"
         "Returns: (mdot, d_mdot_dp0, d_mdot_dt0)");
+
+  m.def("ejector_cd_nozzle_mass_flow_and_jacobian",
+        &solver::ejector_cd_nozzle_mass_flow_and_jacobian, py::arg("p0"),
+        py::arg("t0"), py::arg("p_static_down"), py::arg("area_throat"),
+        py::arg("area_exit"), py::arg("gamma"), py::arg("r_gas"), py::arg("eta"),
+        py::arg("eps_frac"),
+        "C-D nozzle mass flow (choked/unchoked) with analytic Jacobian.\n\n"
+        "Returns: EjectorCDNozzleJacobian (mdot + dmdot_d{p0,t0,p_py})");
+
+  m.def("ejector_jetpump_discharge_and_jacobian",
+        &solver::ejector_jetpump_discharge_and_jacobian, py::arg("p_g"),
+        py::arg("t_g"), py::arg("p_e"), py::arg("t_e"), py::arg("p_py"),
+        py::arg("omega"), py::arg("gamma"), py::arg("recovery_efficiency"),
+        "Jet-pump mixed-flow discharge stagnation with analytic Jacobian.\n\n"
+        "Returns: EjectorJetPumpDischargeJacobian (p03 + dp03_d{p_g,t_g,p_e,t_e,p_py,omega})");
 
   m.def(
       "ejector_entrainment_ratio_and_jacobian",

--- a/python/combaero/_core.cpp
+++ b/python/combaero/_core.cpp
@@ -351,13 +351,16 @@ PYBIND11_MODULE(_core, m) {
         "Border-Carnot turning loss: Pt_in - Pt_out - L*0.5*rho*u^2 = 0 with "
         "L = 4*(1 - cos((3/4)*delta_geom))^2 (Hager sharp-edge correction).");
 
-  // Ejector (critical-mode supersonic ejector on the MultiPortChamberElement
-  // topology). Physics + analytic Jacobians in include/ejector.h; Jacobians
-  // are w.r.t. the 4 thermodynamic inputs (p_g, t_g, p_e, t_e) only -- gamma,
-  // r_gas, geometry and recovery_efficiency are frozen coefficients here.
-  // Area ratios are passed as plain doubles (a lambda builds the internal
-  // EjectorGeometry), keeping the Python call flat like the other solver
-  // bindings.
+  // Ejector (supersonic ejector on the MultiPortChamberElement topology,
+  // spanning the critical / subcritical / unchoked jet-pump regimes). Physics
+  // + analytic Jacobians in include/ejector.h. The critical-mode scalar
+  // closures expose Jacobians w.r.t. the 4 thermodynamic inputs (p_g, t_g,
+  // p_e, t_e); the operating-regime closures add the P_py / omega / m_dot
+  // partials, and ejector_element_residuals_and_jacobian returns the whole
+  // 4-row element system w.r.t. all nine unknowns. gamma, r_gas, geometry and
+  // recovery_efficiency are frozen coefficients here. Area ratios are passed
+  // as plain doubles (a lambda builds the internal EjectorGeometry), keeping
+  // the Python call flat like the other solver bindings.
   py::class_<solver::EjectorEntrainmentResult>(
       m, "EjectorEntrainmentResult",
       "Value outputs of ejector_entrainment_ratio (Huang 1999 Eqs. 1-8)")
@@ -499,6 +502,41 @@ PYBIND11_MODULE(_core, m) {
       py::arg("r_gas"), py::arg("recovery_efficiency"),
       "Critical back pressure P_c* with analytic Jacobian.\n\n"
       "Returns: EjectorCriticalPressureJacobian (value + dpc_d{p_g,t_g,p_e,t_e})");
+
+  py::class_<solver::EjectorElementResidualJacobian>(
+      m, "EjectorElementResidualJacobian",
+      "4-row ejector element residual system + Jacobian. `residuals` is [R0, "
+      "R1, R2, R3]; `jacobian` is jacobian[row][seed] over the 9 unknowns "
+      "(mp, ms, mdot_out, p_g, t_g, p_e, t_e, p_out, p_py).")
+      .def_readonly("residuals", &solver::EjectorElementResidualJacobian::residuals)
+      .def_readonly("jacobian", &solver::EjectorElementResidualJacobian::jacobian);
+
+  m.def(
+      "ejector_element_residuals_and_jacobian",
+      [](double mp, double ms, double mdot_out, double p_g, double t_g,
+         double p_e, double t_e, double p_out, double p_py,
+         double area_ratio_nozzle, double area_ratio_mix, double area_throat,
+         double area_nozzle_exit, double area_secondary, double gamma,
+         double r_gas, double eta_primary, double eta_secondary,
+         double recovery_efficiency, double eps_frac, double s_choke_lo,
+         double s_choke_hi, double s_sub_lo, double s_sub_hi) {
+        return solver::ejector_element_residuals_and_jacobian(
+            mp, ms, mdot_out, p_g, t_g, p_e, t_e, p_out, p_py,
+            solver::EjectorGeometry{area_ratio_nozzle, area_ratio_mix},
+            area_throat, area_nozzle_exit, area_secondary, gamma, r_gas,
+            eta_primary, eta_secondary, recovery_efficiency, eps_frac,
+            s_choke_lo, s_choke_hi, s_sub_lo, s_sub_hi);
+      },
+      py::arg("mp"), py::arg("ms"), py::arg("mdot_out"), py::arg("p_g"),
+      py::arg("t_g"), py::arg("p_e"), py::arg("t_e"), py::arg("p_out"),
+      py::arg("p_py"), py::arg("area_ratio_nozzle"), py::arg("area_ratio_mix"),
+      py::arg("area_throat"), py::arg("area_nozzle_exit"),
+      py::arg("area_secondary"), py::arg("gamma"), py::arg("r_gas"),
+      py::arg("eta_primary"), py::arg("eta_secondary"),
+      py::arg("recovery_efficiency"), py::arg("eps_frac"), py::arg("s_choke_lo"),
+      py::arg("s_choke_hi"), py::arg("s_sub_lo"), py::arg("s_sub_hi"),
+      "Whole-element 4-row ejector (f, J) across all three operating regimes.\n\n"
+      "Returns: EjectorElementResidualJacobian (residuals[4] + jacobian[4][9])");
 
   // Area change elements
   py::class_<combaero::AreaChangeResult>(

--- a/python/combaero/_solver_tools.py
+++ b/python/combaero/_solver_tools.py
@@ -32,6 +32,7 @@ ejector_cd_nozzle_mass_flow_and_jacobian = _core.ejector_cd_nozzle_mass_flow_and
 ejector_cd_nozzle_exit_static_and_jacobian = _core.ejector_cd_nozzle_exit_static_and_jacobian
 ejector_choked_mass_flow_and_jacobian = _core.ejector_choked_mass_flow_and_jacobian
 ejector_critical_back_pressure_and_jacobian = _core.ejector_critical_back_pressure_and_jacobian
+ejector_element_residuals_and_jacobian = _core.ejector_element_residuals_and_jacobian
 ejector_entrainment_ratio_and_jacobian = _core.ejector_entrainment_ratio_and_jacobian
 ejector_jetpump_discharge_and_jacobian = _core.ejector_jetpump_discharge_and_jacobian
 enthalpy_and_jacobian = _core.enthalpy_and_jacobian
@@ -86,6 +87,7 @@ __all__ = [
     "ejector_cd_nozzle_exit_static_and_jacobian",
     "ejector_choked_mass_flow_and_jacobian",
     "ejector_critical_back_pressure_and_jacobian",
+    "ejector_element_residuals_and_jacobian",
     "ejector_entrainment_ratio_and_jacobian",
     "ejector_jetpump_discharge_and_jacobian",
     "enthalpy_and_jacobian",

--- a/python/combaero/_solver_tools.py
+++ b/python/combaero/_solver_tools.py
@@ -29,6 +29,7 @@ dimple_friction_multiplier_and_jacobian = _core.dimple_friction_multiplier_and_j
 dimple_nusselt_enhancement_and_jacobian = _core.dimple_nusselt_enhancement_and_jacobian
 effusion_effectiveness_and_jacobian = _core.effusion_effectiveness_and_jacobian
 ejector_cd_nozzle_mass_flow_and_jacobian = _core.ejector_cd_nozzle_mass_flow_and_jacobian
+ejector_cd_nozzle_exit_static_and_jacobian = _core.ejector_cd_nozzle_exit_static_and_jacobian
 ejector_choked_mass_flow_and_jacobian = _core.ejector_choked_mass_flow_and_jacobian
 ejector_critical_back_pressure_and_jacobian = _core.ejector_critical_back_pressure_and_jacobian
 ejector_entrainment_ratio_and_jacobian = _core.ejector_entrainment_ratio_and_jacobian
@@ -82,6 +83,7 @@ __all__ = [
     "dimple_nusselt_enhancement_and_jacobian",
     "effusion_effectiveness_and_jacobian",
     "ejector_cd_nozzle_mass_flow_and_jacobian",
+    "ejector_cd_nozzle_exit_static_and_jacobian",
     "ejector_choked_mass_flow_and_jacobian",
     "ejector_critical_back_pressure_and_jacobian",
     "ejector_entrainment_ratio_and_jacobian",

--- a/python/combaero/_solver_tools.py
+++ b/python/combaero/_solver_tools.py
@@ -28,9 +28,11 @@ density_and_jacobians = _core.density_and_jacobians
 dimple_friction_multiplier_and_jacobian = _core.dimple_friction_multiplier_and_jacobian
 dimple_nusselt_enhancement_and_jacobian = _core.dimple_nusselt_enhancement_and_jacobian
 effusion_effectiveness_and_jacobian = _core.effusion_effectiveness_and_jacobian
+ejector_cd_nozzle_mass_flow_and_jacobian = _core.ejector_cd_nozzle_mass_flow_and_jacobian
 ejector_choked_mass_flow_and_jacobian = _core.ejector_choked_mass_flow_and_jacobian
 ejector_critical_back_pressure_and_jacobian = _core.ejector_critical_back_pressure_and_jacobian
 ejector_entrainment_ratio_and_jacobian = _core.ejector_entrainment_ratio_and_jacobian
+ejector_jetpump_discharge_and_jacobian = _core.ejector_jetpump_discharge_and_jacobian
 enthalpy_and_jacobian = _core.enthalpy_and_jacobian
 film_cooling_effectiveness_and_jacobian = _core.film_cooling_effectiveness_and_jacobian
 friction_and_jacobian = _core.friction_and_jacobian
@@ -79,9 +81,11 @@ __all__ = [
     "dimple_friction_multiplier_and_jacobian",
     "dimple_nusselt_enhancement_and_jacobian",
     "effusion_effectiveness_and_jacobian",
+    "ejector_cd_nozzle_mass_flow_and_jacobian",
     "ejector_choked_mass_flow_and_jacobian",
     "ejector_critical_back_pressure_and_jacobian",
     "ejector_entrainment_ratio_and_jacobian",
+    "ejector_jetpump_discharge_and_jacobian",
     "enthalpy_and_jacobian",
     "film_cooling_effectiveness_and_jacobian",
     "friction_and_jacobian",

--- a/python/combaero/network/_ejector_huang1999.py
+++ b/python/combaero/network/_ejector_huang1999.py
@@ -250,6 +250,49 @@ def choked_mass_flow(
     return (p0 * area_throat / math.sqrt(t0)) * choke_const * math.sqrt(eta)
 
 
+def cd_nozzle_mass_flow(
+    p0: float,
+    t0: float,
+    p_static_down: float,
+    area_throat: float,
+    area_exit: float,
+    gamma: float,
+    r_gas: float,
+    eta: float = ETA_P,
+    eps_frac: float = 1.0e-3,
+) -> float:
+    """Converging-diverging nozzle mass flow spanning choked and unchoked.
+
+    The R0 primary residual for the operating-regime extension needs one C1
+    relation for both a choked (supersonic) and an unchoked (subsonic venturi)
+    primary. When unchoked, the flow is subsonic throughout and the exit
+    (area_exit, static `p_static_down`) sets the mass flow; when the exit
+    pressure is low enough that the throat reaches sonic, the flow chokes and
+    the mass flow saturates at the sonic-throat value (`choked_mass_flow`,
+    area_throat). The two branches are equal at the choke threshold (the throat
+    passes the same mass either way), so their minimum is continuous; a C1
+    smooth-min (sqrt-rounded, the MPCEv2 idiom) rounds the corner for the
+    Newton Jacobian. See OPERATING_REGIMES_DESIGN.md sec 3.1.
+
+    Parameters mirror `choked_mass_flow` plus `p_static_down` (the exit/mixing
+    static pressure P_py) and `area_exit` (nozzle exit area A_p1).
+    """
+    cap = choked_mass_flow(p0, t0, area_throat, gamma, r_gas, eta)
+    r = p_static_down / p0
+    if r >= 1.0:
+        exit_flux = 0.0
+    else:
+        gm1 = gamma - 1.0
+        gp1 = gamma + 1.0
+        mach = math.sqrt(2.0 / gm1 * (r ** (-gm1 / gamma) - 1.0))
+        flux = mach * (1.0 + 0.5 * gm1 * mach * mach) ** (-gp1 / (2.0 * gm1))
+        exit_flux = (
+            area_exit * p0 / math.sqrt(t0) * math.sqrt(gamma / r_gas) * flux * math.sqrt(eta)
+        )
+    eps = eps_frac * cap
+    return 0.5 * (exit_flux + cap - math.sqrt((exit_flux - cap) ** 2 + eps * eps))
+
+
 def entrainment_ratio(
     p_g: float,
     t_g: float,

--- a/python/combaero/network/_ejector_huang1999.py
+++ b/python/combaero/network/_ejector_huang1999.py
@@ -293,6 +293,50 @@ def cd_nozzle_mass_flow(
     return 0.5 * (exit_flux + cap - math.sqrt((exit_flux - cap) ** 2 + eps * eps))
 
 
+def cd_nozzle_exit_static(
+    m_dot: float,
+    p0: float,
+    t0: float,
+    area_throat: float,
+    area_exit: float,
+    gamma: float,
+    r_gas: float,
+    eta: float = ETA_P,
+    eps_frac: float = 1.0e-3,
+    iterations: int = 200,
+) -> float:
+    """Invert `cd_nozzle_mass_flow` for the exit static pressure P_py that
+    passes `m_dot`.
+
+    The derived mixing pressure of the operating-regime element's unchoked
+    branch: given a forced primary flow and supply, the C-D nozzle's exit
+    static is the P_py the element mixes at (OPERATING_REGIMES_DESIGN.md sec
+    6b). `cd_nozzle_mass_flow` is monotone DECREASING in P_py (higher exit
+    pressure -> less expansion -> less flow: cap at P_py -> p0*r_crit, zero at
+    P_py -> p0), so bisection on ``cd_nozzle_mass_flow(P_py) - m_dot`` in
+    ``(p0*r_crit, p0)`` is unconditionally convergent for any 0 < m_dot < cap.
+
+    Value only (the analytic implicit-function derivatives live in the C++
+    ``ejector_cd_nozzle_exit_static_and_jacobian``, as ratios of the C-D
+    nozzle's own Jacobian: dP_py/dm_dot = 1/(dmdot/dP_py), etc.).
+    """
+    gm1 = gamma - 1.0
+    gp1 = gamma + 1.0
+    r_crit = (2.0 / gp1) ** (gamma / gm1)
+    lo = p0 * r_crit  # cd_nozzle == cap here (max flow)
+    hi = p0 * (1.0 - 1e-12)  # cd_nozzle -> 0 here (no flow)
+    for _ in range(iterations):
+        mid = 0.5 * (lo + hi)
+        if (
+            cd_nozzle_mass_flow(p0, t0, mid, area_throat, area_exit, gamma, r_gas, eta, eps_frac)
+            > m_dot
+        ):
+            lo = mid  # too much flow -> raise P_py
+        else:
+            hi = mid
+    return 0.5 * (lo + hi)
+
+
 def entrainment_ratio(
     p_g: float,
     t_g: float,

--- a/python/combaero/network/ejector_element.py
+++ b/python/combaero/network/ejector_element.py
@@ -79,12 +79,17 @@ Jacobian -- safe because smootherstep is flat at ``s in {0, 1}``).
 ``verify_solution_consistent`` now returns True unconditionally: every regime
 is modeled, so there is no longer a subcritical design point to demote.
 
-Jacobian: FULL analytic, all 4 rows, via the C++ (f, J) path
-(``combaero.network._ejector_huang1999`` is now only the validation
-reference; the hot path calls ``_solver_tools.ejector_*_and_jacobian``,
-i.e. ``include/ejector.h``/``src/ejector.cpp``). The C++ Jacobians are
-exact w.r.t. the four thermodynamic inputs (primary/secondary stagnation
-pressure and temperature) holding ``gamma`` and ``r_gas`` FROZEN. Here
+Assembly: the whole 4-row residual system AND its 9-column analytic
+Jacobian are built in C++ -- a single ``_solver_tools.
+ejector_element_residuals_and_jacobian`` call (``include/ejector.h`` /
+``src/ejector.cpp``) that chains the scalar closures through a forward-mode
+``DualN<9>`` across the regime blend, matching the whole-element (f, J)
+practice of the base ``MultiPortChamberElement`` and ``TeeJunctionElement``.
+``residuals()`` here is only the relabeling shim: physical-flow signs and
+mapping the nine Jacobian seeds to solver column names.
+(``combaero.network._ejector_huang1999`` remains the Python validation
+reference the C++ is kept 1:1 with.) The C++ Jacobian is exact w.r.t. the
+nine Newton unknowns holding ``gamma`` and ``r_gas`` FROZEN. Here
 ``gamma = choke_plane_gamma(secondary.Tt, ...)`` is a weak function of a
 Newton unknown and ``r_gas`` depends only on composition (not a solved
 unknown), so the element Jacobian is exact in the explicit (Pt, Tt)
@@ -131,86 +136,6 @@ def choke_plane_gamma(t_e: float, x: Any, *, iterations: int = 12) -> float:
         t_sy = t_e / ((gamma + 1.0) / 2.0)
         gamma = _real_gamma(t_sy, x)
     return gamma
-
-
-class _D:
-    """Minimal forward-mode dual: a value plus a gradient dict over the element's
-    primitive unknowns (mp, ms, mdot_out, p_g, t_g, p_e, t_e, p_out). Lets the
-    operating-regime residuals be assembled by chaining the C++ closures' analytic
-    partials, exactly mirroring the FD-validated prototype (see
-    validation/ejector/OPERATING_REGIMES_DESIGN.md sec 6b). Only the operators
-    the assembly uses are defined."""
-
-    __slots__ = ("v", "d")
-
-    def __init__(self, v: float, d: dict[str, float] | None = None) -> None:
-        self.v = float(v)
-        self.d = dict(d) if d else {}
-
-    @staticmethod
-    def seed(v: float, name: str) -> _D:
-        return _D(v, {name: 1.0})
-
-    def __add__(self, b: _D | float) -> _D:
-        if isinstance(b, _D):
-            d = dict(self.d)
-            for k, x in b.d.items():
-                d[k] = d.get(k, 0.0) + x
-            return _D(self.v + b.v, d)
-        return _D(self.v + b, self.d)
-
-    __radd__ = __add__
-
-    def __neg__(self) -> _D:
-        return _D(-self.v, {k: -x for k, x in self.d.items()})
-
-    def __sub__(self, b: _D | float) -> _D:
-        return self + (-b if isinstance(b, _D) else -b)
-
-    def __rsub__(self, b: float) -> _D:
-        return (-self) + b
-
-    def __mul__(self, b: _D | float) -> _D:
-        if isinstance(b, _D):
-            d = {k: x * b.v for k, x in self.d.items()}
-            for k, x in b.d.items():
-                d[k] = d.get(k, 0.0) + self.v * x
-            return _D(self.v * b.v, d)
-        return _D(self.v * b, {k: x * b for k, x in self.d.items()})
-
-    __rmul__ = __mul__
-
-    def __truediv__(self, b: _D | float) -> _D:
-        if isinstance(b, _D):
-            inv = 1.0 / b.v
-            d = {k: x * inv for k, x in self.d.items()}
-            for k, x in b.d.items():
-                d[k] = d.get(k, 0.0) - self.v * x * inv * inv
-            return _D(self.v * inv, d)
-        return _D(self.v / b, {k: x / b for k, x in self.d.items()})
-
-
-def _chain(value: float, pairs: list[tuple[float, _D]]) -> _D:
-    """Wrap a C++ closure output: value + sum(partial * grad(input dual))."""
-    d: dict[str, float] = {}
-    for p, inp in pairs:
-        for k, x in inp.d.items():
-            d[k] = d.get(k, 0.0) + p * x
-    return _D(value, d)
-
-
-def _smootherstep(t: _D, lo: float, hi: float) -> _D:
-    """C1 clamped smootherstep on t, saturating to EXACTLY 0/1 outside [lo, hi]
-    (so s_choke = 1 exactly at the primary-choke threshold and critical mode
-    reduces exactly)."""
-    x = (t - lo) / (hi - lo)
-    if x.v <= 0.0:
-        return _D(0.0)
-    if x.v >= 1.0:
-        return _D(1.0)
-    val = x.v * x.v * x.v * (x.v * (x.v * 6.0 - 15.0) + 10.0)
-    dval = 30.0 * x.v * x.v * (x.v - 1.0) * (x.v - 1.0)
-    return _chain(val, [(dval, x)])
 
 
 class EjectorElement(MultiPortChamberElement):
@@ -352,175 +277,72 @@ class EjectorElement(MultiPortChamberElement):
         A_s = self.mixing_area - self.nozzle_exit_area
         rec = self.recovery_efficiency
 
-        # Primitive unknowns as duals. port_mdots are junction-sign convention
+        # Physical port flows. port_mdots are junction-sign convention
         # (positive = out); primary/secondary are inlets (sign -1), so their
-        # physical flow is the negation.
+        # physical flow is the negation. The owned unknown ``P_jct`` is
+        # repurposed as the mixing-plane static pressure P_py (see the module
+        # docstring's residual-design section).
         mp_v = -float(port_mdots[0])
         ms_v = -float(port_mdots[1])
         mo_v = float(port_mdots[2])
-        mp = _D.seed(mp_v, "mp")
-        ms = _D.seed(ms_v, "ms")
-        mdot_out = _D.seed(mo_v, "mdot_out")
-        p_g = _D.seed(primary.Pt, "p_g")
-        t_g = _D.seed(primary.Tt, "t_g")
-        p_e = _D.seed(secondary.Pt, "p_e")
-        t_e = _D.seed(secondary.Tt, "t_e")
-        p_out = _D.seed(outlet.Pt, "p_out")
 
-        # The owned unknown (base name "{id}.P_jct") is repurposed as the
-        # PHYSICAL mixing-plane static pressure P_py -- the pressure common to
-        # the primary jet and the entrained stream at the mixing-chamber
-        # entrance. This is the quantity the two nozzle relations R0/R1 share,
-        # so making it a genuine Newton unknown (instead of deriving it from
-        # the primary nozzle inverse, which makes R0 vacuous in the unchoked
-        # branch) keeps R0 AND R1 live and lets the downstream back pressure
-        # select the operating regime. See OPERATING_REGIMES_DESIGN.md sec 6c.
-        p_py = _D.seed(P_jct, "P_jct")
-
-        # s_choke = smootherstep(mp / cap), cap = choked_mass_flow(Pt_p): 0 when
-        # the primary is clearly unchoked (jet pump), 1 at the choke threshold.
-        cap_v, dcap_dp_g, dcap_dt_g = _solver_tools.ejector_choked_mass_flow_and_jacobian(
-            primary.Pt, primary.Tt, A_t, gamma, r_gas, ETA_P
+        # The 4-row residual system + its 9-column analytic Jacobian are
+        # assembled in C++ (whole-element (f, J), matching the base
+        # MultiPortChamberElement / TeeJunctionElement practice): the scalar
+        # closures are chained through a forward-mode DualN<9> across the
+        # regime blend. See src/ejector.cpp / OPERATING_REGIMES_DESIGN.md sec
+        # 6c. This Python is only the relabeling shim.
+        rj = _solver_tools.ejector_element_residuals_and_jacobian(
+            mp_v,
+            ms_v,
+            mo_v,
+            primary.Pt,
+            primary.Tt,
+            secondary.Pt,
+            secondary.Tt,
+            outlet.Pt,
+            P_jct,
+            arn,
+            arm,
+            A_t,
+            A_e,
+            A_s,
+            gamma,
+            r_gas,
+            ETA_P,
+            ETA_S,
+            rec,
+            self._EPS_FRAC,
+            self._S_CHOKE_LO,
+            self._S_CHOKE_HI,
+            self._S_SUB_LO,
+            self._S_SUB_HI,
         )
-        cap = _chain(cap_v, [(dcap_dp_g, p_g), (dcap_dt_g, t_g)])
-        s = _smootherstep(mp / cap, self._S_CHOKE_LO, self._S_CHOKE_HI)
 
-        # R0: primary C-D nozzle.
-        cd = _solver_tools.ejector_cd_nozzle_mass_flow_and_jacobian(
-            primary.Pt, primary.Tt, p_py.v, A_t, A_e, gamma, r_gas, ETA_P, self._EPS_FRAC
-        )
-        cd_d = _chain(cd.mdot, [(cd.dmdot_dp0, p_g), (cd.dmdot_dt0, t_g), (cd.dmdot_dp_py, p_py)])
-        r0 = mp - cd_d
-
-        # R1/R3 blend the critical (choked-primary) and jet-pump (unchoked)
-        # closures by s = s_choke. The critical closures
-        # (``ejector_entrainment_ratio``, ``ejector_critical_back_pressure``)
-        # assume a choked primary and return NaN once it is not (e.g. Pt_primary
-        # ~ back pressure in the jet-pump root); the jet-pump closure is
-        # symmetric at the choked end. Since smootherstep is FLAT at s in
-        # {0, 1} (both the blend weight AND its gradient vanish there), the
-        # inactive branch contributes exactly zero -- but ``0 * NaN = NaN``
-        # would still poison the value and Jacobian. So evaluate each branch
-        # ONLY where its weight is nonzero; the skipped branch is a hard zero
-        # dual, which is C1-consistent with the flat smootherstep endpoint.
-        omega_eff = ms / mp  # ACTUAL ratio for the discharge (R1 pins ms itself)
-        crit_active = s.v > 0.0
-        jet_active = s.v < 1.0
-
-        if crit_active:
-            entr = _solver_tools.ejector_entrainment_ratio_and_jacobian(
-                primary.Pt, primary.Tt, secondary.Pt, secondary.Tt, arn, arm, gamma
-            )
-            omega_crit = _chain(
-                entr.value.omega,
-                [
-                    (entr.domega_dp_g, p_g),
-                    (entr.domega_dt_g, t_g),
-                    (entr.domega_dp_e, p_e),
-                    (entr.domega_dt_e, t_e),
-                ],
-            )
-            pc = _solver_tools.ejector_critical_back_pressure_and_jacobian(
-                primary.Pt, primary.Tt, secondary.Pt, secondary.Tt, arn, arm, gamma, r_gas, 1.0
-            )
-            p03_crit = _chain(
-                pc.value.p_mixed_stagnation_pa,
-                [(pc.dpc_dp_g, p_g), (pc.dpc_dt_g, t_g), (pc.dpc_dp_e, p_e), (pc.dpc_dt_e, t_e)],
-            )
-            # s_sub: 0 while the outlet stays below the recovered critical back
-            # pressure (genuine critical mode -- outlet floats free), ramping to
-            # 1 as it rises above it (subcritical droop -- outlet pinned).
-            s_sub = _smootherstep(p_out / (rec * p03_crit), self._S_SUB_LO, self._S_SUB_HI)
-        else:
-            omega_crit = _D(0.0)
-            p03_crit = _D(0.0)
-            s_sub = _D(1.0)
-
-        if jet_active:
-            sec = _solver_tools.ejector_cd_nozzle_mass_flow_and_jacobian(
-                secondary.Pt, secondary.Tt, p_py.v, A_s, A_s, gamma, r_gas, ETA_S, self._EPS_FRAC
-            )
-            ms_sec = _chain(
-                sec.mdot, [(sec.dmdot_dp0, p_e), (sec.dmdot_dt0, t_e), (sec.dmdot_dp_py, p_py)]
-            )
-            jp = _solver_tools.ejector_jetpump_discharge_and_jacobian(
-                primary.Pt, primary.Tt, secondary.Pt, secondary.Tt, p_py.v, omega_eff.v, gamma, 1.0
-            )
-            p03_jet = _chain(
-                jp.p03,
-                [
-                    (jp.dp03_dp_g, p_g),
-                    (jp.dp03_dt_g, t_g),
-                    (jp.dp03_dp_e, p_e),
-                    (jp.dp03_dt_e, t_e),
-                    (jp.dp03_dp_py, p_py),
-                    (jp.dp03_domega, omega_eff),
-                ],
-            )
-        else:
-            ms_sec = _D(0.0)
-            p03_jet = _D(0.0)
-
-        # R1: blended entrainment  ms = s*omega_crit*mp + (1-s)*ms_sec.
-        ms_model = s * omega_crit * mp + (1.0 - s) * ms_sec
-        r1 = ms - ms_model
-
-        # R2: mass conservation.
-        r2 = mdot_out - mp - ms
-
-        # R3: regime-dependent closure of the owned unknown.
-        #   discharge = recovery * blend(P_c*, P03_jet) by s_choke.
-        #   w_pin = 1 - s*(1 - s_sub): the weight on the OUTLET-PIN form.
-        #     - jet-pump (s=0):            w_pin = 1  -> pin the outlet
-        #     - subcritical droop (s=1,    w_pin = 1  -> pin the outlet
-        #        outlet > P_c*, s_sub=1)
-        #     - critical (s=1, outlet <    w_pin = 0  -> P_jct diagnostic, outlet
-        #        P_c*, s_sub=0)                          free (set by the network)
-        # In the critical branch the outlet is legitimately below the ejector's
-        # critical back pressure, so pinning it would over-constrain the fixed
-        # downstream boundary; there the owned unknown is instead the diagnostic
-        # recovered stagnation. Everywhere the primary is unchoked, or choked
-        # but back-pressure-loaded above P_c*, the outlet IS what the ejector
-        # sets, so it is pinned and P_py floats to satisfy the two nozzles.
-        discharge = rec * (s * p03_crit + (1.0 - s) * p03_jet)
-        w_pin = 1.0 - s * (1.0 - s_sub)
-        lhs = w_pin * p_out + (1.0 - w_pin) * p_py
-        r3 = lhs - discharge
-
-        # Map each residual's gradient (over the primitives) to solver columns.
-        m_p = f"{self._port_element_ids[0]}.m_dot"
-        m_s = f"{self._port_element_ids[1]}.m_dot"
-        m_out = f"{self._port_element_ids[2]}.m_dot"
-        pn_pt, pn_t = f"{self.primary_node}.Pt", f"{self.primary_node}.T"
-        sn_pt, sn_t = f"{self.secondary_node}.Pt", f"{self.secondary_node}.T"
-        on_pt = f"{self.outlet_node}.Pt"
-        d_mp = -self._port_signs[0]  # d(mp_phys)/d(m_p unknown)
-        d_ms = -self._port_signs[1]
-        d_mo = self._port_signs[2]  # d(mdot_out_phys)/d(m_out unknown)
-        col_of = {
-            "mp": (m_p, d_mp),
-            "ms": (m_s, d_ms),
-            "mdot_out": (m_out, d_mo),
-            "p_g": (pn_pt, 1.0),
-            "t_g": (pn_t, 1.0),
-            "p_e": (sn_pt, 1.0),
-            "t_e": (sn_t, 1.0),
-            "p_out": (on_pt, 1.0),
-            "P_jct": (f"{self.id}.P_jct", 1.0),
-        }
-
-        def to_columns(res: _D) -> dict[str, float]:
+        # Map the 9 Jacobian seeds (in the C++ unknown order) to solver columns.
+        # Inlet flows: the physical flow is -(port unknown), so d(phys)/d(unknown)
+        # = -port_sign; the outlet unknown IS the physical flow (+port_sign).
+        seed_cols: list[tuple[str, float]] = [
+            (f"{self._port_element_ids[0]}.m_dot", -self._port_signs[0]),  # 0 mp
+            (f"{self._port_element_ids[1]}.m_dot", -self._port_signs[1]),  # 1 ms
+            (f"{self._port_element_ids[2]}.m_dot", self._port_signs[2]),  # 2 mdot_out
+            (f"{self.primary_node}.Pt", 1.0),  # 3 p_g
+            (f"{self.primary_node}.T", 1.0),  # 4 t_g
+            (f"{self.secondary_node}.Pt", 1.0),  # 5 p_e
+            (f"{self.secondary_node}.T", 1.0),  # 6 t_e
+            (f"{self.outlet_node}.Pt", 1.0),  # 7 p_out
+            (f"{self.id}.P_jct", 1.0),  # 8 P_py (owned)
+        ]
+        jac: dict[int, dict[str, float]] = {}
+        for row in range(4):
+            grad = rj.jacobian[row]
             cols: dict[str, float] = {}
-            for var, coeff in res.d.items():
-                name, chain = col_of[var]
-                if coeff != 0.0:
-                    cols[name] = cols.get(name, 0.0) + coeff * chain
-            return cols
-
-        return (
-            [r0.v, r1.v, r2.v, r3.v],
-            {0: to_columns(r0), 1: to_columns(r1), 2: to_columns(r2), 3: to_columns(r3)},
-        )
+            for seed, (name, coeff) in enumerate(seed_cols):
+                g = grad[seed]
+                if g != 0.0:
+                    cols[name] = cols.get(name, 0.0) + coeff * g
+            jac[row] = cols
+        return (list(rj.residuals), jac)
 
     def verify_solution_consistent(
         self,

--- a/python/combaero/network/ejector_element.py
+++ b/python/combaero/network/ejector_element.py
@@ -2,31 +2,33 @@
 topology (``MultiPortChamberElement``).
 
 Ports: ``primary_node`` (motive, high-pressure inlet), ``secondary_node``
-(suction/entrained inlet), ``outlet_node``. Critical (double-choked) mode
-only, reusing the validated closed-form physics in
-``combaero.network._ejector_huang1999`` (Huang 1999's entrainment ratio,
-Eqs. 1-8; Kracik & Dvorak 2016's mixing closure for the critical back
+(suction/entrained inlet), ``outlet_node``. Reuses the validated closed-form
+physics in ``combaero.network._ejector_huang1999`` (Huang 1999's entrainment
+ratio, Eqs. 1-8; Kracik & Dvorak 2016's mixing closure for the critical back
 pressure, their Eqs. 7-13) -- see that module's docstring and
 ``validation/ejector/README.md`` for the full derivation, paper references,
 and the accuracy comparison against three alternative closures that were
 also evaluated.
 
-Operating-regime scope and a known limitation. This element models the
-critical (double-choked) plateau ONLY: the primary is assumed choked and the
-entrained flow critical, so ``omega`` is back-pressure-independent. Two
-regimes are therefore NOT yet modeled -- (a) an UNCHOKED primary, which
-occurs when the forced primary mass flow is below the choke threshold
-``mdot_choked(P_back)``; the physical branch there floats the primary Pt to
-just ABOVE the back pressure (forward flow, ``dp >= 0``) and behaves as a
-subsonic jet pump, but ``R0 = mp - ejector_choked_mass_flow(...)`` hard-codes
-the choked branch and instead converges to a self-contradictory root with the
-primary Pt BELOW the back pressure (``verify_solution_consistent`` then demotes
-it) -- and (b) the SUBCRITICAL entrainment droop for ``P_c* < Pt_outlet <
-P_b0``. The full diagnosis (with the reported non-converging case) and the
-proposed extension -- a choked/unchoked ``R0`` reusing the compressible-orifice
-nozzle ``(f, J)``, a C1 smooth-min critical/subcritical ``R1``, and a subsonic
-jet-pump mode, all in one Newton-solvable residual system -- are in
-``validation/ejector/OPERATING_REGIMES_DESIGN.md``.
+Operating regimes. This element resolves all three physical regimes in one
+Newton-solvable residual system (design + provenance in
+``validation/ejector/OPERATING_REGIMES_DESIGN.md``):
+
+  * CRITICAL (double-choked): primary choked, entrained flow critical, so
+    ``omega`` is back-pressure-independent. The outlet floats freely below
+    the ejector's critical back pressure ``P_c*``.
+  * SUBCRITICAL droop: primary still choked but the outlet is pushed above
+    ``P_c*``; the outlet pressure sets the operating point.
+  * UNCHOKED jet pump: the forced primary mass flow is below the choke
+    threshold ``mdot_choked(P_back)``, so the primary Pt floats to just above
+    the back pressure (forward flow, ``dp >= 0``) and the device acts as a
+    subsonic constant-area jet pump (Keenan-Neumann-Lustwerk mixing via
+    ``ejector_jetpump_discharge``).
+
+The regime is selected smoothly (no branching discontinuity) by two
+smootherstep weights: ``s_choke = smootherstep(mp / mdot_choked(Pt_p))``
+(0 = unchoked jet pump, 1 = choked) and ``s_sub`` (0 = outlet below ``P_c*``,
+critical; 1 = outlet above it, subcritical). See the residual design below.
 
 Working fluid: combaero's real-fluid EOS covers combustion/air-relevant
 species only (N2, O2, Ar, CO2, H2O, light hydrocarbons, CO, H2, NH3) -- no
@@ -37,25 +39,45 @@ computed on the fly via ``cb.cp_mass``/``cb.cv_mass``), using the secondary
 stream's own composition -- Huang's model assumes a single working fluid, so
 this is the representative gamma/R for the whole closed form.
 
-Residual design (see the design discussion that produced this; not
-re-derived here). Ports are ``[primary, secondary, outlet]``, so
+Residual design. Ports are ``[primary, secondary, outlet]``, so
 ``_port_signs = [-1, -1, +1]`` and the base class's ``unknowns()``/
-``n_equations()`` (``{id}.P_jct``, N+1 = 4 rows) are inherited unchanged --
-only the row CONTENT is ejector physics instead of impulse-CV physics:
+``n_equations()`` (one owned unknown ``{id}.P_jct``, N+1 = 4 rows) are
+inherited unchanged -- but the owned unknown is REPURPOSED as the physical
+mixing-plane static pressure ``P_py`` (the pressure common to the primary jet
+and the entrained stream at the mixing-chamber entrance), and the row content
+is ejector physics instead of impulse-CV physics. With ``s = s_choke``:
 
-    R0 = mp - mdot_choked(Pt_primary, Tt_primary, throat_area, gamma, eta_p)
-    R1 = ms - omega(Pt_primary, Tt_primary, Pt_secondary, Tt_secondary) * mp
+    R0 = mp - cd_nozzle(Pt_p, P_py, A_t, A_e)      (primary C-D nozzle)
+    R1 = ms - [s*omega_crit*mp + (1-s)*ms_sec]     (blended entrainment)
     R2 = mdot_out - mp - ms                        (mass conservation)
-    R3 = P_jct - recovery_efficiency * P_c*(...)   (P_jct repurposed as P_c*)
+    R3 = [w_pin*Pt_outlet + (1-w_pin)*P_py] - recovery*discharge
 
-``P_jct`` is NOT tied to the outlet port's actual pressure: in critical mode
-the entrainment ratio is by definition independent of back pressure, so the
-outlet's actual Pt is legitimately external (set by the downstream network,
-same as any ordinary node) -- asserting ``Pt_outlet = P_c*`` would
-over-constrain it. ``P_jct`` is instead a diagnostic upper bound, checked
-post-solve by ``verify_solution_consistent`` (Pt_outlet must not exceed it --
-violation means the design point is subcritical, which this element does not
-model).
+``P_py`` is a genuine Newton unknown (not derived): it is the quantity the two
+nozzle relations R0/R1 share, so making it free keeps BOTH live and lets the
+downstream back pressure select the operating regime. ``R0``'s C-D nozzle
+smooth-mins the subsonic-flux and sonic-cap branches, so it is choked or
+unchoked automatically as ``P_py`` moves. ``discharge = recovery * (s*P_c* +
+(1-s)*P03_jetpump)`` blends the critical and jet-pump mixing closures; each is
+evaluated ONLY where its weight is nonzero (the critical closures return NaN
+for an unchoked primary, and ``0 * NaN = NaN`` would otherwise poison the
+Jacobian -- safe because smootherstep is flat at ``s in {0, 1}``).
+
+``R3`` closes the system differently per regime via
+``w_pin = 1 - s*(1 - s_sub)`` (the weight on the outlet-pin form):
+
+  * jet pump (s=0) and subcritical droop (s=1, s_sub=1): ``w_pin = 1`` ->
+    ``Pt_outlet = recovery*discharge``. The outlet is what the ejector sets;
+    the downstream boundary then forces ``P_py`` through this pin, and R0/R1
+    set the primary Pt and entrainment. This pin is what excludes the spurious
+    double-choked root (primary Pt below the back pressure) that a
+    back-pressure-independent closure would otherwise admit.
+  * critical (s=1, outlet below ``P_c*``, s_sub=0): ``w_pin = 0`` ->
+    ``P_py = recovery*P_c*`` (a diagnostic) and the outlet floats FREE, set by
+    the downstream network. Pinning it here would over-constrain the fixed
+    outlet boundary (``Pt_outlet < P_c*`` legitimately).
+
+``verify_solution_consistent`` now returns True unconditionally: every regime
+is modeled, so there is no longer a subcritical design point to demote.
 
 Jacobian: FULL analytic, all 4 rows, via the C++ (f, J) path
 (``combaero.network._ejector_huang1999`` is now only the validation
@@ -77,11 +99,12 @@ input, so its d/dt_e central-difference targets also hold gamma fixed).
 
 from __future__ import annotations
 
+import math
 from typing import Any
 
 import combaero as cb
 from combaero import _solver_tools
-from combaero.network._ejector_huang1999 import ETA_P, EjectorGeometry
+from combaero.network._ejector_huang1999 import ETA_P, ETA_S, EjectorGeometry
 from combaero.network.components import MultiPortChamberElement, NetworkMixtureState
 
 
@@ -110,8 +133,90 @@ def choke_plane_gamma(t_e: float, x: Any, *, iterations: int = 12) -> float:
     return gamma
 
 
+class _D:
+    """Minimal forward-mode dual: a value plus a gradient dict over the element's
+    primitive unknowns (mp, ms, mdot_out, p_g, t_g, p_e, t_e, p_out). Lets the
+    operating-regime residuals be assembled by chaining the C++ closures' analytic
+    partials, exactly mirroring the FD-validated prototype (see
+    validation/ejector/OPERATING_REGIMES_DESIGN.md sec 6b). Only the operators
+    the assembly uses are defined."""
+
+    __slots__ = ("v", "d")
+
+    def __init__(self, v: float, d: dict[str, float] | None = None) -> None:
+        self.v = float(v)
+        self.d = dict(d) if d else {}
+
+    @staticmethod
+    def seed(v: float, name: str) -> _D:
+        return _D(v, {name: 1.0})
+
+    def __add__(self, b: _D | float) -> _D:
+        if isinstance(b, _D):
+            d = dict(self.d)
+            for k, x in b.d.items():
+                d[k] = d.get(k, 0.0) + x
+            return _D(self.v + b.v, d)
+        return _D(self.v + b, self.d)
+
+    __radd__ = __add__
+
+    def __neg__(self) -> _D:
+        return _D(-self.v, {k: -x for k, x in self.d.items()})
+
+    def __sub__(self, b: _D | float) -> _D:
+        return self + (-b if isinstance(b, _D) else -b)
+
+    def __rsub__(self, b: float) -> _D:
+        return (-self) + b
+
+    def __mul__(self, b: _D | float) -> _D:
+        if isinstance(b, _D):
+            d = {k: x * b.v for k, x in self.d.items()}
+            for k, x in b.d.items():
+                d[k] = d.get(k, 0.0) + self.v * x
+            return _D(self.v * b.v, d)
+        return _D(self.v * b, {k: x * b for k, x in self.d.items()})
+
+    __rmul__ = __mul__
+
+    def __truediv__(self, b: _D | float) -> _D:
+        if isinstance(b, _D):
+            inv = 1.0 / b.v
+            d = {k: x * inv for k, x in self.d.items()}
+            for k, x in b.d.items():
+                d[k] = d.get(k, 0.0) - self.v * x * inv * inv
+            return _D(self.v * inv, d)
+        return _D(self.v / b, {k: x / b for k, x in self.d.items()})
+
+
+def _chain(value: float, pairs: list[tuple[float, _D]]) -> _D:
+    """Wrap a C++ closure output: value + sum(partial * grad(input dual))."""
+    d: dict[str, float] = {}
+    for p, inp in pairs:
+        for k, x in inp.d.items():
+            d[k] = d.get(k, 0.0) + p * x
+    return _D(value, d)
+
+
+def _smootherstep(t: _D, lo: float, hi: float) -> _D:
+    """C1 clamped smootherstep on t, saturating to EXACTLY 0/1 outside [lo, hi]
+    (so s_choke = 1 exactly at the primary-choke threshold and critical mode
+    reduces exactly)."""
+    x = (t - lo) / (hi - lo)
+    if x.v <= 0.0:
+        return _D(0.0)
+    if x.v >= 1.0:
+        return _D(1.0)
+    val = x.v * x.v * x.v * (x.v * (x.v * 6.0 - 15.0) + 10.0)
+    dval = 30.0 * x.v * x.v * (x.v - 1.0) * (x.v - 1.0)
+    return _chain(val, [(dval, x)])
+
+
 class EjectorElement(MultiPortChamberElement):
-    """Critical-mode supersonic ejector: 2 inlets (primary, secondary), 1 outlet."""
+    """Supersonic ejector across operating regimes: 2 inlets (primary, secondary),
+    1 outlet. Critical (double-choked), subcritical, and unchoked-primary
+    (subsonic jet-pump) in one C1 residual system."""
 
     def __init__(
         self,
@@ -216,121 +321,218 @@ class EjectorElement(MultiPortChamberElement):
         solver.py scaling block this overrides."""
         return ["mdot", "mdot", "mdot", "p"]
 
+    # smootherstep window for s_choke, on mp / choked_mass_flow(Pt_p): s = 0
+    # when clearly unchoked (jet pump), 1 exactly at the primary-choke threshold.
+    _S_CHOKE_LO = 0.90
+    _S_CHOKE_HI = 0.999
+    # s_sub window on outlet.Pt / (recovery * P_c*): 0 (critical, outlet free)
+    # below the recovered critical back pressure, 1 (subcritical, outlet pinned)
+    # above it. Centred on 1 with a narrow band for a sharp-but-smooth handover.
+    _S_SUB_LO = 0.98
+    _S_SUB_HI = 1.02
+    _EPS_FRAC = 1.0e-3  # C-D nozzle / secondary-flux smooth-min rounding
+
     def residuals(
         self,
         states: list[NetworkMixtureState],
         P_jct: float,
         port_mdots: list[float],
     ) -> tuple[list[float], dict[int, dict[str, float]]]:
-        primary, secondary, _outlet = states
+        primary, secondary, outlet = states
 
-        # gamma/r_gas: frozen coefficients (see module docstring). gamma is a
-        # weak function of secondary.Tt via the Python fixed point; r_gas is a
-        # pure function of composition (not a Newton unknown). Recomputed each
-        # call, so the converged root is exact; the C++ Jacobians below hold
-        # both fixed, dropping only the tiny implicit d(gamma)/d(Tt) term.
+        # gamma/r_gas: frozen coefficients (see module docstring). Recomputed
+        # each call so the converged root is exact; the closure Jacobians hold
+        # both fixed (drops only the tiny implicit d(gamma)/d(Tt) term).
         gamma = choke_plane_gamma(secondary.Tt, secondary.X)
         r_gas = float(cb.specific_gas_constant(secondary.X))
         arn = self.area_ratio_nozzle
         arm = self.area_ratio_mix
+        A_t = self.throat_area
+        A_e = self.nozzle_exit_area
+        A_s = self.mixing_area - self.nozzle_exit_area
+        rec = self.recovery_efficiency
 
-        mp_choked, dmp_choked_dp_g, dmp_choked_dt_g = (
-            _solver_tools.ejector_choked_mass_flow_and_jacobian(
-                primary.Pt, primary.Tt, self.throat_area, gamma, r_gas, ETA_P
+        # Primitive unknowns as duals. port_mdots are junction-sign convention
+        # (positive = out); primary/secondary are inlets (sign -1), so their
+        # physical flow is the negation.
+        mp_v = -float(port_mdots[0])
+        ms_v = -float(port_mdots[1])
+        mo_v = float(port_mdots[2])
+        mp = _D.seed(mp_v, "mp")
+        ms = _D.seed(ms_v, "ms")
+        mdot_out = _D.seed(mo_v, "mdot_out")
+        p_g = _D.seed(primary.Pt, "p_g")
+        t_g = _D.seed(primary.Tt, "t_g")
+        p_e = _D.seed(secondary.Pt, "p_e")
+        t_e = _D.seed(secondary.Tt, "t_e")
+        p_out = _D.seed(outlet.Pt, "p_out")
+
+        # The owned unknown (base name "{id}.P_jct") is repurposed as the
+        # PHYSICAL mixing-plane static pressure P_py -- the pressure common to
+        # the primary jet and the entrained stream at the mixing-chamber
+        # entrance. This is the quantity the two nozzle relations R0/R1 share,
+        # so making it a genuine Newton unknown (instead of deriving it from
+        # the primary nozzle inverse, which makes R0 vacuous in the unchoked
+        # branch) keeps R0 AND R1 live and lets the downstream back pressure
+        # select the operating regime. See OPERATING_REGIMES_DESIGN.md sec 6c.
+        p_py = _D.seed(P_jct, "P_jct")
+
+        # s_choke = smootherstep(mp / cap), cap = choked_mass_flow(Pt_p): 0 when
+        # the primary is clearly unchoked (jet pump), 1 at the choke threshold.
+        cap_v, dcap_dp_g, dcap_dt_g = _solver_tools.ejector_choked_mass_flow_and_jacobian(
+            primary.Pt, primary.Tt, A_t, gamma, r_gas, ETA_P
+        )
+        cap = _chain(cap_v, [(dcap_dp_g, p_g), (dcap_dt_g, t_g)])
+        s = _smootherstep(mp / cap, self._S_CHOKE_LO, self._S_CHOKE_HI)
+
+        # R0: primary C-D nozzle.
+        cd = _solver_tools.ejector_cd_nozzle_mass_flow_and_jacobian(
+            primary.Pt, primary.Tt, p_py.v, A_t, A_e, gamma, r_gas, ETA_P, self._EPS_FRAC
+        )
+        cd_d = _chain(cd.mdot, [(cd.dmdot_dp0, p_g), (cd.dmdot_dt0, t_g), (cd.dmdot_dp_py, p_py)])
+        r0 = mp - cd_d
+
+        # R1/R3 blend the critical (choked-primary) and jet-pump (unchoked)
+        # closures by s = s_choke. The critical closures
+        # (``ejector_entrainment_ratio``, ``ejector_critical_back_pressure``)
+        # assume a choked primary and return NaN once it is not (e.g. Pt_primary
+        # ~ back pressure in the jet-pump root); the jet-pump closure is
+        # symmetric at the choked end. Since smootherstep is FLAT at s in
+        # {0, 1} (both the blend weight AND its gradient vanish there), the
+        # inactive branch contributes exactly zero -- but ``0 * NaN = NaN``
+        # would still poison the value and Jacobian. So evaluate each branch
+        # ONLY where its weight is nonzero; the skipped branch is a hard zero
+        # dual, which is C1-consistent with the flat smootherstep endpoint.
+        omega_eff = ms / mp  # ACTUAL ratio for the discharge (R1 pins ms itself)
+        crit_active = s.v > 0.0
+        jet_active = s.v < 1.0
+
+        if crit_active:
+            entr = _solver_tools.ejector_entrainment_ratio_and_jacobian(
+                primary.Pt, primary.Tt, secondary.Pt, secondary.Tt, arn, arm, gamma
             )
-        )
-        entr = _solver_tools.ejector_entrainment_ratio_and_jacobian(
-            primary.Pt, primary.Tt, secondary.Pt, secondary.Tt, arn, arm, gamma
-        )
-        omega = entr.value.omega
-        pc = _solver_tools.ejector_critical_back_pressure_and_jacobian(
-            primary.Pt,
-            primary.Tt,
-            secondary.Pt,
-            secondary.Tt,
-            arn,
-            arm,
-            gamma,
-            r_gas,
-            self.recovery_efficiency,
-        )
-        pc_star = pc.value.p_c_pa
+            omega_crit = _chain(
+                entr.value.omega,
+                [
+                    (entr.domega_dp_g, p_g),
+                    (entr.domega_dt_g, t_g),
+                    (entr.domega_dp_e, p_e),
+                    (entr.domega_dt_e, t_e),
+                ],
+            )
+            pc = _solver_tools.ejector_critical_back_pressure_and_jacobian(
+                primary.Pt, primary.Tt, secondary.Pt, secondary.Tt, arn, arm, gamma, r_gas, 1.0
+            )
+            p03_crit = _chain(
+                pc.value.p_mixed_stagnation_pa,
+                [(pc.dpc_dp_g, p_g), (pc.dpc_dt_g, t_g), (pc.dpc_dp_e, p_e), (pc.dpc_dt_e, t_e)],
+            )
+            # s_sub: 0 while the outlet stays below the recovered critical back
+            # pressure (genuine critical mode -- outlet floats free), ramping to
+            # 1 as it rises above it (subcritical droop -- outlet pinned).
+            s_sub = _smootherstep(p_out / (rec * p03_crit), self._S_SUB_LO, self._S_SUB_HI)
+        else:
+            omega_crit = _D(0.0)
+            p03_crit = _D(0.0)
+            s_sub = _D(1.0)
 
-        # port_mdots are junction-sign convention (positive = out of
-        # junction); primary/secondary are inlets (sign -1), so their
-        # physical mass flow is the negation.
-        mp = -float(port_mdots[0])
-        ms = -float(port_mdots[1])
-        mdot_out = float(port_mdots[2])
+        if jet_active:
+            sec = _solver_tools.ejector_cd_nozzle_mass_flow_and_jacobian(
+                secondary.Pt, secondary.Tt, p_py.v, A_s, A_s, gamma, r_gas, ETA_S, self._EPS_FRAC
+            )
+            ms_sec = _chain(
+                sec.mdot, [(sec.dmdot_dp0, p_e), (sec.dmdot_dt0, t_e), (sec.dmdot_dp_py, p_py)]
+            )
+            jp = _solver_tools.ejector_jetpump_discharge_and_jacobian(
+                primary.Pt, primary.Tt, secondary.Pt, secondary.Tt, p_py.v, omega_eff.v, gamma, 1.0
+            )
+            p03_jet = _chain(
+                jp.p03,
+                [
+                    (jp.dp03_dp_g, p_g),
+                    (jp.dp03_dt_g, t_g),
+                    (jp.dp03_dp_e, p_e),
+                    (jp.dp03_dt_e, t_e),
+                    (jp.dp03_dp_py, p_py),
+                    (jp.dp03_domega, omega_eff),
+                ],
+            )
+        else:
+            ms_sec = _D(0.0)
+            p03_jet = _D(0.0)
 
-        r0 = mp - mp_choked
-        r1 = ms - omega * mp
-        r2 = mdot_out - mp - ms  # == sum(port_mdots); mass conservation
-        r3 = P_jct - pc_star
+        # R1: blended entrainment  ms = s*omega_crit*mp + (1-s)*ms_sec.
+        ms_model = s * omega_crit * mp + (1.0 - s) * ms_sec
+        r1 = ms - ms_model
 
-        # Full analytic Jacobian. Column-name conventions (see solver.py's
-        # element jac-relay loop): port mass flows are direct unknowns keyed
-        # "{outer_id}.m_dot"; a physical port flow d(mp) = -_port_signs[i]
-        # because port_mdots[i] = _port_signs[i] * (that unknown). Port
-        # stagnation pressures "{node}.Pt" are direct unknowns; port
-        # stagnation temperatures are emitted as "{node}.T" and chained
-        # through the solver's temperature relay (same convention the
-        # compressible orifice uses: pass Tt, key the column .T). "{id}.P_jct"
-        # is this element's own direct unknown.
+        # R2: mass conservation.
+        r2 = mdot_out - mp - ms
+
+        # R3: regime-dependent closure of the owned unknown.
+        #   discharge = recovery * blend(P_c*, P03_jet) by s_choke.
+        #   w_pin = 1 - s*(1 - s_sub): the weight on the OUTLET-PIN form.
+        #     - jet-pump (s=0):            w_pin = 1  -> pin the outlet
+        #     - subcritical droop (s=1,    w_pin = 1  -> pin the outlet
+        #        outlet > P_c*, s_sub=1)
+        #     - critical (s=1, outlet <    w_pin = 0  -> P_jct diagnostic, outlet
+        #        P_c*, s_sub=0)                          free (set by the network)
+        # In the critical branch the outlet is legitimately below the ejector's
+        # critical back pressure, so pinning it would over-constrain the fixed
+        # downstream boundary; there the owned unknown is instead the diagnostic
+        # recovered stagnation. Everywhere the primary is unchoked, or choked
+        # but back-pressure-loaded above P_c*, the outlet IS what the ejector
+        # sets, so it is pinned and P_py floats to satisfy the two nozzles.
+        discharge = rec * (s * p03_crit + (1.0 - s) * p03_jet)
+        w_pin = 1.0 - s * (1.0 - s_sub)
+        lhs = w_pin * p_out + (1.0 - w_pin) * p_py
+        r3 = lhs - discharge
+
+        # Map each residual's gradient (over the primitives) to solver columns.
         m_p = f"{self._port_element_ids[0]}.m_dot"
         m_s = f"{self._port_element_ids[1]}.m_dot"
-        pn_pt = f"{self.primary_node}.Pt"
-        pn_t = f"{self.primary_node}.T"
-        sn_pt = f"{self.secondary_node}.Pt"
-        sn_t = f"{self.secondary_node}.T"
-        # d(mp)/d(m_p unknown) and d(ms)/d(m_s unknown).
-        d_mp = -self._port_signs[0]
+        m_out = f"{self._port_element_ids[2]}.m_dot"
+        pn_pt, pn_t = f"{self.primary_node}.Pt", f"{self.primary_node}.T"
+        sn_pt, sn_t = f"{self.secondary_node}.Pt", f"{self.secondary_node}.T"
+        on_pt = f"{self.outlet_node}.Pt"
+        d_mp = -self._port_signs[0]  # d(mp_phys)/d(m_p unknown)
         d_ms = -self._port_signs[1]
-
-        row0 = {
-            m_p: d_mp,
-            pn_pt: -dmp_choked_dp_g,
-            pn_t: -dmp_choked_dt_g,
-        }
-        row1 = {
-            m_s: d_ms,
-            m_p: -omega * d_mp,
-            pn_pt: -mp * entr.domega_dp_g,
-            pn_t: -mp * entr.domega_dt_g,
-            sn_pt: -mp * entr.domega_dp_e,
-            sn_t: -mp * entr.domega_dt_e,
-        }
-        mass_row: dict[str, float] = {}
-        for i in range(self.N):
-            mdot_var = f"{self._port_element_ids[i]}.m_dot"
-            mass_row[mdot_var] = mass_row.get(mdot_var, 0.0) + self._port_signs[i]
-        row3 = {
-            f"{self.id}.P_jct": 1.0,
-            pn_pt: -pc.dpc_dp_g,
-            pn_t: -pc.dpc_dt_g,
-            sn_pt: -pc.dpc_dp_e,
-            sn_t: -pc.dpc_dt_e,
+        d_mo = self._port_signs[2]  # d(mdot_out_phys)/d(m_out unknown)
+        col_of = {
+            "mp": (m_p, d_mp),
+            "ms": (m_s, d_ms),
+            "mdot_out": (m_out, d_mo),
+            "p_g": (pn_pt, 1.0),
+            "t_g": (pn_t, 1.0),
+            "p_e": (sn_pt, 1.0),
+            "t_e": (sn_t, 1.0),
+            "p_out": (on_pt, 1.0),
+            "P_jct": (f"{self.id}.P_jct", 1.0),
         }
 
-        return [r0, r1, r2, r3], {0: row0, 1: row1, 2: mass_row, 3: row3}
+        def to_columns(res: _D) -> dict[str, float]:
+            cols: dict[str, float] = {}
+            for var, coeff in res.d.items():
+                name, chain = col_of[var]
+                if coeff != 0.0:
+                    cols[name] = cols.get(name, 0.0) + coeff * chain
+            return cols
+
+        return (
+            [r0.v, r1.v, r2.v, r3.v],
+            {0: to_columns(r0), 1: to_columns(r1), 2: to_columns(r2), 3: to_columns(r3)},
+        )
 
     def verify_solution_consistent(
         self,
         sol: dict[str, float],
         rel_tol: float = 1e-3,
     ) -> bool:
-        """Post-solve check: the outlet's actual back pressure must not
-        exceed the computed critical back pressure P_c* (stored in
-        ``{id}.P_jct``). A violation means the converged operating point is
-        subcritical, which this element does not model (critical-mode
-        omega, used in the residuals, is only valid up to P_c*). Missing
-        keys => True (do not police incomplete dicts, matching the
-        convention used elsewhere in this module)."""
-        pc_key = f"{self.id}.P_jct"
-        pt_key = f"{self.outlet_node}.Pt"
-        if pc_key not in sol or pt_key not in sol:
-            return True
-        return float(sol[pt_key]) <= float(sol[pc_key]) * (1.0 + rel_tol)
+        """No post-solve demotion. The element now models the critical,
+        subcritical, and unchoked-primary (jet-pump) regimes in one C1 residual
+        system, so a converged root is physical by construction (the old
+        ``outlet.Pt <= P_c*`` check demoted valid subcritical/jet-pump points
+        and is dropped -- see OPERATING_REGIMES_DESIGN.md sec 6b)."""
+        return True
 
     def diagnostics(
         self,
@@ -346,24 +548,83 @@ class EjectorElement(MultiPortChamberElement):
 
         gamma = choke_plane_gamma(secondary.Tt, secondary.X)
         r_gas = float(cb.specific_gas_constant(secondary.X))
-        entr = _solver_tools.ejector_entrainment_ratio_and_jacobian(
-            primary.Pt,
-            primary.Tt,
-            secondary.Pt,
-            secondary.Tt,
-            self.area_ratio_nozzle,
-            self.area_ratio_mix,
-            gamma,
-        )
-
         diag["gamma"] = gamma
         diag["r_gas"] = r_gas
-        diag["omega"] = entr.value.omega
-        diag["p_c_star_pa"] = float(P_jct)
         diag["outlet_pt_pa"] = float(outlet.Pt)
-        diag["critical_mode"] = 1.0 if float(outlet.Pt) <= float(P_jct) else 0.0
+        diag["p_py_pa"] = float(P_jct)  # owned unknown = mixing-plane static
+
+        # Operating regime: s_choke = smootherstep(mp/cap), reported so the GUI
+        # can label critical (1) / jet-pump (0) / transition, plus the actual
+        # entrainment ratio and the choked-mode reference quantities. The
+        # critical closures (omega_critical, P_c*) assume a choked primary and
+        # return NaN in the jet-pump regime, so they are reported only when
+        # meaningful (s_choke > 0).
         if port_mdots is not None and len(port_mdots) == self.N:
-            diag["m_dot_primary"] = -float(port_mdots[0])
-            diag["m_dot_secondary"] = -float(port_mdots[1])
+            mp = -float(port_mdots[0])
+            ms = -float(port_mdots[1])
+            cap = _solver_tools.ejector_choked_mass_flow_and_jacobian(
+                primary.Pt, primary.Tt, self.throat_area, gamma, r_gas, ETA_P
+            )[0]
+            t = (mp / cap - self._S_CHOKE_LO) / (self._S_CHOKE_HI - self._S_CHOKE_LO)
+            t = min(max(t, 0.0), 1.0)
+            s_choke = t * t * t * (t * (t * 6.0 - 15.0) + 10.0)
+            diag["s_choke"] = s_choke
+            diag["m_dot_primary"] = mp
+            diag["m_dot_secondary"] = ms
             diag["m_dot_outlet"] = float(port_mdots[2])
+            # ACTUAL entrainment ratio -- regime-independent, always valid.
+            diag["omega"] = ms / mp if mp != 0.0 else float("nan")
+            # Regime label. critical_mode = 1 only when the primary is choked
+            # AND the outlet sits below the ejector's critical back pressure
+            # (double-choked plateau); 0 in the subcritical-droop and unchoked
+            # jet-pump regimes, where the outlet pressure sets the operating
+            # point.
+            critical_mode = 0.0
+            if s_choke > 0.0:
+                omega_c = self._critical_omega(primary, secondary, gamma)
+                p_c_star = self._critical_back_pressure(primary, secondary, gamma, r_gas)
+                diag["omega_critical"] = omega_c
+                diag["p_c_star_pa"] = p_c_star
+                if s_choke >= 0.5 and math.isfinite(p_c_star) and float(outlet.Pt) <= p_c_star:
+                    critical_mode = 1.0
+            diag["critical_mode"] = critical_mode
+        else:
+            diag["omega"] = self._critical_omega(primary, secondary, gamma)
+            diag["p_c_star_pa"] = self._critical_back_pressure(primary, secondary, gamma, r_gas)
         return diag
+
+    def _critical_omega(
+        self, primary: NetworkMixtureState, secondary: NetworkMixtureState, gamma: float
+    ) -> float:
+        return float(
+            _solver_tools.ejector_entrainment_ratio_and_jacobian(
+                primary.Pt,
+                primary.Tt,
+                secondary.Pt,
+                secondary.Tt,
+                self.area_ratio_nozzle,
+                self.area_ratio_mix,
+                gamma,
+            ).value.omega
+        )
+
+    def _critical_back_pressure(
+        self,
+        primary: NetworkMixtureState,
+        secondary: NetworkMixtureState,
+        gamma: float,
+        r_gas: float,
+    ) -> float:
+        return float(
+            _solver_tools.ejector_critical_back_pressure_and_jacobian(
+                primary.Pt,
+                primary.Tt,
+                secondary.Pt,
+                secondary.Tt,
+                self.area_ratio_nozzle,
+                self.area_ratio_mix,
+                gamma,
+                r_gas,
+                self.recovery_efficiency,
+            ).value.p_c_pa
+        )

--- a/python/tests/test_ejector_element.py
+++ b/python/tests/test_ejector_element.py
@@ -286,32 +286,57 @@ def test_residuals_jacobian_matches_finite_difference(monkeypatch):
     assert checked >= 12
 
 
-def test_diagnostics_reports_omega_and_critical_mode():
+def test_diagnostics_reports_actual_omega_and_regime():
     e = _element()
     e._port_element_ids = ["chan_p", "chan_s", "chan_o"]
     primary, secondary, outlet = _states()
+    # Actual entrainment ratio is now reported directly from the port flows
+    # (regime-independent), NOT the choked-mode model value.
     port_mdots = [-0.5, -0.3, 0.8]
     diag = e.diagnostics([primary, secondary, outlet], 100000.0, port_mdots)
-    assert 0.0 < diag["omega"] < 5.0
+    assert diag["omega"] == pytest.approx(0.3 / 0.5)  # ms / mp
     assert diag["gamma"] == pytest.approx(1.4, abs=0.05)  # air
     assert diag["r_gas"] == pytest.approx(287.0, abs=1.0)  # air
     assert diag["m_dot_primary"] == pytest.approx(0.5)
     assert diag["m_dot_secondary"] == pytest.approx(0.3)
     assert diag["m_dot_outlet"] == pytest.approx(0.8)
-    # outlet Pt (40 kPa) vs P_jct guess (100 kPa): still "critical" by this metric.
+    # Primary at 700 kPa is choked (s_choke -> 1) and the outlet (40 kPa) is
+    # below the ejector's P_c*: the double-choked critical plateau.
+    assert diag["s_choke"] == pytest.approx(1.0)
     assert diag["critical_mode"] == 1.0
+    assert diag["p_c_star_pa"] > float(outlet.Pt)
 
 
-def test_verify_solution_consistent_flags_subcritical():
+def test_diagnostics_reports_jet_pump_regime():
+    # A near-atmospheric primary that cannot choke: the unchoked jet-pump
+    # regime. s_choke -> 0 and the critical-only fields are suppressed.
     e = _element()
-    sol_ok = {"ej1.P_jct": 100000.0, "o.Pt": 40000.0}
-    sol_bad = {"ej1.P_jct": 40000.0, "o.Pt": 100000.0}
-    assert e.verify_solution_consistent(sol_ok) is True
-    assert e.verify_solution_consistent(sol_bad) is False
+    e._port_element_ids = ["chan_p", "chan_s", "chan_o"]
+    primary = NetworkMixtureState(
+        P=101325.0, Pt=101325.0, T=300.0, Tt=300.0, m_dot=0.0, Y=_DRY_AIR_Y
+    )
+    secondary = NetworkMixtureState(
+        P=101325.0, Pt=101325.0, T=300.0, Tt=300.0, m_dot=0.0, Y=_DRY_AIR_Y
+    )
+    outlet = NetworkMixtureState(
+        P=101325.0, Pt=101325.0, T=300.0, Tt=300.0, m_dot=0.0, Y=_DRY_AIR_Y
+    )
+    port_mdots = [-0.0051, -0.0338, 0.0389]
+    diag = e.diagnostics([primary, secondary, outlet], 100142.0, port_mdots)
+    assert diag["s_choke"] == pytest.approx(0.0)
+    assert diag["critical_mode"] == 0.0
+    assert diag["omega"] == pytest.approx(0.0338 / 0.0051)
+    # Critical-only diagnostics are NaN here and are not reported.
+    assert "p_c_star_pa" not in diag
 
 
-def test_verify_solution_consistent_true_on_missing_keys():
+def test_verify_solution_consistent_always_true_all_regimes_modeled():
+    # The subcritical/jet-pump regimes are now MODELED (not demoted): the old
+    # "outlet exceeds P_c* -> inconsistent" check is gone, so verification is
+    # unconditionally satisfied once the residual system has converged.
     e = _element()
+    assert e.verify_solution_consistent({"ej1.P_jct": 100000.0, "o.Pt": 40000.0}) is True
+    assert e.verify_solution_consistent({"ej1.P_jct": 40000.0, "o.Pt": 100000.0}) is True
     assert e.verify_solution_consistent({}) is True
 
 

--- a/python/tests/test_ejector_jetpump.py
+++ b/python/tests/test_ejector_jetpump.py
@@ -30,7 +30,11 @@ from pathlib import Path
 import pytest
 
 import validation.ejector.data as _data_pkg
-from combaero.network._ejector_huang1999 import cd_nozzle_mass_flow, choked_mass_flow
+from combaero.network._ejector_huang1999 import (
+    cd_nozzle_exit_static,
+    cd_nozzle_mass_flow,
+    choked_mass_flow,
+)
 from validation.ejector.models.huang1999 import (
     EjectorGeometry,
     jet_pump_entrainment_ratio,
@@ -237,6 +241,27 @@ def test_cd_nozzle_is_c1_across_the_choke_threshold() -> None:
     slopes = [slope(p) for p in ps]
     for i in range(len(slopes) - 1):
         assert abs(slopes[i + 1] - slopes[i]) < 5.0e-7  # bounded curvature, no kink
+
+
+def test_cd_nozzle_exit_static_round_trips() -> None:
+    """cd_nozzle_exit_static inverts cd_nozzle_mass_flow: feeding the exit
+    static back through the nozzle must recover the input mass flow (the
+    derived mixing pressure P_py of the unchoked-primary element branch)."""
+    A_t, A_e, g, R, Tt, p0 = 3.14e-5, 1.0e-4, 1.40, 287.0, 300.0, 101325.0
+    cap = choked_mass_flow(p0, Tt, A_t, g, R)
+    for mp in (0.2 * cap, 0.5 * cap, 0.8 * cap, 0.95 * cap):
+        p_py = cd_nozzle_exit_static(mp, p0, Tt, A_t, A_e, g, R)
+        assert cd_nozzle_mass_flow(p0, Tt, p_py, A_t, A_e, g, R) == pytest.approx(mp, rel=1e-9)
+        assert p0 * (2.0 / 2.4) ** (1.4 / 0.4) < p_py < p0  # within (p0*r_crit, p0)
+
+
+def test_cd_nozzle_exit_static_decreases_with_mass_flow() -> None:
+    """More mass flow needs more expansion -> a LOWER exit static. Monotone
+    decreasing in m_dot."""
+    A_t, A_e, g, R, Tt, p0 = 3.14e-5, 1.0e-4, 1.40, 287.0, 300.0, 101325.0
+    cap = choked_mass_flow(p0, Tt, A_t, g, R)
+    ps = [cd_nozzle_exit_static(f * cap, p0, Tt, A_t, A_e, g, R) for f in (0.2, 0.4, 0.6, 0.8)]
+    assert all(ps[i + 1] < ps[i] for i in range(len(ps) - 1))
 
 
 def test_raises_when_primary_cannot_be_unchoked() -> None:

--- a/python/tests/test_ejector_jetpump.py
+++ b/python/tests/test_ejector_jetpump.py
@@ -30,6 +30,7 @@ from pathlib import Path
 import pytest
 
 import validation.ejector.data as _data_pkg
+from combaero.network._ejector_huang1999 import cd_nozzle_mass_flow, choked_mass_flow
 from validation.ejector.models.huang1999 import (
     EjectorGeometry,
     jet_pump_entrainment_ratio,
@@ -196,6 +197,46 @@ def test_fixture_jetpump_sweep_reproduces_model() -> None:
             i["recovery_efficiency"],
         ).omega
         assert live == pytest.approx(pt["omega"], rel=1e-9)
+
+
+def test_cd_nozzle_saturates_at_choked_cap() -> None:
+    """The C-D nozzle (R0 primary residual) saturates at the sonic-throat mass
+    flow once the exit pressure is low enough to choke -- deep expansion gives
+    the choked_mass_flow value (to within the smooth-min rounding)."""
+    A_t, A_e, g, R, Tt, p0 = 3.14e-5, 1.0e-4, 1.40, 287.0, 300.0, 101325.0
+    cap = choked_mass_flow(p0, Tt, A_t, g, R)
+    deep = cd_nozzle_mass_flow(p0, Tt, 0.3 * p0, A_t, A_e, g, R)
+    assert deep == pytest.approx(cap, rel=1e-3)  # within eps_frac rounding
+
+
+def test_cd_nozzle_monotone_rises_as_exit_pressure_falls() -> None:
+    """Unchoked: lower exit pressure -> more expansion -> more mass flow, up to
+    the choke cap. Strictly increasing as p_static_down falls, then flat."""
+    A_t, A_e, g, R, Tt, p0 = 3.14e-5, 1.0e-4, 1.40, 287.0, 300.0, 101325.0
+    ps = [p0 * f for f in (0.999, 0.99, 0.97, 0.95, 0.9)]
+    mdots = [cd_nozzle_mass_flow(p0, Tt, p, A_t, A_e, g, R) for p in ps]
+    assert all(mdots[i + 1] >= mdots[i] for i in range(len(mdots) - 1))
+    cap = choked_mass_flow(p0, Tt, A_t, g, R)
+    assert all(m <= cap * (1.0 + 1e-9) for m in mdots)  # never exceeds the cap
+
+
+def test_cd_nozzle_is_c1_across_the_choke_threshold() -> None:
+    """The smooth-min rounds the choke corner: the finite-difference slope is
+    continuous across the threshold (a bare min() would jump to zero)."""
+    A_t, A_e, g, R, Tt, p0 = 3.14e-5, 1.0e-4, 1.40, 287.0, 300.0, 101325.0
+
+    def slope(p):
+        h = 1.0
+        return (
+            cd_nozzle_mass_flow(p0, Tt, p + h, A_t, A_e, g, R)
+            - cd_nozzle_mass_flow(p0, Tt, p - h, A_t, A_e, g, R)
+        ) / (2.0 * h)
+
+    # scan the corner; consecutive slopes must not jump discontinuously
+    ps = [p0 * f for f in (0.975, 0.973, 0.971, 0.969, 0.967)]
+    slopes = [slope(p) for p in ps]
+    for i in range(len(slopes) - 1):
+        assert abs(slopes[i + 1] - slopes[i]) < 5.0e-7  # bounded curvature, no kink
 
 
 def test_raises_when_primary_cannot_be_unchoked() -> None:

--- a/python/tests/test_gui_ejector.py
+++ b/python/tests/test_gui_ejector.py
@@ -248,6 +248,70 @@ def test_ejector_runner_solve_converges_cold_and_exposes_diagnostics():
     assert p_c > 0.0
 
 
+def _jetpump_ejector_schema() -> dict:
+    """Low primary mass flow (0.0051 kg/s) into the same geometry against a
+    101.325 kPa suction/outlet. That mass flow is well below the primary's
+    choke threshold at this back pressure, so the physical operating point is
+    the UNCHOKED subsonic jet-pump regime (primary Pt floats to ~the back
+    pressure, dp >= 0, omega ~ 7) -- the reported case that previously failed
+    to converge (converged instead to a spurious double-choked root with
+    Pt_primary below the back pressure). See OPERATING_REGIMES_DESIGN.md."""
+    return {
+        "nodes": [
+            _node("mb_p", "mass_boundary", {"m_dot": 0.0051, "Tt": 300.0}),
+            _node("pb_s", "pressure_boundary", {"Pt": 101325.0, "Tt": 300.0}, y=200),
+            _node("pb_o", "pressure_boundary", {"Pt": 101325.0, "Tt": 300.0}, x=600),
+            _node("mc_p", "momentum_chamber", {"area": 0.1}, x=150),
+            _node("mc_s", "momentum_chamber", {"area": 0.1}, x=150, y=200),
+            _node("mc_o", "momentum_chamber", {"area": 0.15}, x=450),
+            _node(
+                "ej1",
+                "ejector",
+                {
+                    "throat_area": _THROAT,
+                    "nozzle_exit_area": _NOZZLE_EXIT,
+                    "mixing_area": _MIXING,
+                },
+                x=300,
+            ),
+        ],
+        "edges": [
+            _edge("e1", "mb_p", "mc_p"),
+            _edge("e2", "mc_p", "ej1", tgt_handle="port-primary-target"),
+            _edge("e3", "pb_s", "mc_s"),
+            _edge("e4", "mc_s", "ej1", tgt_handle="port-secondary-target"),
+            _edge("e5", "ej1", "mc_o", src_handle="port-outlet-source"),
+            _edge("e6", "mc_o", "pb_o"),
+        ],
+    }
+
+
+def test_ejector_runner_solves_unchoked_jet_pump_regime():
+    """The reported low-flow case must converge to the physical jet-pump root:
+    unchoked primary (s_choke -> 0), forward flow (dp >= 0), and a large
+    entrainment ratio -- NOT the spurious double-choked artifact."""
+    runner = NetworkRunner.from_dict(_jetpump_ejector_schema())
+    result = runner.solve(timeout=120.0)
+    df = result.to_dataframe()
+    row = df[df["id"] == "ej1"]
+    assert not row.empty, "ejector element row missing from results"
+    assert bool(row["success"].iloc[0]), "jet-pump ejector solve did not converge"
+
+    mp = float(row["m_dot_primary"].iloc[0])
+    ms = float(row["m_dot_secondary"].iloc[0])
+    assert mp == pytest.approx(0.0051, rel=1e-3)
+    assert ms > 0.0  # entrained flow is drawn in (positive suction)
+    omega = float(row["omega"].iloc[0])
+    assert 5.0 < omega < 9.0, f"expected jet-pump omega ~ 7, got {omega}"
+    # Unchoked regime, not the double-choked artifact.
+    assert float(row["s_choke"].iloc[0]) == pytest.approx(0.0, abs=1e-6)
+    assert float(row["critical_mode"].iloc[0]) == 0.0
+    # Primary floats up to ~the back pressure: forward flow, dp >= 0.
+    mc_p = df[df["id"] == "mc_p"]
+    if not mc_p.empty and "Pt" in df.columns:
+        assert float(mc_p["Pt"].iloc[0]) >= 101325.0 * 0.999
+
+
 def test_ejector_element_m_dot_reports_total_throughflow():
     """The ejector has no own `.m_dot` unknown (a junction). Its ElementResult
     m_dot -- shown on the node card and telemetry -- must report the total

--- a/src/ejector.cpp
+++ b/src/ejector.cpp
@@ -117,6 +117,12 @@ template <int N> DualN<N> operator-(const DualN<N>& a, double c) {
   r.v -= c;
   return r;
 }
+template <int N> DualN<N> operator-(double c, const DualN<N>& a) {
+  DualN<N> r;
+  r.v = c - a.v;
+  for (int i = 0; i < N; ++i) r.d[i] = -a.d[i];
+  return r;
+}
 template <int N> DualN<N> operator*(const DualN<N>& a, const DualN<N>& b) {
   DualN<N> r;
   r.v = a.v * b.v;
@@ -136,6 +142,15 @@ template <int N> DualN<N> operator/(const DualN<N>& a, const DualN<N>& b) {
   double inv2 = inv * inv;
   r.v = a.v * inv;
   for (int i = 0; i < N; ++i) r.d[i] = (a.d[i] * b.v - a.v * b.d[i]) * inv2;
+  return r;
+}
+template <int N> DualN<N> operator/(const DualN<N>& a, double c) { return a * (1.0 / c); }
+template <int N> DualN<N> operator/(double c, const DualN<N>& a) {
+  DualN<N> r;
+  double inv = 1.0 / a.v;
+  r.v = c * inv;
+  double coef = -c * inv * inv;
+  for (int i = 0; i < N; ++i) r.d[i] = a.d[i] * coef;
   return r;
 }
 template <int N> DualN<N> dsqrt(const DualN<N>& a) {
@@ -184,6 +199,49 @@ EjectorCDNozzleJacobian ejector_cd_nozzle_mass_flow_and_jacobian(
   D diff = exit_flux - cap;
   D mdot = 0.5 * (exit_flux + cap - dsqrt(diff * diff + eps * eps));
   return {mdot.v, mdot.d[0], mdot.d[1], mdot.d[2]};
+}
+
+EjectorJetPumpDischargeJacobian ejector_jetpump_discharge_and_jacobian(
+    double p_g_val, double t_g_val, double p_e_val, double t_e_val,
+    double p_py_val, double omega_val, double gamma, double recovery_efficiency) {
+  // Seeds: 0=p_g, 1=t_g, 2=p_e, 3=t_e, 4=p_py, 5=omega.
+  using D = DualN<6>;
+  D p_g = D::seed(p_g_val, 0);
+  D t_g = D::seed(t_g_val, 1);
+  D p_e = D::seed(p_e_val, 2);
+  D t_e = D::seed(t_e_val, 3);
+  D p_py = D::seed(p_py_val, 4);
+  D gam = D::seed(omega_val, 5);
+
+  double gm1 = gamma - 1.0;
+  double gp1 = gamma + 1.0;
+  double k = gm1 / gamma;
+
+  // Both streams expand isentropically to the common mixing static P_py:
+  // lambda = sqrt((g+1)/(g-1) * (1 - (P_py/P0)^((g-1)/g))). Subsonic (< 1).
+  D lambda1 = dsqrt((gp1 / gm1) * (1.0 - dpow(p_py / p_g, k)));
+  D lambda2 = dsqrt((gp1 / gm1) * (1.0 - dpow(p_py / p_e, k)));
+  D theta21 = t_e / t_g;
+
+  // Kracik & Dvorak mixing (their Eqs. 7-13), identical to the critical path's
+  // chain -- only lambda1 is subsonic here instead of supersonic.
+  D z1 = lambda1 + 1.0 / lambda1;
+  D z2 = lambda2 + 1.0 / lambda2;
+  D z3 = (z1 + gam * dsqrt(theta21) * z2) / dsqrt((1.0 + gam) * (1.0 + gam * theta21));
+  D lambda3 = (z3 - dsqrt(z3 * z3 - 4.0)) * 0.5; // subsonic root (Eq. 12)
+
+  double k7 = std::pow(gp1 / 2.0, 1.0 / gm1);
+  auto q_of = [&](const D& lam) {
+    return dpow(1.0 - (gm1 / gp1) * lam * lam, 1.0 / gm1) * k7 * lam;
+  };
+  D q1 = q_of(lambda1);
+  D q2 = q_of(lambda2);
+  D q3 = q_of(lambda3);
+
+  D p03 = p_g * dsqrt((1.0 + gam) * (1.0 + gam * theta21)) /
+          (1.0 + (p_g / p_e) * gam * dsqrt(theta21) * q1 / q2) * q1 / q3;
+  D out = recovery_efficiency * p03;
+  return {out.v, out.d[0], out.d[1], out.d[2], out.d[3], out.d[4], out.d[5]};
 }
 
 // -----------------------------------------------------------------------------

--- a/src/ejector.cpp
+++ b/src/ejector.cpp
@@ -1,9 +1,11 @@
-// 1-D critical-mode supersonic ejector model. See include/ejector.h for
-// paper references and the Jacobian-scope note.
+// 1-D supersonic ejector model (critical / subcritical / unchoked jet-pump
+// regimes). See include/ejector.h for paper references and the scope note.
 
 #include "ejector.h"
 #include <array>
 #include <cmath>
+#include <initializer_list>
+#include <utility>
 
 namespace combaero::solver {
 
@@ -468,6 +470,150 @@ EjectorCriticalPressureResult ejector_critical_back_pressure(
   return ejector_critical_back_pressure_and_jacobian(p_g, t_g, p_e, t_e, geom, gamma, r_gas,
                                                       recovery_efficiency)
       .value;
+}
+
+// -----------------------------------------------------------------------------
+// Whole-element (f, J): the 4-row operating-regime residual system.
+//
+// A transliteration of EjectorElement.residuals() (ejector_element.py): the
+// scalar closures above are chained into a forward-mode DualN<9> exactly as the
+// Python `_chain` wraps each closure's (value, partials), then blended by the
+// two smootherstep weights. Kept in 1:1 correspondence so the two can be
+// cross-validated (tests/test_ejector_jacobians.cpp FD-checks this directly).
+// -----------------------------------------------------------------------------
+namespace {
+
+// _chain: value + sum(partial * grad(input dual)) -- 1:1 with Python _chain.
+template <int N>
+DualN<N> ejector_chain(double value,
+                       std::initializer_list<std::pair<double, DualN<N>>> pairs) {
+  DualN<N> r = DualN<N>::constant(value);
+  for (const auto& pr : pairs) {
+    for (int i = 0; i < N; ++i) r.d[i] += pr.first * pr.second.d[i];
+  }
+  return r;
+}
+
+// C1 clamped smootherstep saturating to EXACTLY 0/1 outside [lo, hi] -- 1:1
+// with Python _smootherstep (so s_choke = 1 exactly at the choke threshold and
+// critical mode reduces exactly).
+template <int N>
+DualN<N> ejector_smootherstep(const DualN<N>& t, double lo, double hi) {
+  DualN<N> x = (t - lo) / (hi - lo);
+  if (x.v <= 0.0) return DualN<N>::constant(0.0);
+  if (x.v >= 1.0) return DualN<N>::constant(1.0);
+  double val = x.v * x.v * x.v * (x.v * (x.v * 6.0 - 15.0) + 10.0);
+  double dval = 30.0 * x.v * x.v * (x.v - 1.0) * (x.v - 1.0);
+  return ejector_chain<N>(val, {{dval, x}});
+}
+
+} // namespace
+
+EjectorElementResidualJacobian ejector_element_residuals_and_jacobian(
+    double mp_v, double ms_v, double mo_v, double p_g_v, double t_g_v,
+    double p_e_v, double t_e_v, double p_out_v, double p_py_v,
+    const EjectorGeometry& geom, double area_throat, double area_nozzle_exit,
+    double area_secondary, double gamma, double r_gas, double eta_primary,
+    double eta_secondary, double recovery_efficiency, double eps_frac,
+    double s_choke_lo, double s_choke_hi, double s_sub_lo, double s_sub_hi) {
+  using D = DualN<9>;
+
+  // Seed the nine Newton unknowns (see header for the index convention).
+  const D mp = D::seed(mp_v, 0);
+  const D ms = D::seed(ms_v, 1);
+  const D mdot_out = D::seed(mo_v, 2);
+  const D p_g = D::seed(p_g_v, 3);
+  const D t_g = D::seed(t_g_v, 4);
+  const D p_e = D::seed(p_e_v, 5);
+  const D t_e = D::seed(t_e_v, 6);
+  const D p_out = D::seed(p_out_v, 7);
+  const D p_py = D::seed(p_py_v, 8); // owned unknown == mixing-plane static
+
+  // s_choke = smootherstep(mp / cap), cap = choked_mass_flow(Pt_p).
+  auto [cap_v, dcap_dp0, dcap_dt0] =
+      ejector_choked_mass_flow_and_jacobian(p_g_v, t_g_v, area_throat, gamma, r_gas, eta_primary);
+  D cap = ejector_chain<9>(cap_v, {{dcap_dp0, p_g}, {dcap_dt0, t_g}});
+  D s = ejector_smootherstep<9>(mp / cap, s_choke_lo, s_choke_hi);
+
+  // R0: primary C-D nozzle (choked/unchoked via the closure's own smooth-min).
+  auto cd = ejector_cd_nozzle_mass_flow_and_jacobian(
+      p_g_v, t_g_v, p_py_v, area_throat, area_nozzle_exit, gamma, r_gas, eta_primary, eps_frac);
+  D cd_d = ejector_chain<9>(
+      cd.mdot, {{cd.dmdot_dp0, p_g}, {cd.dmdot_dt0, t_g}, {cd.dmdot_dp_py, p_py}});
+  D r0 = mp - cd_d;
+
+  // Blend the critical (choked-primary) and jet-pump (unchoked) closures by
+  // s = s_choke. The critical closures return NaN for an unchoked primary, and
+  // the jet-pump closure is symmetric at the choked end; smootherstep is flat
+  // at s in {0, 1} so the inactive branch contributes zero, but 0 * NaN = NaN
+  // would still poison the value/Jacobian -- so evaluate each branch ONLY where
+  // its weight is nonzero, leaving a hard-zero dual otherwise (C1-consistent
+  // with the flat endpoint).
+  D omega_eff = ms / mp; // ACTUAL ratio for the discharge (R1 pins ms itself)
+  const bool crit_active = s.v > 0.0;
+  const bool jet_active = s.v < 1.0;
+
+  D omega_crit = D::constant(0.0);
+  D p03_crit = D::constant(0.0);
+  D s_sub = D::constant(1.0);
+  if (crit_active) {
+    auto entr = ejector_entrainment_ratio_and_jacobian(p_g_v, t_g_v, p_e_v, t_e_v, geom, gamma);
+    omega_crit = ejector_chain<9>(entr.value.omega,
+                                  {{entr.domega_dp_g, p_g},
+                                   {entr.domega_dt_g, t_g},
+                                   {entr.domega_dp_e, p_e},
+                                   {entr.domega_dt_e, t_e}});
+    auto pc = ejector_critical_back_pressure_and_jacobian(
+        p_g_v, t_g_v, p_e_v, t_e_v, geom, gamma, r_gas, 1.0);
+    p03_crit = ejector_chain<9>(pc.value.p_mixed_stagnation_pa,
+                                {{pc.dpc_dp_g, p_g},
+                                 {pc.dpc_dt_g, t_g},
+                                 {pc.dpc_dp_e, p_e},
+                                 {pc.dpc_dt_e, t_e}});
+    s_sub = ejector_smootherstep<9>(p_out / (recovery_efficiency * p03_crit), s_sub_lo, s_sub_hi);
+  }
+
+  D ms_sec = D::constant(0.0);
+  D p03_jet = D::constant(0.0);
+  if (jet_active) {
+    auto sec = ejector_cd_nozzle_mass_flow_and_jacobian(
+        p_e_v, t_e_v, p_py_v, area_secondary, area_secondary, gamma, r_gas, eta_secondary,
+        eps_frac);
+    ms_sec = ejector_chain<9>(
+        sec.mdot, {{sec.dmdot_dp0, p_e}, {sec.dmdot_dt0, t_e}, {sec.dmdot_dp_py, p_py}});
+    auto jp = ejector_jetpump_discharge_and_jacobian(
+        p_g_v, t_g_v, p_e_v, t_e_v, p_py_v, omega_eff.v, gamma, 1.0);
+    p03_jet = ejector_chain<9>(jp.p03,
+                               {{jp.dp03_dp_g, p_g},
+                                {jp.dp03_dt_g, t_g},
+                                {jp.dp03_dp_e, p_e},
+                                {jp.dp03_dt_e, t_e},
+                                {jp.dp03_dp_py, p_py},
+                                {jp.dp03_domega, omega_eff}});
+  }
+
+  // R1: blended entrainment  ms = s*omega_crit*mp + (1-s)*ms_sec.
+  D ms_model = s * omega_crit * mp + (1.0 - s) * ms_sec;
+  D r1 = ms - ms_model;
+
+  // R2: mass conservation.
+  D r2 = mdot_out - mp - ms;
+
+  // R3: regime-dependent closure of the owned unknown (see ejector_element.py
+  // for the w_pin table). discharge = recovery * blend(P_c*, P03_jet) by
+  // s_choke; w_pin = 1 - s*(1 - s_sub) is the weight on the outlet-pin form.
+  D discharge = recovery_efficiency * (s * p03_crit + (1.0 - s) * p03_jet);
+  D w_pin = 1.0 - s * (1.0 - s_sub);
+  D lhs = w_pin * p_out + (1.0 - w_pin) * p_py;
+  D r3 = lhs - discharge;
+
+  EjectorElementResidualJacobian out;
+  const D rows[4] = {r0, r1, r2, r3};
+  for (int i = 0; i < 4; ++i) {
+    out.residuals[i] = rows[i].v;
+    for (int j = 0; j < 9; ++j) out.jacobian[i][j] = rows[i].d[j];
+  }
+  return out;
 }
 
 } // namespace combaero::solver

--- a/src/ejector.cpp
+++ b/src/ejector.cpp
@@ -201,6 +201,34 @@ EjectorCDNozzleJacobian ejector_cd_nozzle_mass_flow_and_jacobian(
   return {mdot.v, mdot.d[0], mdot.d[1], mdot.d[2]};
 }
 
+EjectorCDExitStaticJacobian ejector_cd_nozzle_exit_static_and_jacobian(
+    double m_dot, double p0, double t0, double area_throat, double area_exit,
+    double gamma, double r_gas, double eta, double eps_frac) {
+  double gm1 = gamma - 1.0;
+  double gp1 = gamma + 1.0;
+  double r_crit = std::pow(2.0 / gp1, gamma / gm1);
+  // cd_nozzle_mass_flow is monotone decreasing in P_py: bisect for the root.
+  double lo = p0 * r_crit;
+  double hi = p0 * (1.0 - 1e-12);
+  for (int i = 0; i < 200; ++i) {
+    double mid = 0.5 * (lo + hi);
+    double f = ejector_cd_nozzle_mass_flow(p0, t0, mid, area_throat, area_exit, gamma, r_gas,
+                                           eta, eps_frac);
+    if (f > m_dot) {
+      lo = mid; // too much flow -> raise P_py
+    } else {
+      hi = mid;
+    }
+  }
+  double p_py = 0.5 * (lo + hi);
+  // Implicit function theorem: F(P_py) = cd_nozzle(P_py) - m_dot = 0, so
+  // dP_py/dx = -(dF/dx)/(dF/dP_py), using the C-D nozzle's own Jacobian.
+  EjectorCDNozzleJacobian j = ejector_cd_nozzle_mass_flow_and_jacobian(
+      p0, t0, p_py, area_throat, area_exit, gamma, r_gas, eta, eps_frac);
+  double inv = 1.0 / j.dmdot_dp_py;
+  return {p_py, inv, -j.dmdot_dp0 * inv, -j.dmdot_dt0 * inv};
+}
+
 EjectorJetPumpDischargeJacobian ejector_jetpump_discharge_and_jacobian(
     double p_g_val, double t_g_val, double p_e_val, double t_e_val,
     double p_py_val, double omega_val, double gamma, double recovery_efficiency) {

--- a/src/ejector.cpp
+++ b/src/ejector.cpp
@@ -2,6 +2,7 @@
 // paper references and the Jacobian-scope note.
 
 #include "ejector.h"
+#include <array>
 #include <cmath>
 
 namespace combaero::solver {
@@ -43,10 +44,146 @@ ejector_choked_mass_flow_and_jacobian(double p0, double t0, double area_throat,
   return {mdot, mdot / p0, -0.5 * mdot / t0};
 }
 
+double ejector_cd_nozzle_mass_flow(double p0, double t0, double p_static_down,
+                                   double area_throat, double area_exit,
+                                   double gamma, double r_gas, double eta,
+                                   double eps_frac) {
+  double cap = ejector_choked_mass_flow(p0, t0, area_throat, gamma, r_gas, eta);
+  double exit_flux = 0.0;
+  double r = p_static_down / p0;
+  if (r < 1.0) {
+    double gm1 = gamma - 1.0;
+    double gp1 = gamma + 1.0;
+    double mach = std::sqrt(2.0 / gm1 * (std::pow(r, -gm1 / gamma) - 1.0));
+    double flux = mach * std::pow(1.0 + 0.5 * gm1 * mach * mach, -gp1 / (2.0 * gm1));
+    exit_flux = area_exit * p0 / std::sqrt(t0) * std::sqrt(gamma / r_gas) * flux * std::sqrt(eta);
+  }
+  double eps = eps_frac * cap;
+  double diff = exit_flux - cap;
+  return 0.5 * (exit_flux + cap - std::sqrt(diff * diff + eps * eps));
+}
+
 double ejector_q_lambda(double lam, double gamma) {
   double gm1 = gamma - 1.0;
   double gp1 = gamma + 1.0;
   return std::pow(1.0 - (gm1 / gp1) * lam * lam, 1.0 / gm1) * std::pow(gp1 / 2.0, 1.0 / gm1) * lam;
+}
+
+// -----------------------------------------------------------------------------
+// Generic forward-mode dual (N seeds) for the operating-regime closures, whose
+// Newton unknowns include P_py and the outlet pressure in addition to the four
+// thermodynamic inputs -- so the fixed 4-seed Dual4 above (kept untouched for
+// the validated critical-mode path) does not fit. Same analytic chain-rule
+// bookkeeping; DualN<N>::seed(v, i) sets the i-th partial to 1.
+// -----------------------------------------------------------------------------
+namespace {
+
+template <int N> struct DualN {
+  double v = 0.0;
+  std::array<double, N> d{};
+  static DualN constant(double c) {
+    DualN r;
+    r.v = c;
+    return r;
+  }
+  static DualN seed(double c, int i) {
+    DualN r;
+    r.v = c;
+    r.d[i] = 1.0;
+    return r;
+  }
+};
+
+template <int N> DualN<N> operator+(const DualN<N>& a, const DualN<N>& b) {
+  DualN<N> r;
+  r.v = a.v + b.v;
+  for (int i = 0; i < N; ++i) r.d[i] = a.d[i] + b.d[i];
+  return r;
+}
+template <int N> DualN<N> operator+(const DualN<N>& a, double c) {
+  DualN<N> r = a;
+  r.v += c;
+  return r;
+}
+template <int N> DualN<N> operator+(double c, const DualN<N>& a) { return a + c; }
+template <int N> DualN<N> operator-(const DualN<N>& a, const DualN<N>& b) {
+  DualN<N> r;
+  r.v = a.v - b.v;
+  for (int i = 0; i < N; ++i) r.d[i] = a.d[i] - b.d[i];
+  return r;
+}
+template <int N> DualN<N> operator-(const DualN<N>& a, double c) {
+  DualN<N> r = a;
+  r.v -= c;
+  return r;
+}
+template <int N> DualN<N> operator*(const DualN<N>& a, const DualN<N>& b) {
+  DualN<N> r;
+  r.v = a.v * b.v;
+  for (int i = 0; i < N; ++i) r.d[i] = a.d[i] * b.v + a.v * b.d[i];
+  return r;
+}
+template <int N> DualN<N> operator*(const DualN<N>& a, double c) {
+  DualN<N> r;
+  r.v = a.v * c;
+  for (int i = 0; i < N; ++i) r.d[i] = a.d[i] * c;
+  return r;
+}
+template <int N> DualN<N> operator*(double c, const DualN<N>& a) { return a * c; }
+template <int N> DualN<N> operator/(const DualN<N>& a, const DualN<N>& b) {
+  DualN<N> r;
+  double inv = 1.0 / b.v;
+  double inv2 = inv * inv;
+  r.v = a.v * inv;
+  for (int i = 0; i < N; ++i) r.d[i] = (a.d[i] * b.v - a.v * b.d[i]) * inv2;
+  return r;
+}
+template <int N> DualN<N> dsqrt(const DualN<N>& a) {
+  DualN<N> r;
+  r.v = std::sqrt(a.v);
+  double coef = 0.5 / r.v;
+  for (int i = 0; i < N; ++i) r.d[i] = a.d[i] * coef;
+  return r;
+}
+template <int N> DualN<N> dpow(const DualN<N>& a, double c) {
+  DualN<N> r;
+  r.v = std::pow(a.v, c);
+  double coef = c * std::pow(a.v, c - 1.0);
+  for (int i = 0; i < N; ++i) r.d[i] = a.d[i] * coef;
+  return r;
+}
+
+} // namespace
+
+EjectorCDNozzleJacobian ejector_cd_nozzle_mass_flow_and_jacobian(
+    double p0_val, double t0_val, double p_py_val, double area_throat,
+    double area_exit, double gamma, double r_gas, double eta, double eps_frac) {
+  // Seeds: 0 = p0, 1 = t0, 2 = p_py.
+  using D = DualN<3>;
+  D p0 = D::seed(p0_val, 0);
+  D t0 = D::seed(t0_val, 1);
+  D p_py = D::seed(p_py_val, 2);
+
+  double gm1 = gamma - 1.0;
+  double gp1 = gamma + 1.0;
+  double choke_const = std::sqrt(gamma / r_gas * std::pow(2.0 / gp1, gp1 / gm1));
+  D cap = (choke_const * area_throat * std::sqrt(eta)) * p0 / dsqrt(t0);
+
+  D exit_flux = D::constant(0.0);
+  if (p_py_val < p0_val) {
+    D r = p_py / p0;
+    D mach_sq = (2.0 / gm1) * (dpow(r, -gm1 / gamma) - 1.0);
+    D mach = dsqrt(mach_sq);
+    D flux = mach * dpow(1.0 + 0.5 * gm1 * mach * mach, -gp1 / (2.0 * gm1));
+    exit_flux = (area_exit * std::sqrt(gamma / r_gas) * std::sqrt(eta)) * p0 / dsqrt(t0) * flux;
+  }
+
+  // eps = eps_frac * cap depends on (p0, t0); differentiate it too (FD of the
+  // Python value function does), else the Jacobian would be inconsistent.
+  D eps = eps_frac * cap;
+  D diff = exit_flux - cap;
+  D mdot = 0.5 * (exit_flux + cap - dsqrt(diff * diff + eps * eps));
+  return {mdot.v, mdot.d[0], mdot.d[1], mdot.d[2]};
 }
 
 // -----------------------------------------------------------------------------

--- a/tests/test_ejector_jacobians.cpp
+++ b/tests/test_ejector_jacobians.cpp
@@ -154,3 +154,37 @@ TEST(EjectorJacobians, JetPumpDischargeValueAndJacobian) {
     }
   }
 }
+
+TEST(EjectorJacobians, CDNozzleExitStaticImplicitDerivatives) {
+  // Inverse of the C-D nozzle: analytic implicit-function partials
+  // (m_dot, p0, t0) vs central difference of the bisection value. Also checks
+  // the round-trip cd_nozzle(exit_static(m_dot)) == m_dot.
+  const double A_t = 3.14e-5, A_e = 1.0e-4, g = 1.40, R = 287.0, eta = 0.95, eps = 1e-3;
+  struct Pt {
+    double m_dot, p0, t0;
+  };
+  const Pt pts[] = {
+      {0.0051, 101325.0, 300.0}, // reported
+      {0.0030, 101325.0, 300.0}, // deeper unchoked
+      {0.0065, 101325.0, 300.0}, // near choke
+      {0.0300, 604000.0, 368.0}, // higher motive
+  };
+  auto val = [&](double md, double p0, double t0) {
+    return ejector_cd_nozzle_exit_static_and_jacobian(md, p0, t0, A_t, A_e, g, R, eta, eps).p_py;
+  };
+  for (const auto& p : pts) {
+    auto j = ejector_cd_nozzle_exit_static_and_jacobian(p.m_dot, p.p0, p.t0, A_t, A_e, g, R, eta,
+                                                        eps);
+    // round-trip
+    double back = ejector_cd_nozzle_mass_flow(p.p0, p.t0, j.p_py, A_t, A_e, g, R, eta, eps);
+    EXPECT_NEAR(back, p.m_dot, 1e-9 * p.m_dot) << "round-trip at m_dot=" << p.m_dot;
+    // implicit derivatives vs FD
+    double hm = 1e-7 * p.m_dot, hp = 1e-6 * p.p0, ht = 1e-6 * p.t0;
+    double cd_m = (val(p.m_dot + hm, p.p0, p.t0) - val(p.m_dot - hm, p.p0, p.t0)) / (2 * hm);
+    double cd_p = (val(p.m_dot, p.p0 + hp, p.t0) - val(p.m_dot, p.p0 - hp, p.t0)) / (2 * hp);
+    double cd_t = (val(p.m_dot, p.p0, p.t0 + ht) - val(p.m_dot, p.p0, p.t0 - ht)) / (2 * ht);
+    EXPECT_NEAR(j.dp_py_dm_dot, cd_m, 1e-4 * std::abs(cd_m) + 1e-6) << "dm at " << p.m_dot;
+    EXPECT_NEAR(j.dp_py_dp0, cd_p, 1e-4 * std::abs(cd_p) + 1e-9) << "dp0 at " << p.m_dot;
+    EXPECT_NEAR(j.dp_py_dt0, cd_t, 1e-4 * std::abs(cd_t) + 1e-9) << "dt0 at " << p.m_dot;
+  }
+}

--- a/tests/test_ejector_jacobians.cpp
+++ b/tests/test_ejector_jacobians.cpp
@@ -85,3 +85,33 @@ TEST(EjectorJacobians, ChokedMassFlowMatchesCentralDifference) {
     EXPECT_GT(mdot, 0.0);
   }
 }
+
+TEST(EjectorJacobians, CDNozzleAnalyticMatchesCentralDifference) {
+  // C-D nozzle R0 residual: analytic (p0, t0, p_py) partials vs central
+  // difference of the value function. Covers unchoked, near-threshold, and
+  // choked (flat) points.
+  const double A_t = 3.14e-5, A_e = 1.0e-4, g = 1.40, R = 287.0, eta = 0.95, eps = 1e-3;
+  struct Pt {
+    double p0, t0, p_py;
+  };
+  const Pt pts[] = {
+      {101325.0, 300.0, 100207.0}, // unchoked (reported root)
+      {101325.0, 300.0, 98700.0},  // near the choke threshold
+      {101325.0, 300.0, 60000.0},  // choked (flat region)
+      {604000.0, 368.0, 300000.0}, // higher motive, unchoked
+  };
+  auto val = [&](double p0, double t0, double p_py) {
+    return ejector_cd_nozzle_mass_flow(p0, t0, p_py, A_t, A_e, g, R, eta, eps);
+  };
+  for (const auto& p : pts) {
+    EjectorCDNozzleJacobian j =
+        ejector_cd_nozzle_mass_flow_and_jacobian(p.p0, p.t0, p.p_py, A_t, A_e, g, R, eta, eps);
+    double hp0 = 1e-6 * p.p0, ht0 = 1e-6 * p.t0, hpy = 1e-6 * p.p_py;
+    double cd_p0 = (val(p.p0 + hp0, p.t0, p.p_py) - val(p.p0 - hp0, p.t0, p.p_py)) / (2 * hp0);
+    double cd_t0 = (val(p.p0, p.t0 + ht0, p.p_py) - val(p.p0, p.t0 - ht0, p.p_py)) / (2 * ht0);
+    double cd_py = (val(p.p0, p.t0, p.p_py + hpy) - val(p.p0, p.t0, p.p_py - hpy)) / (2 * hpy);
+    EXPECT_NEAR(j.dmdot_dp0, cd_p0, 1e-6 * std::abs(cd_p0) + 1e-12) << "dp0 at p_py=" << p.p_py;
+    EXPECT_NEAR(j.dmdot_dt0, cd_t0, 1e-6 * std::abs(cd_t0) + 1e-12) << "dt0 at p_py=" << p.p_py;
+    EXPECT_NEAR(j.dmdot_dp_py, cd_py, 1e-5 * std::abs(cd_py) + 1e-12) << "dp_py at p_py=" << p.p_py;
+  }
+}

--- a/tests/test_ejector_jacobians.cpp
+++ b/tests/test_ejector_jacobians.cpp
@@ -188,3 +188,65 @@ TEST(EjectorJacobians, CDNozzleExitStaticImplicitDerivatives) {
     EXPECT_NEAR(j.dp_py_dt0, cd_t, 1e-4 * std::abs(cd_t) + 1e-9) << "dt0 at " << p.m_dot;
   }
 }
+
+TEST(EjectorJacobians, ElementResidualsMatchCentralDifference) {
+  // Whole-element (f, J): every entry of the 4x9 analytic Jacobian vs a
+  // central difference of the residual value, at operating points inside each
+  // regime. This directly guards the DualN<9> assembly in
+  // ejector_element_residuals_and_jacobian (the C++ home of the element
+  // assembly; 1:1 with EjectorElement.residuals()). Points are chosen
+  // ASYMMETRIC (p_g != p_e or t_g != t_e) and away from the s_choke/s_sub
+  // seams so no partial is genuinely ~0 -- the same reason the Python FD test
+  // avoids the symmetric degenerate root.
+  const double A_t = 3.14e-5, A_e = 1.0e-4, A_mix = 8.0e-4, A_s = A_mix - A_e;
+  const EjectorGeometry geom{A_e / A_t, A_mix / A_t};
+  const double R = 287.0, ep = 0.95, es = 0.85, rec = 1.0, eps = 1e-3;
+  const double sc_lo = 0.90, sc_hi = 0.999, ss_lo = 0.98, ss_hi = 1.02;
+  // gamma is a frozen coefficient here (matches the element's frozen-property
+  // Jacobian); use a fixed representative air value so the FD holds it fixed.
+  const double g = 1.4;
+
+  struct Case {
+    const char* id;
+    double u[9]; // mp, ms, mdot_out, p_g, t_g, p_e, t_e, p_out, p_py
+  };
+  const Case cases[] = {
+      // Unchoked jet-pump regime (s_choke -> 0), asymmetric streams.
+      {"jetpump", {0.0051, 0.030, 0.0351, 105000.0, 305.0, 100000.0, 295.0, 100500.0, 99000.0}},
+      // Deeper unchoked, different values.
+      {"jetpump2", {0.0040, 0.022, 0.0260, 130000.0, 310.0, 101325.0, 292.0, 101000.0, 98500.0}},
+      // Double-choked critical regime (s_choke -> 1, outlet < P_c* -> s_sub 0).
+      {"critical", {0.44, 0.13, 0.57, 700000.0, 440.0, 22850.0, 280.0, 40000.0, 100000.0}},
+  };
+
+  auto resid = [&](const double u[9], int row) {
+    return ejector_element_residuals_and_jacobian(u[0], u[1], u[2], u[3], u[4], u[5], u[6], u[7],
+                                                  u[8], geom, A_t, A_e, A_s, g, R, ep, es, rec, eps,
+                                                  sc_lo, sc_hi, ss_lo, ss_hi)
+        .residuals[row];
+  };
+
+  for (const auto& c : cases) {
+    auto rj = ejector_element_residuals_and_jacobian(c.u[0], c.u[1], c.u[2], c.u[3], c.u[4], c.u[5],
+                                                     c.u[6], c.u[7], c.u[8], geom, A_t, A_e, A_s, g,
+                                                     R, ep, es, rec, eps, sc_lo, sc_hi, ss_lo, ss_hi);
+    for (int row = 0; row < 4; ++row) {
+      for (int k = 0; k < 9; ++k) {
+        double a[9], b[9];
+        for (int m = 0; m < 9; ++m) a[m] = b[m] = c.u[m];
+        double h = 1e-6 * std::abs(c.u[k]);
+        if (h == 0.0) h = 1e-6;
+        a[k] += h;
+        b[k] -= h;
+        double cd = (resid(a, row) - resid(b, row)) / (2 * h);
+        double an = rj.jacobian[row][k];
+        // Residuals span mass rows (O(0.01-1)) and pressure rows (O(1e4-1e5)),
+        // so the abs floor is scaled to the residual magnitude to tolerate CD
+        // round-off on the pressure rows without masking mass-row errors.
+        double floor = 1e-6 * std::abs(rj.residuals[row]) + 1e-7;
+        EXPECT_NEAR(an, cd, 1e-5 * std::abs(cd) + floor)
+            << "case " << c.id << " row " << row << " seed " << k;
+      }
+    }
+  }
+}

--- a/tests/test_ejector_jacobians.cpp
+++ b/tests/test_ejector_jacobians.cpp
@@ -115,3 +115,42 @@ TEST(EjectorJacobians, CDNozzleAnalyticMatchesCentralDifference) {
     EXPECT_NEAR(j.dmdot_dp_py, cd_py, 1e-5 * std::abs(cd_py) + 1e-12) << "dp_py at p_py=" << p.p_py;
   }
 }
+
+TEST(EjectorJacobians, JetPumpDischargeValueAndJacobian) {
+  // R3 building block: value parity vs the Python mixing closure, and analytic
+  // partials (p_g, t_g, p_e, t_e, p_py, omega) vs central difference.
+  struct Case {
+    double p_g, t_g, p_e, t_e, p_py, omega, gamma, rec, expected;
+  };
+  const Case cs[] = {
+      {101325.0, 300.0, 101325.0, 300.0, 100207.0, 7.0, 1.4, 1.0, 101325.00000000015},
+      {102435.0, 300.0, 101325.0, 288.15, 100000.0, 3.5, 1.4, 1.0, 101544.85636197214},
+      {110000.0, 320.0, 100000.0, 300.0, 95000.0, 1.5, 1.4, 0.9, 92957.65455779647},
+  };
+  auto val = [](double pg, double tg, double pe, double te, double ppy, double om, double gm,
+                double rec) {
+    return ejector_jetpump_discharge_and_jacobian(pg, tg, pe, te, ppy, om, gm, rec).p03;
+  };
+  for (const auto& c : cs) {
+    auto j = ejector_jetpump_discharge_and_jacobian(c.p_g, c.t_g, c.p_e, c.t_e, c.p_py, c.omega,
+                                                    c.gamma, c.rec);
+    EXPECT_NEAR(j.p03, c.expected, 1e-7 * c.expected) << "value at p_py=" << c.p_py;
+    double h[6] = {1e-6 * c.p_g, 1e-6 * c.t_g, 1e-6 * c.p_e,
+                   1e-6 * c.t_e, 1e-6 * c.p_py, 1e-6 * c.omega};
+    double an[6] = {j.dp03_dp_g, j.dp03_dt_g, j.dp03_dp_e, j.dp03_dt_e, j.dp03_dp_py, j.dp03_domega};
+    for (int k = 0; k < 6; ++k) {
+      double a[8] = {c.p_g, c.t_g, c.p_e, c.t_e, c.p_py, c.omega, c.gamma, c.rec};
+      double b[8];
+      for (int m = 0; m < 8; ++m) b[m] = a[m];
+      a[k] += h[k];
+      b[k] -= h[k];
+      double cd = (val(a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7]) -
+                   val(b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7])) /
+                  (2 * h[k]);
+      // Abs floor 1e-5 tolerates central-difference round-off on partials that
+      // are genuinely ~0 at the symmetric degenerate point (p_g=p_e, t_g=t_e);
+      // real partials here are O(0.01)-O(1000), caught by the relative term.
+      EXPECT_NEAR(an[k], cd, 1e-5 * std::abs(cd) + 1e-5) << "seed " << k << " at p_py=" << c.p_py;
+    }
+  }
+}

--- a/tests/test_ejector_physics.cpp
+++ b/tests/test_ejector_physics.cpp
@@ -83,3 +83,24 @@ TEST(EjectorPhysics, MachFromAreaRatioSupersonicInvertsAreaOverAstar) {
     EXPECT_NEAR(ejector_area_over_astar(mach, gamma), area_ratio, 1e-8);
   }
 }
+
+TEST(EjectorPhysics, CDNozzleMassFlowMatchesPythonReference) {
+  // Value parity vs cd_nozzle_mass_flow in _ejector_huang1999.py (the R0
+  // primary residual). Cases: reported unchoked root, deeply choked, healthy
+  // motive (choked), and a near-threshold point.
+  struct Case {
+    double p0, t0, p_py, at, ae, gamma, r_gas, eta, eps, expected;
+  };
+  const Case cases[] = {
+      {101325.0, 300.0, 100207.0, 3.14e-05, 0.0001, 1.4, 287.0, 0.95, 0.001, 0.004970173368263851},
+      {101325.0, 300.0, 40000.0, 3.14e-05, 0.0001, 1.4, 287.0, 0.95, 0.001, 0.007236469139827049},
+      {604000.0, 368.0, 52828.0, 3.14e-05, 0.0001, 1.4, 287.0, 0.95, 0.001, 0.03894786052281535},
+      {101325.0, 300.0, 101000.0, 3.14e-05, 0.0001, 1.4, 287.0, 0.95, 0.001, 0.0026910837365242053},
+  };
+  for (const auto& c : cases) {
+    double mdot = ejector_cd_nozzle_mass_flow(c.p0, c.t0, c.p_py, c.at, c.ae, c.gamma,
+                                              c.r_gas, c.eta, c.eps);
+    EXPECT_NEAR(mdot, c.expected, 1e-9 * c.expected)
+        << "cd_nozzle mismatch at p_py=" << c.p_py;
+  }
+}

--- a/validation/ejector/OPERATING_REGIMES_DESIGN.md
+++ b/validation/ejector/OPERATING_REGIMES_DESIGN.md
@@ -8,13 +8,10 @@ resolves it. Nothing here is implemented yet -- this is the spec that the
 implementation PRs will follow.
 
 Companion docs:
-- `README.md` (this directory) -- current (critical-mode) model, accuracy
-  comparison, golden-fixture contract.
+- `README.md` (this directory) -- the reference model (critical plateau +
+  subcritical/jet-pump closures), accuracy comparison, golden-fixture contract.
 - `../../python/combaero/network/_ejector_huang1999.py` -- the closed-form
-  critical-mode physics (Huang 1999 + Kracik & Dvorak 2016).
-- `../../docs/ejector/handover.md` -- the original (2026-07-13) groundwork
-  handover (untracked, alongside the source PDFs; now largely superseded, kept
-  for history).
+  physics across regimes (Huang 1999 + Kracik & Dvorak 2016).
 
 ---
 

--- a/validation/ejector/OPERATING_REGIMES_DESIGN.md
+++ b/validation/ejector/OPERATING_REGIMES_DESIGN.md
@@ -437,6 +437,77 @@ solver-dispatch change is needed**:
   regression: `gui/tmp/ejector_test_low_flow_not_converged.json` converges to
   `Pt_primary ~= Pb`, `dp >= 0`, `omega ~= 7`.
 
+## 6c. Phase 2 -- final implemented structure (supersedes 4b's "`P_py` DERIVED")
+
+**What actually shipped, and why 4b's derived-`P_py` plan was wrong.** During
+element assembly the 4b structure (`P_py` DERIVED from the primary nozzle
+inverse) converged but ALWAYS to the spurious double-choked artifact
+(`s_choke -> 1`, `omega ~ 33`), never the jet pump. Root cause: deriving
+`P_py = nozzle_inverse(mp, Pt_p)` makes `R0 = mp - cd_nozzle(Pt_p, P_py)`
+**VACUOUS in the unchoked branch** -- `P_py` is defined AS the exit static that
+makes the nozzle flow `mp`, so `R0 == 0` identically for any `Pt_p`. R0 then
+fails to pin `Pt_p`, and the solver slides to the choked basin. (Deriving `P_py`
+from the SECONDARY nozzle instead just moves the vacuity to R1.) The two nozzle
+relations genuinely share one `P_py`; it must be a free unknown for both to stay
+live.
+
+**Resolution -- `P_py` is the single owned unknown (NOT a second one).** The 4b
+rank spike ruled out `P_py` as a SECOND unknown carrying its own `R_py` row (that
+row is parallel to R0/R3 in the jet pump). But the base already owns exactly one
+scalar (`{id}.P_jct`) and emits N+1 = 4 rows -- the DOF the junction contract
+requires (4 rows - 3 skipped port-MCN mass rows - 1 owned = 0). So **repurpose
+that single owned unknown as `P_py`** (the mixing-plane static), add NO new row,
+and let R0/R1/R3 close it through the network coupling. Full rank, DOF-balanced,
+no solver-dispatch change. Shipped rows (`s = s_choke`):
+
+    R0 = mp - cd_nozzle(Pt_p, P_py, A_t, A_e)                  primary C-D nozzle
+    R1 = ms - [s*omega_crit*mp + (1 - s)*ms_sec(P_py)]         blended entrainment
+    R2 = mdot_out - mp - ms                                    mass conservation
+    R3 = [w_pin*outlet.Pt + (1 - w_pin)*P_py] - recovery*discharge
+         discharge = s*P_c* + (1 - s)*p03_jetpump(P_py, omega_eff = ms/mp)
+         w_pin     = 1 - s*(1 - s_sub)
+         s_sub     = smootherstep(outlet.Pt / (recovery*P_c*), 0.98, 1.02)
+
+**`R3` is regime-dependent by `w_pin`** -- this is the key correction over 4b's
+unconditional `outlet.Pt = recovery*discharge` pin, which BROKE critical mode
+(it over-constrains a genuine double-choked point whose outlet is legitimately
+below `P_c*`, forcing `outlet.Pt = recovery*P_c*` against the fixed downstream
+boundary -> `|F|` stall). The three regimes:
+
+  * jet pump (`s=0`) and subcritical droop (`s=1, outlet > P_c*, s_sub=1`):
+    `w_pin = 1` -> pin `outlet.Pt`. The pin is what excludes the artifact
+    (its recovered discharge cannot match the imposed back pressure), and the
+    downstream boundary forces `P_py` through the pin, which R0/R1 turn into
+    `Pt_p` and entrainment.
+  * critical (`s=1, outlet < P_c*, s_sub=0`): `w_pin = 0` -> `P_py = recovery*P_c*`
+    (diagnostic) and the outlet floats free. This is exactly 4b's diagnostic
+    form, recovered as the `w_pin -> 0` limit, so all the existing critical-mode
+    element tests pass unchanged.
+
+**`0 * NaN` guard.** The critical closures (`entrainment_ratio`,
+`critical_back_pressure`) return NaN for an unchoked primary; since smootherstep
+is flat at `s in {0, 1}` the inactive branch's weight AND gradient vanish, but
+`0 * NaN = NaN` would still poison the value/Jacobian. Each branch is therefore
+evaluated ONLY where its weight is nonzero (`crit_active = s.v > 0`,
+`jet_active = s.v < 1`); the skipped branch is a hard-zero dual, C1-consistent
+with the flat endpoint. This was the concrete source of the `|F| = nan` stall
+before the guard.
+
+**Warm-start (jet-pump regime).** The GUI ejector warm-start seeds a mass-flow
+primary at its choked-inverse Pt; when that is BELOW the outlet back pressure
+the primary cannot choke, so it now seeds `Pt_p = outlet.Pt` (jet-pump branch)
+and `P_jct = 0.99*outlet.Pt` instead of the choked-inverse / `P_c*` seed. Cold
+Newton lands in the jet-pump basin directly (`graph_builder._seed_ejector_warmstart`).
+
+**Verified:** element Jacobian matches FD at the jet-pump root (the earlier
+`d(R3)/d(mc_p.Pt) = NaN` gone; the lone residual `e4.m_dot R3` "mismatch" is FD
+round-off on a genuinely ~0 partial). End-to-end: the reported low-flow network
+converges to `omega = 6.62`, `s_choke = 0`, `P_py = 100.1 kPa`, `Pt_p = Pb`
+(`dp = 0`); the 700/22.85/40 kPa double-choked reference still converges in
+critical mode (`critical_mode = 1`). Regression tests:
+`test_ejector_runner_solves_unchoked_jet_pump_regime` and the retained cold
+critical solve.
+
 ## 7. References
 
 - Huang, Chang, Wang, Petrenko (1999), *A 1-D analysis of ejector performance*,
@@ -555,3 +626,58 @@ reduction test landing 50% off before the fix.
 monotone convergence, ~1.4x Sanger overprediction, bounded reported-case omega,
 monotonicity, boundary flags, fixture regression) and the `jetpump_cases`
 section of the golden fixture.
+
+### 8.3 Phase 2 -- element integration (all three regimes in one solve)
+
+**Formulation & the two rejected structures.** The `EjectorElement` residuals
+were rebuilt to resolve critical / subcritical-droop / unchoked-jet-pump in one
+C1 Newton system (full structure in sec 6c). Two grounded structures were built
+and REJECTED with evidence: (a) the 4b "`P_py` DERIVED from the primary nozzle
+inverse" plan converged but ALWAYS to the double-choked artifact (`omega ~ 33`),
+because deriving `P_py` makes `R0` algebraically vacuous in the unchoked branch,
+so it stops pinning `Pt_p`; (b) an unconditional outlet-pin `R3` (right for the
+jet pump) BROKE genuine critical mode -- it forces `outlet.Pt = recovery*P_c*`
+against a fixed downstream boundary whose outlet is legitimately below `P_c*`,
+stalling at `|F| ~ 1.8e4`. The shipped structure owns `P_py` as the SINGLE
+repurposed junction unknown (no new row, DOF unchanged) and makes `R3`
+regime-dependent via `w_pin = 1 - s_choke*(1 - s_sub)`, recovering 4b's
+diagnostic form as the `w_pin -> 0` (critical) limit.
+
+**Why the artifact is a genuine math root and how it is excluded.** With a
+back-pressure-independent closure the choked artifact (`Pt_p < Pb`, primary
+sonic, `omega ~ 33`) satisfies R0-R2 and is a real root; only the OUTLET PIN
+excludes it -- its recovered discharge cannot match the imposed back pressure,
+so it is a non-root of the FULL network. The pin is active exactly where it must
+be (jet pump + droop) and off where it must be (critical).
+
+**Constant audit.** No new fitted constants. The only new numeric knobs are
+smootherstep windows: `s_choke in [0.90, 0.999]` on `mp/cap` (must SATURATE to
+exactly 1 at choke -- a non-saturating form leaves a ~10 Pa R3 residual and
+~0.3% omega error in critical, per 4b), and `s_sub in [0.98, 1.02]` on
+`outlet.Pt/(recovery*P_c*)` (centred on the physical critical/subcritical
+boundary `outlet = P_c*`). `recovery_efficiency` stays 1.0 (audited in 8.2).
+
+**Invariant preserved.** The pre-existing critical-mode element tests
+(`residuals` cross-check vs the reference physics, all-residuals-zero at the
+choked root, analytic-Jacobian-vs-FD, full double-choked network) pass
+UNCHANGED -- the critical regime is the `s_choke=1, s_sub=0` limit of the new
+blend. Mass conservation (`R2`) and `omega = ms/mp` (actual, regime-independent)
+hold at every root.
+
+**Dead ends.** Derived-`P_py` (vacuous R0) and unconditional outlet-pin (breaks
+critical), both above. Also a `0 * NaN = NaN` Jacobian poison from eagerly
+evaluating the critical closures (which return NaN for an unchoked primary) even
+at `s_choke = 0` -- fixed by evaluating each branch only where its weight is
+nonzero, C1-safe because smootherstep is flat at the endpoints. Also a warm-start
+that seeded the primary at its choked-inverse Pt (the artifact basin) for a
+mass-flow primary below the choke threshold -- fixed by detecting that case and
+seeding `Pt_p = outlet.Pt`.
+
+**Pinned by.** `python/tests/test_ejector_element.py` (new
+`test_diagnostics_reports_actual_omega_and_regime`,
+`test_diagnostics_reports_jet_pump_regime`,
+`test_verify_solution_consistent_always_true_all_regimes_modeled`, plus the
+retained critical residual/Jacobian/network tests) and
+`python/tests/test_gui_ejector.py::test_ejector_runner_solves_unchoked_jet_pump_regime`
+(the reported low-flow case -> `omega ~ 6.6`, `s_choke = 0`, `dp >= 0`)
+alongside the retained cold critical solve.

--- a/validation/ejector/OPERATING_REGIMES_DESIGN.md
+++ b/validation/ejector/OPERATING_REGIMES_DESIGN.md
@@ -365,40 +365,54 @@ and committed on `feat/ejector-phase2-element` (WIP, not yet a PR):
   The secondary entrained flux reuses `ejector_cd_nozzle_mass_flow`
   (area_throat = area_exit = A_s), so no new closure.
 
-**Increment 4 -- the element assembly (next; the largest piece).** Five rows on
-the `MultiPortChamberElement` topology, with `P_py` (the common mixing static)
-exposed as a SECOND element-owned unknown alongside `P_jct`:
+**Increment 4a (DONE):** pybind for `ejector_cd_nozzle_mass_flow_and_jacobian`
+and `ejector_jetpump_discharge_and_jacobian` (Python values match the ctest to
+machine precision) so the element can call them.
 
-    R0  = mp - cd_nozzle(p_g, t_g, P_py, A_t, A_p1)          primary C-D nozzle
+**Increment 4b -- element structure settled by a Jacobian-rank spike.** The
+first blueprint (five rows, `P_py` exposed as a SECOND owned unknown with an
+`R_py` row) was RULED OUT: a throwaway Jacobian-rank spike showed the 5-row
+block is **rank-deficient in the jet-pump regime** (smallest singular value
+~1e-8), and this is structural, not tunable. Any `R_py` that pins `P_py` is, at
+the jet-pump solution, linearly parallel to an existing row -- pin via the
+nozzle and `grad(R_py) = c * grad(R0)`; pin via the discharge and it is parallel
+to `R3`; and at the jet-pump solution nothing zero-valued is independent of
+R0-R3. So **`P_py` cannot be a Newton unknown**. (The earlier "A' reduces to
+critical" claim was never validated -- that spike case was buggy.)
+
+Settled structure -- **four rows, `P_py` DERIVED** (not a solver unknown); the
+element keeps the base `MultiPortChamberElement` unknown/row count, so **no
+solver-dispatch change is needed**:
+
+    P_py = s_choke*P_sy + (1 - s_choke)*nozzle_inverse(mp, Pt_p)   derived
+    s_choke = smoothstep(mp / choked_mass_flow(Pt_p))    keyed on mp, NOT P_py
+    R0  = mp - cd_nozzle(Pt_p, Tt_p, P_py, A_t, A_p1)          primary C-D nozzle
     R1  = ms - [s_choke*omega_crit*mp + (1 - s_choke)*ms_sec]  blended entrainment
-          ms_sec = cd_nozzle(p_e, t_e, P_py, A_s, A_s)         (secondary flux)
-    R2  = mdot_out - mp - ms                                  mass conservation
-    R3  = outlet.Pt - recovery*[s_choke*P_c* + (1 - s_choke)*p03_jetpump(P_py)]
-                                                              outlet-pin (A')
-    R_py = s_choke*(P_py - P_sy) + (1 - s_choke)*R0_like       P_py definition
+          ms_sec = cd_nozzle(Pt_s, Tt_s, P_py, A_s, A_s)        (secondary flux)
+    R2  = mdot_out - mp - ms                                   mass conservation
+    R3  = outlet.Pt - recovery*[s_choke*p03_crit + (1 - s_choke)*p03_jetpump(P_py)]
 
-- `s_choke` is a smooth primary-choke indicator (C-D nozzle exit flux vs the
-  sonic cap); `omega_crit`/`P_c*` are the existing critical closures.
-- **Why R_py is mandatory (design finding):** in critical mode R0/R1/R3 are all
-  P_py-independent (choked primary; Huang omega and P_c*), so without R_py the
-  P_py Jacobian column is all-zeros and the Newton block is singular. R_py must
-  therefore be non-degenerate in BOTH regimes -- `s*(P_py - P_sy)` pins P_py in
-  critical, and the `(1-s)` branch must re-assert the primary relation (so the
-  row is not identically zero when unchoked); finalize its exact form so R_py's
-  row stays full-rank across the blend.
-- **Spurious-root exclusion = A' + B** (validated in the residual-structure
-  spike): R3 pins `outlet.Pt = recovery*p03`, so the choked artifact (discharge
-  ~= P_c* != outlet) is a non-root; B is the physical warm-start (Pt_primary >=
-  outlet, P_py just below it) that keeps Newton out of the sticky choked basin.
-- **Solver-integration change required:** the solver's MultiPortChamber dispatch
-  (`solver.py`, `P_jct_val = x[m_indices[0]]`) passes only the FIRST owned
-  unknown to `residuals()`. Extend it to pass the remaining owned unknowns
-  (backward-compatible: an optional map keyed by `element.unknowns()[1:]`), so
-  `EjectorElement` receives `P_py`. The Jacobian relay already handles named
-  unknown columns generically, so only the value-passing side changes.
-- Then: `verify_solution_consistent` accepts subcritical + jet-pump roots (drop
-  the `outlet <= P_c*` demotion); assemble the full analytic `(f, J)` in C++
-  (blend of the committed closures); rewrite the element unit tests for the new
+- **Full rank in both regimes** (spike-confirmed: 4/4 in jet-pump, 4/4 in
+  critical). `R0` transitions smoothly from a real constraint (`mp = choked` in
+  critical) to nearly-redundant-but-nonzero (jet-pump); the jet-pump block is
+  ill-conditioned in deep-unchoked (cond ~1e4) but well within the solver's LM
+  fallback.
+- **`s_choke` is keyed on `mp / choked_mass_flow(Pt_p)`, NOT on `P_py`** -- this
+  is essential: a `P_py`-based indicator is circular (`s` depends on `P_py`
+  depends on `s`) and mislabels the choked critical state. `s -> 1` as the
+  primary chokes (`mp -> choked`), `s -> 0` when `mp << choked`.
+- **`nozzle_inverse(mp, Pt_p)`** is the new closure needed: the unchoked C-D
+  nozzle exit static `P_py` such that `cd_nozzle(Pt_p, P_py) = mp` -- a 1-D
+  inversion with an implicit-function derivative (`dP_py/dmp`, `dP_py/dPt_p`).
+  Python reference -> C++ -> FD-checked, same recipe as the C-D nozzle.
+- **Spurious-root exclusion still A' + B:** R3 pins `outlet.Pt = recovery*p03`
+  (blended discharge), so the choked artifact (`discharge ~= P_c* != outlet`) is
+  a non-root; B is the physical warm-start (Pt_primary >= outlet) keeping Newton
+  out of the sticky choked basin.
+- Then: assemble the 4-row analytic `(f, J)` (blend of the committed closures +
+  the derived `P_py` chain, whose Jacobian folds in `dP_py` via the chain rule);
+  `verify_solution_consistent` accepts subcritical + jet-pump roots (drop the
+  `outlet <= P_c*` demotion); rewrite the element unit tests for the new
   structure; extend the golden fixture with coupled rows; and the end-to-end
   regression: `gui/tmp/ejector_test_low_flow_not_converged.json` converges to
   `Pt_primary ~= Pb`, `dp >= 0`, `omega ~= 7`.

--- a/validation/ejector/OPERATING_REGIMES_DESIGN.md
+++ b/validation/ejector/OPERATING_REGIMES_DESIGN.md
@@ -414,6 +414,21 @@ solver-dispatch change is needed**:
   (blended discharge), so the choked artifact (`discharge ~= P_c* != outlet`) is
   a non-root; B is the physical warm-start (Pt_primary >= outlet) keeping Newton
   out of the sticky choked basin.
+- **Jacobian VALIDATED** (prototype matches FD at non-degenerate points, both
+  regimes): assembled via a Python dual (value + grad-dict over the 8 primitives
+  mp, ms, mdot_out, p_g, t_g, p_e, t_e, p_out), chaining the committed closures'
+  partials -- `P_py` is injected as a dual carrying its implicit partials from
+  `cd_nozzle_exit_static` + `P_sy` + `s_choke`. Two physics details this pinned
+  down: the discharge mixing uses `omega_eff = ms / mp` (the ACTUAL ratio; R1
+  separately pins `ms = ms_model`), and the symmetric reported root has
+  genuinely ~0 R3/d(mp,ms) partials (FD is unreliable there -- validate the
+  Jacobian at asymmetric points).
+- **`P_jct` bookkeeping:** R3 must reference `outlet.Pt` (the A' pin), so it
+  cannot also define the base's `P_jct`. The ejector is not an impulse-CV
+  junction, so drop `P_jct` from `unknowns()` (the 4 rows R0-R3 constrain the 3
+  port pressures + mass flows directly; `flow_at_node` uses the port outer-mdot
+  indices, not `P_jct`, so it is unaffected) -- verify the DOF balances via the
+  end-to-end network solve.
 - Then: assemble the 4-row analytic `(f, J)` (blend of the committed closures +
   the derived `P_py` chain, whose Jacobian folds in `dP_py` via the chain rule);
   `verify_solution_consistent` accepts subcritical + jet-pump roots (drop the

--- a/validation/ejector/OPERATING_REGIMES_DESIGN.md
+++ b/validation/ejector/OPERATING_REGIMES_DESIGN.md
@@ -348,6 +348,61 @@ new exported symbols, and the doc-hygiene rules).
 5. **GUI**: surface the operating regime (critical / subcritical / jet-pump /
    backflow) as an ejector diagnostic; validate the reported network converges.
 
+## 6b. Phase 2 C++ port -- progress and the element-assembly blueprint
+
+Phases 2 (element) and 3 (C++ port) were merged into one combined effort: the
+element is C++-`(f, J)`-only, so a Python element path would be pure churn. Done
+and committed on `feat/ejector-phase2-element` (WIP, not yet a PR):
+
+- **Increment 1-2 -- C-D nozzle R0** (`ejector_cd_nozzle_mass_flow[_and_jacobian]`):
+  subsonic exit-`A_p1` flux smooth-min'd with the sonic-throat cap; value parity
+  vs the Python `cd_nozzle_mass_flow` (1e-9) and analytic `d/d(p0,t0,P_py)` vs
+  FD. Introduced a generic `DualN<N>` (the validated 4-seed `Dual4` untouched).
+- **Increment 3 -- jet-pump mixed discharge R3**
+  (`ejector_jetpump_discharge_and_jacobian`): `recovery * p03`, the Kracik &
+  Dvorak mixing reused at the subsonic-primary state, `DualN<6>` Jacobian
+  (seeds p_g,t_g,p_e,t_e,P_py,omega), value parity + FD-checked all six seeds.
+  The secondary entrained flux reuses `ejector_cd_nozzle_mass_flow`
+  (area_throat = area_exit = A_s), so no new closure.
+
+**Increment 4 -- the element assembly (next; the largest piece).** Five rows on
+the `MultiPortChamberElement` topology, with `P_py` (the common mixing static)
+exposed as a SECOND element-owned unknown alongside `P_jct`:
+
+    R0  = mp - cd_nozzle(p_g, t_g, P_py, A_t, A_p1)          primary C-D nozzle
+    R1  = ms - [s_choke*omega_crit*mp + (1 - s_choke)*ms_sec]  blended entrainment
+          ms_sec = cd_nozzle(p_e, t_e, P_py, A_s, A_s)         (secondary flux)
+    R2  = mdot_out - mp - ms                                  mass conservation
+    R3  = outlet.Pt - recovery*[s_choke*P_c* + (1 - s_choke)*p03_jetpump(P_py)]
+                                                              outlet-pin (A')
+    R_py = s_choke*(P_py - P_sy) + (1 - s_choke)*R0_like       P_py definition
+
+- `s_choke` is a smooth primary-choke indicator (C-D nozzle exit flux vs the
+  sonic cap); `omega_crit`/`P_c*` are the existing critical closures.
+- **Why R_py is mandatory (design finding):** in critical mode R0/R1/R3 are all
+  P_py-independent (choked primary; Huang omega and P_c*), so without R_py the
+  P_py Jacobian column is all-zeros and the Newton block is singular. R_py must
+  therefore be non-degenerate in BOTH regimes -- `s*(P_py - P_sy)` pins P_py in
+  critical, and the `(1-s)` branch must re-assert the primary relation (so the
+  row is not identically zero when unchoked); finalize its exact form so R_py's
+  row stays full-rank across the blend.
+- **Spurious-root exclusion = A' + B** (validated in the residual-structure
+  spike): R3 pins `outlet.Pt = recovery*p03`, so the choked artifact (discharge
+  ~= P_c* != outlet) is a non-root; B is the physical warm-start (Pt_primary >=
+  outlet, P_py just below it) that keeps Newton out of the sticky choked basin.
+- **Solver-integration change required:** the solver's MultiPortChamber dispatch
+  (`solver.py`, `P_jct_val = x[m_indices[0]]`) passes only the FIRST owned
+  unknown to `residuals()`. Extend it to pass the remaining owned unknowns
+  (backward-compatible: an optional map keyed by `element.unknowns()[1:]`), so
+  `EjectorElement` receives `P_py`. The Jacobian relay already handles named
+  unknown columns generically, so only the value-passing side changes.
+- Then: `verify_solution_consistent` accepts subcritical + jet-pump roots (drop
+  the `outlet <= P_c*` demotion); assemble the full analytic `(f, J)` in C++
+  (blend of the committed closures); rewrite the element unit tests for the new
+  structure; extend the golden fixture with coupled rows; and the end-to-end
+  regression: `gui/tmp/ejector_test_low_flow_not_converged.json` converges to
+  `Pt_primary ~= Pb`, `dp >= 0`, `omega ~= 7`.
+
 ## 7. References
 
 - Huang, Chang, Wang, Petrenko (1999), *A 1-D analysis of ejector performance*,

--- a/validation/ejector/OPERATING_REGIMES_DESIGN.md
+++ b/validation/ejector/OPERATING_REGIMES_DESIGN.md
@@ -399,8 +399,13 @@ solver-dispatch change is needed**:
   fallback.
 - **`s_choke` is keyed on `mp / choked_mass_flow(Pt_p)`, NOT on `P_py`** -- this
   is essential: a `P_py`-based indicator is circular (`s` depends on `P_py`
-  depends on `s`) and mislabels the choked critical state. `s -> 1` as the
-  primary chokes (`mp -> choked`), `s -> 0` when `mp << choked`.
+  depends on `s`) and mislabels the choked critical state. It must be a
+  SATURATING C1 form (clamped smootherstep on `mp/cap` with `lo~0.90`,
+  `hi~0.999`) so `s = 1` EXACTLY at the choke (`mp -> cap`) -- a `tanh` that
+  only asymptotes to 1 leaves an ~10 Pa R3 residual and a ~0.3% omega error in
+  critical mode. Verified: with the smootherstep, both physical roots evaluate
+  to all-four-residuals ~= 0 (jet-pump: R0=-6e-17, R3=1e-10, omega~6.6;
+  critical: s=1, P_py=P_sy, omega_eff=omega_crit, R3=0 all exact).
 - **`nozzle_inverse(mp, Pt_p)`** is the new closure needed: the unchoked C-D
   nozzle exit static `P_py` such that `cd_nozzle(Pt_p, P_py) = mp` -- a 1-D
   inversion with an implicit-function derivative (`dP_py/dmp`, `dP_py/dPt_p`).

--- a/validation/ejector/OPERATING_REGIMES_DESIGN.md
+++ b/validation/ejector/OPERATING_REGIMES_DESIGN.md
@@ -508,6 +508,27 @@ critical mode (`critical_mode = 1`). Regression tests:
 `test_ejector_runner_solves_unchoked_jet_pump_regime` and the retained cold
 critical solve.
 
+**Assembly moved to C++ (whole-element (f, J)).** The 4-row blend was first
+assembled in Python via a forward-mode dual (`_D`) chaining the C++ scalar
+closures' partials -- correct and FD-validated, but a pattern used by no other
+element. A repo survey established that the house practice for a multi-row
+COUPLED junction is whole-element `(f, J)` in C++ (the base
+`MultiPortChamberElement` and `TeeJunctionElement` both do this; the ejector is
+a `MultiPortChamberElement` subclass), so the assembly was ported to a single
+C++ function `ejector_element_residuals_and_jacobian` (`src/ejector.cpp`) that
+seeds a `DualN<9>` over the nine unknowns and runs the identical smootherstep /
+branch-skip / `w_pin` blend, returning the 4 residuals + a 4x9 Jacobian. The
+Python `residuals()` is now a thin relabeling shim (physical-flow signs +
+seed->column names), mirroring the base class. The C++ output is **bit-identical**
+to the retired Python dual (residuals to 0.0, Jacobian to ~1e-11 round-off,
+across jet-pump / critical / non-converged points) since it is the same
+chain-rule over the same closures; and it is FD-checked directly in
+`tests/test_ejector_jacobians.cpp::ElementResidualsMatchCentralDifference`. The
+`_and_jacobian` scalar closures and this element function are solver-internal
+(`combaero._solver_tools`), a tier below the documented public API, so no
+`units_data.h` / `API_*.md` entry is required (consistent with the other
+ejector closures).
+
 ## 7. References
 
 - Huang, Chang, Wang, Petrenko (1999), *A 1-D analysis of ejector performance*,
@@ -680,4 +701,6 @@ seeding `Pt_p = outlet.Pt`.
 retained critical residual/Jacobian/network tests) and
 `python/tests/test_gui_ejector.py::test_ejector_runner_solves_unchoked_jet_pump_regime`
 (the reported low-flow case -> `omega ~ 6.6`, `s_choke = 0`, `dp >= 0`)
-alongside the retained cold critical solve.
+alongside the retained cold critical solve. The C++ whole-element assembly is
+FD-guarded by
+`tests/test_ejector_jacobians.cpp::ElementResidualsMatchCentralDifference`.

--- a/validation/ejector/README.md
+++ b/validation/ejector/README.md
@@ -38,6 +38,11 @@ model: primary flow choked at the nozzle throat, entrained flow choked at the
 hypothetical throat y-y, constant-pressure mixing (Huang's Eqs. 1-8,
 `entrainment_ratio`). In this regime the entrainment ratio omega is fixed and
 independent of back pressure -- the flat plateau of the ejector characteristic.
+It also carries the off-plateau operating-regime closures (see "Operating
+regimes" below): `cd_nozzle_mass_flow` / `cd_nozzle_exit_static` (choked or
+unchoked primary), `dead_head_back_pressure` + `subcritical_entrainment_ratio`
++ `blended_entrainment_ratio` (the subcritical droop), and
+`jet_pump_entrainment_ratio` (the unchoked subsonic jet pump).
 
 It also implements the critical back pressure P_c* (`critical_back_pressure`),
 using Kracik & Dvorak's mixing closure (their Eqs. 7-13) rather than Huang's
@@ -61,20 +66,22 @@ invariant to count, while A_3/A_t shrinks as count grows, since the aggregate
 throat area scales with count but the shared mixing chamber does not.
 `count=1` reduces exactly to the direct constructor.
 
-Out of scope for the *current* model: the subcritical, unchoked-primary, and
-back-flow branches. These are designed in
-`OPERATING_REGIMES_DESIGN.md`, which diagnoses a real
-non-converging low-primary-flow case and proposes the extension. In brief, the
-device passes through these regimes as the forced primary flow rises: (1)
+## Operating regimes
+
+The device passes through these regimes as the forced primary flow rises: (1)
 `mp < mdot_choked(Pb)` -> primary **unchoked**, a subsonic jet pump (primary Pt
 floats just above the back pressure); (2) primary **choked** -> supersonic
-ejector, whose entrained flow is then **critical** (`Pb <= P_c*`, modeled here),
-**subcritical** (`P_c* < Pb < P_b0`, drooping omega), or **backflow**
-(`Pb >= P_b0`). A known limitation of the current critical-only model: a
-forced-primary flow below the choke threshold converges to a self-contradictory
-choked-branch root (primary Pt *below* the back pressure) and is demoted by
-`verify_solution_consistent` -- see the design doc for the fix (choked/unchoked
-R0 + subcritical R1 + jet-pump mode).
+ejector, whose entrained flow is then **critical** (`Pb <= P_c*`, the flat
+plateau), **subcritical** (`P_c* < Pb < P_b0`, drooping omega), or **backflow**
+(`Pb >= P_b0`). The critical plateau was the original model; the subcritical
+droop and the unchoked jet pump are now implemented too (Phase 1A/1B reference
+closures listed under "Model scope"; the network `EjectorElement` composes all
+of them into one C1 residual system that resolves every regime in a single
+solve -- Phase 2). Full diagnosis (of the original non-converging
+low-primary-flow case, which used to converge to a self-contradictory
+choked-branch root with primary Pt *below* the back pressure) and the
+provenance of the fix are in `OPERATING_REGIMES_DESIGN.md`. Backflow
+(`Pb >= P_b0`) remains out of scope.
 
 ## gamma provenance (the only CoolProp step)
 
@@ -223,8 +230,9 @@ one dataset. `test_ejector_huang.py` checks P_c* by regression, by trend
    difference Jacobian columns to tight tolerance.~~ Done (PR #253).
 4. ~~pybind bindings, in a separate PR.~~ Done (PR #254).
 5. ~~GUI work and validation.~~ Done (PR #259).
-6. **Operating-regime extension (next):** choked/unchoked primary (R0),
-   subcritical entrainment droop (R1), and the unchoked subsonic jet-pump mode,
-   in one C1 residual system so critical <-> subcritical <-> jet-pump solve in a
-   single Newton pass. Full findings and design in
-   `OPERATING_REGIMES_DESIGN.md`.
+6. ~~**Operating-regime extension:** choked/unchoked primary (R0), subcritical
+   entrainment droop (R1), and the unchoked subsonic jet-pump mode, in one C1
+   residual system so critical <-> subcritical <-> jet-pump solve in a single
+   Newton pass.~~ Done: reference closures (Phase 1A/1B) and the whole-element
+   C++ `(f, J)` composed into `EjectorElement` (Phase 2). Full findings,
+   design, and provenance in `OPERATING_REGIMES_DESIGN.md`.


### PR DESCRIPTION
## Summary

Completes the **ejector operating-regime extension**: the network `EjectorElement` now resolves all three physical regimes — critical (double-choked), subcritical droop, and unchoked-primary subsonic jet pump — in one C1 Newton-solvable residual system, with the whole 4-row `(f, J)` assembled in C++.

A previously **non-converging** network — a low primary mass flow (below the choke threshold at its back pressure) drawing suction against atmospheric — now converges to the physical jet-pump root (`Pt_primary ≈ Pb`, `dp ≥ 0`, `omega ≈ 6.6`) instead of failing or landing on a spurious double-choked root with the primary pressure *below* the back pressure.

Design + provenance: `validation/ejector/OPERATING_REGIMES_DESIGN.md` sec 6c/8.3.

## What's in it

**Regime physics & structure**
- The base junction's single owned unknown (`{id}.P_jct`) is repurposed as the physical mixing-plane static pressure `P_py` (a genuine Newton unknown), so both nozzle relations stay live and the downstream back pressure selects the regime.
- `R3` closes the system per regime via `w_pin = 1 − s_choke·(1 − s_sub)`: pin the outlet (jet pump + droop) or hold `P_py = recovery·P_c*` as a diagnostic with the outlet free (critical). The critical regime is exactly the `w_pin → 0` limit of the new blend, so existing critical-mode behaviour is unchanged.
- Two smootherstep weights select the regime smoothly (no branching discontinuity). Inactive branches are skipped where their weight is zero, avoiding `0·NaN` Jacobian poisoning (the critical closures return NaN for an unchoked primary).

**Whole-element `(f, J)` in C++**
- A repo survey established that the house pattern for a multi-row *coupled junction* is whole-element `(f, J)` in C++ (the base `MultiPortChamberElement` — which `EjectorElement` subclasses — and `TeeJunctionElement` both do this). The 4-row assembly was ported to a single C++ `ejector_element_residuals_and_jacobian` seeding a `DualN<9>`; Python `residuals()` is now a thin relabeling shim.
- **Bit-identical** to the prior (FD-validated) Python-dual assembly: residuals to 0.0, Jacobian to ~1e-11, across jet-pump / critical / non-converged points. FD-guarded directly by a new C++ ctest.

**Diagnostics / API**
- `diagnostics()` reports the actual `omega = ms/mp` (regime-independent), a `critical_mode` flag, the mixing pressure `p_py_pa`, and suppresses critical-only fields when the primary is unchoked.
- `verify_solution_consistent` returns True unconditionally now that every regime is modeled.
- GUI ejector warm-start seeds the jet-pump operating point when a mass-flow primary sits below the choke threshold.

## Testing
- Full Python suite green; all C++ ejector ctests pass (physics + jacobians, incl. the new `ElementResidualsMatchCentralDifference` FD guard).
- New end-to-end regression `test_ejector_runner_solves_unchoked_jet_pump_regime`; retained the cold double-choked critical solve.

## Docs
- Refreshed the now-multi-regime scope notes in `include/ejector.h`, `src/ejector.cpp`, `python/combaero/_core.cpp`, `docs/API_PYTHON.md`, and `validation/ejector/README.md`.
- Recorded the full arc + the C++-assembly move in `OPERATING_REGIMES_DESIGN.md` sec 6c/8.3; removed a superseded groundwork note.

## Notes for review
- The `_and_jacobian` closures + the element function are solver-internal (`combaero._solver_tools`), a tier below the documented public API, so no `units_data.h`/`API_*.md` sync is required (consistent with the other ejector closures; `test_units_sync` passes).
- History is 11 well-scoped commits (increments 1–4 → element integration → C++ port → docs) — **squash-merge** if you prefer a single commit on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
