### PR TITLE
docs(junction): correct the unverified Hager/Bassett accuracy claim (#272 step 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   version-sync checklist.
 
 ### Documentation
+- **Corrected the `BorderCarnotLossElement` / momentum-CV accuracy claim, which
+  was stated as fact in five places but is not established.** The Python
+  docstring, `include/solver_interface.h`, `include/multi_port_chamber.h`,
+  `docs/API_CPP.md` and the v3 addendum all asserted that
+  `L = 4*(1 - cos((3/4)*delta))^2` "reproduces Hager `xi_l` and Bassett `K_inc`
+  exactly at M -> 0". The repo's own Tier-1 tests
+  (`python/tests/test_momentum_cv_tier1_bassett.py`) are `xfail` and contradict
+  it. All five now state the anchoring as design intent with the measured
+  deviation and a pointer to issue #272, so nobody takes the element as
+  quantitatively validated against Hager/Bassett. **No behaviour change** --
+  the physics and the coefficient are untouched; only the accuracy claim is
+  corrected. Also refreshed the Tier-1 module docstring, which described a
+  model version predating the sin^2(theta) + cross-coupling integration
+  (including a sign-flipped `K_str`) and framed the disagreement as one
+  undisentangled question; it now carries the measured K table and separates
+  the two independent problems, and `experimental_bounded_solver.py` records
+  that bounds do *not* explain the gap.
 - **Documented the ejector's operating-regime limitations and the planned
   extension.** A new design note (`validation/ejector/OPERATING_REGIMES_DESIGN.md`)
   diagnoses a real non-converging low-primary-flow case: the critical-only

--- a/docs/API_CPP.md
+++ b/docs/API_CPP.md
@@ -842,9 +842,10 @@ MultiPortChamberResult multi_port_chamber_residuals_and_jacobian(
     const std::vector<double>& A);
 
 // Two-port in-line loss element: Pt_in - Pt_out - L*0.5*rho*u_in^2 = 0.
-// L applies the Hager (3/4) effective-angle correction; reproduces Hager xi_l
-// and Bassett K_inc exactly at M -> 0 on a sharp-edged lateral. Sign-free in
-// mdot (mdot^2 in the dynamic head).
+// L applies the Hager (3/4) effective-angle correction, INTENDED to reproduce
+// Hager xi_l and Bassett K_inc at M -> 0 on a sharp-edged lateral -- unverified,
+// Tier-1 tests xfail at 11-29% deviation (issue #272). Sign-free in mdot
+// (mdot^2 in the dynamic head).
 BorderCarnotLossResult border_carnot_loss_residual_and_jacobian(
     double mdot,
     double Pt_in, double Pt_out,

--- a/include/multi_port_chamber.h
+++ b/include/multi_port_chamber.h
@@ -42,8 +42,10 @@ inline constexpr double HAGER_FRACTION = 0.75;
 inline constexpr double MACH_CHOKE_THRESHOLD = 0.95;
 
 // Border-Carnot dynamic-head prefactor in L_i = 4 * (1 - cos(theta_eff))^2.
-// PDF Section 3.1: the squared form (vs the naive 2*(1-cos(theta)) linear
-// form) reproduces Hager xi_l and Bassett K_inc exactly at M -> 0.
+// PDF Section 3.1 claims the squared form (vs the naive 2*(1-cos(theta))
+// linear form) reproduces Hager xi_l and Bassett K_inc exactly at M -> 0.
+// That claim is UNVERIFIED in this repo: the Tier-1 tests are xfail at
+// 11-29% deviation on the lateral (see issue #272).
 inline constexpr double BC_LOSS_PREFACTOR = 4.0;
 
 // -----------------------------------------------------------------------------

--- a/include/solver_interface.h
+++ b/include/solver_interface.h
@@ -623,8 +623,10 @@ MultiPortChamberResult multi_port_chamber_residuals_and_jacobian(
 // Two-port in-line element: stagnation drop across the port.
 //   R = Pt_in - Pt_out - L(delta_geom) * 0.5 * rho_in * u_in^2 = 0
 //   L = 4 * (1 - cos((3/4) * delta_geom))^2     (PDF Section 3.1)
-// Sign-free (mdot^2 in the dynamic head); matches Hager xi_l and Bassett K_inc
-// at M -> 0 on a sharp-edged lateral with the Hager (3/4) correction.
+// Sign-free (mdot^2 in the dynamic head). The (3/4) correction is INTENDED to
+// match Hager xi_l and Bassett K_inc at M -> 0 on a sharp-edged lateral; that
+// agreement is unverified (Tier-1 tests are xfail at 11-29% deviation, see
+// issue #272), so treat the anchoring as a design goal, not a property.
 struct BorderCarnotLossResult {
   double residual;
   double d_res_dPt_in;

--- a/python/combaero/network/components.py
+++ b/python/combaero/network/components.py
@@ -3472,9 +3472,14 @@ class BorderCarnotLossElement(NetworkElement):
         L = 4 * (1 - cos((3/4) * delta_geom))^2
 
     The (3/4) factor is Hager's effective-angle correction for sharp-edged
-    lateral branches. The form reproduces Hager xi_l and Bassett K_inc exactly
-    at M -> 0 on a sharp-edged 90-deg lateral. Straight-through ports
-    (delta_geom = 0) get L = 0 and need no loss element at all.
+    lateral branches. The form is *intended* to reproduce Hager xi_l and
+    Bassett K_inc at M -> 0 on a sharp-edged 90-deg lateral, but this is NOT
+    yet demonstrated: the Tier-1 tests
+    (``python/tests/test_momentum_cv_tier1_bassett.py``) are xfail, measuring
+    11-29% deviation from Bassett K6 on the lateral. See issue #272 -- do not
+    rely on this element being quantitatively anchored to Hager/Bassett.
+    Straight-through ports (delta_geom = 0) get L = 0 and need no loss element
+    at all.
 
     The element is sign-free in m_dot (mdot^2 in the dynamic head). The
     initial form has no direction asymmetry parameter; an

--- a/python/tests/experimental_bounded_solver.py
+++ b/python/tests/experimental_bounded_solver.py
@@ -3,14 +3,24 @@ Bounds experiment: does enforcing physical positivity (m_dot >= 0 on
 canonically forward channels, all pressures >= 0) make MPCE Tier-1 match
 Bassett K2/K6 at M -> 0?
 
-If yes: Tier-1 disagreement is solver landing on degenerate roots
-(bidirectional-flow basins that are mathematically valid but physically
-forbidden by the boundary conditions). Fix is to expose bounded
-least_squares as a solver option for MPCE networks.
+ANSWER (measured 2026-09-03): NO, and emphatically so. The bounded solve
+converges cleanly (|F| ~ 1e-11) yet lands FARTHER from Bassett K6 than the
+default solver at every q:
 
-If no: the PDF Section 3.4 formula itself is the problem -- no constant L
-in form-2 BorderCarnotLoss can match Bassett K6 = q^2 + 1 - 0.7654*q.
-Fix is to revisit the loss-element form.
+    q      K_lat bounded   K_lat default   Bassett K6
+   0.25       0.6799          0.7751         0.8712      (22% vs 11%)
+   0.50       0.4847          0.8657         0.8673      (44% vs  0.2%)
+   0.75       0.4145          1.2719         0.9885      (58% vs 29%)
+
+So Tier-1 disagreement is NOT the solver landing on degenerate roots, and
+promoting bounded least_squares to a production solver path would not fix it
+(it would make the lateral worse). By this file's own decision rule the PDF
+Section 3.4 formula is the problem: the loss-element form / cross-coupling
+projection is what needs revisiting. Tracked as issue #272.
+
+Kept as the record of that experiment and as a bounded-solver harness; the
+K_lateral test below is left FAILING on purpose so the finding is not
+silently lost. Not collected by default (filename is not test_*.py).
 
 The experiment wraps scipy.optimize.least_squares(method='trf', bounds=...)
 around NetworkSolver's existing _residuals_and_jacobian() callable. The

--- a/python/tests/test_momentum_cv_tier1_bassett.py
+++ b/python/tests/test_momentum_cv_tier1_bassett.py
@@ -1,36 +1,56 @@
 """
 Tier 1 validation: MPCE + BorderCarnotLoss vs Bassett 2001 / Hager 1984 at M -> 0.
 
-STATUS: tests are xfail. The PDF Section 3.4 claim "MPCE + loss element form 2
-reproduces Hager exactly at M -> 0" does NOT hold empirically as set up here.
+STATUS: both K tests are xfail. The PDF Section 3.4 claim "MPCE + loss element
+form 2 reproduces Hager exactly at M -> 0" does NOT hold. Tracked as issue #272.
 
-The disagreement could come from EITHER of two sources (or both); this file
-does not yet disentangle them:
+MEASURED (2026-09-03, sin^2(theta) impulse + cross-coupling in place, imposed-q
+network below, M_com = 0.025 throughout). K is defined here as
+(Pt_com - Pt_port) / q_dyn_com, so positive K = stagnation loss:
 
-1. PDF formula mismatch (algebra).
-   MPCE impulse + MCN KE coupling gives, at equal areas low Mach:
-     K_straight_MPCE = q^2 - 2*q          (not Hager xi_t = q^2 - 0.5*q)
-     K_lateral_MPCE  = q^2 - 1            (not Bassett K6 = q^2 + 1 - 0.7654*q)
-   Form-2 BorderCarnotLoss adds K_loss = L*q^2 with constant L for the
-   lateral; no constant L makes (1+L)*q^2 - 1 equal Bassett K6 across q.
+    q     K_str   Bassett K2    K_lat   Bassett K6   K_lat bounded-LM
+   0.25   0.4375     0.1875     0.7751     0.8712        0.6799
+   0.50   0.7500     0.0000     0.8657     0.8673        0.4847
+   0.75   0.9375    -0.0625     1.2719     0.9885        0.4145
 
-2. Solver finding a degenerate near-root.
-   The momentum-CV junction has multiple near-singular directions in its
-   Jacobian (sum-mass residual lives in a left-null direction of the
-   pressure block; impulse residuals are sign-free so flow direction can
-   flip). Newton lands on whichever locally-zero residual basin is
-   closest to the initial guess; that basin may not be the physically
-   correct root. We see this in the smoke tests too (test_three_port_*).
+Two SEPARATE problems, not one. Earlier revisions of this docstring framed it
+as a single undisentangled question and quoted formulas from a model version
+that predates the sin^2(theta) + cross-coupling integration; both are corrected
+here against the numbers above.
 
-Resolution requires both:
-- Verifying converged residual norm matches PDF expectations at the imposed q
-  (rules out solver degeneracy), AND
-- Either (a) revisiting the loss-element form (linear-in-q? referenced to
-  q_common not q_local?) or (b) accepting the PDF spec as approximate.
+1. K_straight: a MODEL gap, and the cleaner of the two.
+   The sin^2(theta) projection gives exactly K_str = 2*q - q^2 (reproduced to
+   4 decimals in the table, under BOTH the default and the bounded solver --
+   it is solver-independent), against Bassett K2 = q^2 - 1.5*q + 0.5. These
+   are different functions, not a tuning discrepancy: they cross zero in
+   different places and have opposite slope over Bassett's range. Either the
+   straight-port projection is wrong, or Bassett K2 is outside what the
+   impulse formulation can represent. That decision has not been made.
+   (Note the sign convention: 2*q - q^2, NOT the q^2 - 2*q quoted by older
+   comments -- the measured values are positive.)
 
-Tier 1 is foundational: until this is sorted, Tier 2 (Pérez-García / Wang
+2. K_lateral: closer, and NOT explained by solver basin choice.
+   The default solver agrees with Bassett K6 to 11.0% / 0.2% / 28.7% at
+   q = 0.25 / 0.5 / 0.75 -- it fails the 20%-or-0.15-absolute tolerance only
+   at q = 0.75. An earlier hypothesis held that bounds (enforcing physically
+   forward flow) would fix this; experimental_bounded_solver.py tests it and
+   the answer is NO -- bounded least_squares converges cleanly (|F| ~ 1e-11)
+   and lands FARTHER from K6 (22% / 44% / 58%), i.e. worse than the default
+   solver at every q. Degenerate-root selection is therefore ruled out as the
+   explanation, and the remaining candidates are the loss-element form or the
+   cross-coupling projection.
+
+Both xfails are strict=False, so they will not fail loudly if a change happens
+to fix them; re-check the table above after touching the junction closure.
+
+Tier 1 is foundational: until this is sorted, Tier 2 (Perez-Garcia / Wang
 compressible) rides on a low-Mach baseline that already disagrees with the
 canonical reference. See docs/junction/tier2_reference_data.md.
+
+Regenerate the table by calling _extract_K_at_imposed_q(q) below for the
+default-solver columns, and with
+  uv run pytest python/tests/experimental_bounded_solver.py -s
+for the bounded-LM column.
 """
 
 import math
@@ -153,12 +173,12 @@ def _extract_K_at_imposed_q(q: float) -> dict[str, float]:
 
 @pytest.mark.xfail(
     reason=(
-        "MPCE+cross-coupling reproduces Bassett K6 within ~15% under bounded "
-        "least_squares (see experimental_bounded_solver.py). The default "
-        "NetworkSolver (hybr -> LM) lands on a different basin for this "
-        "imposed-q setup -- the Newton problem is harder with cross-coupling "
-        "active. Switching the production solver to bounded LM for MPCE "
-        "networks is a separate work item."
+        "K_lateral agrees with Bassett K6 to 11.0% / 0.2% / 28.7% at "
+        "q = 0.25 / 0.5 / 0.75 -- only q=0.75 misses the tolerance. Bounds "
+        "do NOT explain the gap: experimental_bounded_solver.py converges to "
+        "|F| ~ 1e-11 and lands farther out (22% / 44% / 58%), so degenerate-"
+        "root selection is ruled out. Remaining candidates are the loss-"
+        "element form and the cross-coupling projection. Issue #272."
     ),
     strict=False,
 )
@@ -166,10 +186,9 @@ def test_low_mach_K_lateral_agrees_with_bassett_K6():
     """Sweep q over Bassett's range, compare K_lateral to K6.
 
     With sin^2(theta) impulse + cross-coupling (Bassett axial momentum +
-    wall reaction Eq 3-4) integrated into MPCE, K_lat matches Bassett
-    K6 = 1 + q^2 - 2*q*cos((3/4)*theta) within ~15% under the bounded LM
-    solver. With the default solver it lands on a different basin -- see
-    xfail reason.
+    wall reaction Eq 3-4) integrated into MPCE, K_lat tracks Bassett
+    K6 = 1 + q^2 - 2*q*cos((3/4)*theta) closely at low q and diverges as q
+    rises. See the module docstring for the measured table.
     """
     results = []
     for q in [0.25, 0.5, 0.75]:
@@ -198,9 +217,12 @@ def test_low_mach_K_lateral_agrees_with_bassett_K6():
 
 @pytest.mark.xfail(
     reason=(
-        "Empirically MPCE alone does not reproduce Hager xi_t / Bassett K2 "
-        "at M -> 0. Could be PDF formula mismatch or solver degeneracy. "
-        "See module docstring."
+        "MODEL gap, not solver degeneracy: the sin^2(theta) projection gives "
+        "exactly K_str = 2*q - q^2 under BOTH the default and the bounded "
+        "solver, against Bassett K2 = q^2 - 1.5*q + 0.5 -- different "
+        "functions, opposite slope over Bassett's range. Either the "
+        "straight-port projection is wrong or K2 is outside what the impulse "
+        "formulation can represent; undecided. Issue #272."
     ),
     strict=False,
 )

--- a/python/tests/test_momentum_cv_vs_tee.py
+++ b/python/tests/test_momentum_cv_vs_tee.py
@@ -27,7 +27,10 @@ What's worth verifying here:
 
 Tier-1 (Hager / Bassett digitised CSVs under docs/bassett/) and Tier-2
 (Perez-Garcia / Wang compressible reference data under docs/junction/) are
-the strict numerical validations; they live in separate test files (TBD).
+the strict numerical validations. Tier-1 lives in
+test_momentum_cv_tier1_bassett.py and is currently xfail -- the momentum-CV
+match at M -> 0 that the PDF promises is NOT established (issue #272).
+Tier-2 has reference data but no tests yet.
 This file is the qualitative agreement check.
 """
 


### PR DESCRIPTION
Step 1 of #272 -- the cheap, independent part: fix documentation that states things the code contradicts. **No behaviour change**; physics, coefficients and test outcomes are untouched (2 xfail / 17 pass before and after).

## 1. The accuracy claim that isn't true

`L = 4*(1 - cos((3/4)*delta))^2` was documented in **five places** as reproducing Hager `xi_l` and Bassett `K_inc` *"exactly at M -> 0"*:

- `python/combaero/network/components.py` (`BorderCarnotLossElement` docstring)
- `include/solver_interface.h`
- `include/multi_port_chamber.h`
- `docs/API_CPP.md`
- `docs/junction/junction_model_v3_addendum.md` (gitignored -- edited locally, not in this commit)

The repo's own Tier-1 tests are `xfail` and contradict it. All now state the anchoring as design intent, with the measured deviation and a pointer to #272, so the element is not mistaken for validated against Hager/Bassett.

## 2. Tier-1 docs refreshed against measured values

The `test_momentum_cv_tier1_bassett.py` module docstring described a model version **predating** the sin^2(theta) + cross-coupling integration, quoted a **sign-flipped** `K_str`, and framed the disagreement as one undisentangled "formula mismatch OR solver degeneracy" question. Measured now (M_com = 0.025):

| q | K_str | Bassett K2 | K_lat | Bassett K6 | K_lat bounded-LM |
|---|---|---|---|---|---|
| 0.25 | 0.4375 | 0.1875 | 0.7751 | 0.8712 | 0.6799 |
| 0.50 | 0.7500 | 0.0000 | 0.8657 | 0.8673 | 0.4847 |
| 0.75 | 0.9375 | -0.0625 | 1.2719 | 0.9885 | 0.4145 |

These are two independent problems, and the docstring now says so:

- **`K_straight` is a solver-independent MODEL gap.** The sin^2(theta) projection gives exactly `2q - q^2` (matching the table to 4 decimals under *both* solvers) against Bassett K2 `= q^2 - 1.5q + 0.5` -- different functions with opposite slope over the range. Confirms `experimental_bounded_solver.py`'s sign convention and refutes the module docstring's `q^2 - 2q`.
- **`K_lateral` is 11.0% / 0.2% / 28.7% off K6**, failing the 20%-or-0.15-absolute tolerance only at q = 0.75.

## 3. Both xfail reasons stated the opposite of what the code measures

The lateral `xfail` claimed bounded `least_squares` recovers ~15% agreement and that the default solver lands on a wrong basin, with "switching the production solver to bounded LM" as the implied fix. Running `experimental_bounded_solver.py` today: the bounded solve **converges cleanly** (`|F| ~ 1e-11`) and lands **farther** from K6 -- 22% / 44% / 58%, worse than the default at every q.

**Degenerate-root selection is ruled out as the explanation, and promoting bounded LM to a production solver path would not fix Tier 1.** That file was written to answer exactly this question; its docstring now records the answer instead of the hypothesis. This also revises what I put in #272 when I opened it -- I will update the issue.

The `K_straight` xfail said "tracked separately"; that tracking never existed and is now #272.

## Notes

- `experimental_bounded_solver.py` is not collected by default (filename is not `test_*.py`, verified via `--collect-only`), so its deliberately-failing lateral test does not affect CI. It is left failing on purpose, and the docstring says so, rather than being relaxed into a false green.
- Both Tier-1 xfails remain `strict=False`, so a fix would silently xpass. Flipping them to strict belongs with the fix that closes each branch (#272 steps 2-3), not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RNDxZouiHoJdaLpnnPjHq
