### PR TITLE
fix(network): infer flow area from every area-bearing neighbour (#262)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   does not otherwise (no solver init strategy cracks it without the seed).
 
 ### Changed
+- **Flow-area inference now consults every area-bearing neighbour, and refuses
+  to invent an area it cannot determine (issue #262).** Seven `resolve_topology`
+  sites searched only for a neighbouring `ChannelElement` and, failing that,
+  substituted a hard-coded constant (0.01 / 0.02 / 0.1 m^2). With a non-channel
+  neighbour -- a momentum chamber, a combustor, an ejector outlet -- that
+  fabricated a geometry the network does not contain: the reported case
+  (`momentum_chamber (0.15 m^2) -> area_change -> channel (0.636 m^2)`) resolved
+  `F0 = 0.01`, a 63.6x expansion out of nothing, and stalled the solver with a
+  message that blamed the solver rather than the geometry. In simpler chains it
+  is worse than a stall -- it converges, inflating the chamber stagnation
+  pressure by 4% at 1 kg/s, 64% at 5 kg/s and 342% at 20 kg/s.
+  All seven sites now share one inference path (channels first, so networks that
+  resolved before resolve identically; then other area-bearing elements; then
+  adjacent nodes whose area was set explicitly). An auto-sized area is never
+  used as a source.
+  **Breaking:** where the area *is* the geometry being modelled --
+  `AreaChangeElement` (`F0`/`F1`), `ChannelElement` (`diameter`),
+  `TeeJunctionElement` (`F_C`), `BorderCarnotLossElement` (`area`) -- an
+  unresolvable area now raises a `ValueError` naming the component, the
+  parameter that clears it, and where the search looked, instead of silently
+  defaulting. Networks that relied on those defaults must set the value
+  explicitly or give a neighbour a known area; both clear the error. Where the
+  area is only a dynamic-head reference (`MomentumChamberNode`,
+  `CombustorNode`, `PressureLossElement`) a nominal default still stands, since
+  a network can legitimately never read it -- `PressureLossElement` warns when a
+  head-loss correlation will actually consume the defaulted value, and stays
+  quiet for fraction-based correlations that never touch it.
 - **`EjectorElement` now evaluates its residuals and a FULL analytic
   Jacobian (all four rows) through the C++ `(f, J)` path** rather than the
   pure-Python reference physics plus a finite-difference Jacobian fallback.

--- a/docs/API_PYTHON.md
+++ b/docs/API_PYTHON.md
@@ -555,6 +555,47 @@ ejector = EjectorElement(
 # regime is modeled.
 ```
 
+### Flow-Area Inference
+
+Components that need a reference flow area infer one from the topology when you
+do not supply it. Inference searches the neighbourhood of the attached nodes:
+channels first (so networks that resolved before resolve identically), then any
+other area-bearing element (`AreaChangeElement`, `TeeJunctionElement`,
+`BorderCarnotLossElement`, `PressureLossElement`), then adjacent nodes whose
+area you set explicitly (`MomentumChamberNode`, `CombustorNode`). An area that
+was itself auto-sized is never used as a source -- inheriting a placeholder
+would launder one guess into another.
+
+What happens when nothing can be inferred depends on what the area means:
+
+| Component | Parameter | Unresolvable |
+|---|---|---|
+| `AreaChangeElement` | `F0`, `F1` | **raises** |
+| `ChannelElement` | `diameter` | **raises** |
+| `TeeJunctionElement` | `F_C` | **raises** |
+| `BorderCarnotLossElement` | `area` | **raises** |
+| `MomentumChamberNode` | `area` | nominal default |
+| `CombustorNode` | `area` | nominal default |
+| `PressureLossElement` | `area` | nominal default, warns if a head-loss correlation reads it |
+
+The first group raises because the area *is* the geometry being modelled -- a
+default there invents a contraction or expansion the network does not contain,
+and the solver either stalls on it or converges to a confidently wrong answer.
+The second group defaults because the area is only a dynamic-head reference and
+a network can legitimately never read it.
+
+```python
+# Unresolvable -> a named error saying which parameter clears it
+AreaChangeElement("expansion", "plenum_a", "plenum_b")
+# ValueError: AreaChangeElement 'expansion': cannot determine upstream area F0
+# -- no neighbouring channel, area-bearing element or node with a known area
+# was found at 'plenum_a'. Set upstream area F0 explicitly ...
+
+# Either fix clears it: set the value, or give a neighbour a known area
+AreaChangeElement("expansion", "plenum_a", "plenum_b", F0=0.05, F1=0.08)
+MomentumChamberNode("chamber", area=0.15)  # neighbour the area change can read
+```
+
 ### Combustion Integration
 ```python
 from combaero.network.combustion import (

--- a/docs/archive/AREA_INFERENCE_262.md
+++ b/docs/archive/AREA_INFERENCE_262.md
@@ -1,0 +1,92 @@
+# Flow-Area Inference: Provenance Record (issue #262)
+
+Why the area-inference rules are what they are. The contract itself lives in
+[API_PYTHON.md](../API_PYTHON.md) ("Flow-Area Inference"); the behaviour is
+pinned by `python/tests/test_area_inference.py`.
+
+## The defect
+
+Seven `resolve_topology` implementations searched for a neighbouring
+`ChannelElement` and, when none was found, assigned a hard-coded constant
+(0.01 / 0.02 / 0.1 m^2). Those constants trace to "something had to be there",
+not to any geometry -- the fudge-shaped-constant case the model-provenance
+discipline exists to catch. With a non-channel neighbour (a momentum chamber,
+a combustor, an ejector outlet) the fallback fabricated an area that the
+network does not contain.
+
+## What the audit established
+
+Two measurements decided the design; neither was predictable from reading the
+code.
+
+**1. Which sites are genuinely affected.** Probing all seven with a
+non-channel, area-bearing neighbour: six resolved to their hard-coded default
+and ignored the real neighbour area; `BorderCarnotLossElement` refused to
+guess and raised, which is where the "raise, don't default" precedent came
+from.
+
+**2. Which defaults are load-bearing.** Counting fallback hits across the test
+suite, then perturbing the constant 0.1 -> 0.2 and re-running:
+
+| site | suite hits | of which a neighbour area existed | sensitive to the value |
+|---|---|---|---|
+| `AreaChangeElement.F0` / `.F1` | 0 | - | - |
+| `TeeJunctionElement.F_C` | 0 | - | - |
+| `ChannelElement.diameter` | 0 | - | - |
+| `MomentumChamberNode.area` | 20 | 2 | no |
+| `CombustorNode.area` | 29 | 0 | no |
+| `PressureLossElement.area` | 13 | 0 | 3 tests |
+
+The three sites the issue is actually about are never exercised, so making
+them raise costs nothing. The three that fire constantly are insensitive to
+the value in 59 of 62 cases -- in 60 of 62 no neighbour area exists anywhere,
+so inference cannot rescue them and a raise would force a migration on
+networks that are working correctly.
+
+## Formulation chosen
+
+Split by what the area *means*, not by node-versus-element:
+
+- **The area is the geometry being modelled** (`AreaChangeElement` F0/F1,
+  `ChannelElement` diameter, `TeeJunctionElement` F_C,
+  `BorderCarnotLossElement` area) -- raise. A default here invents a
+  contraction or expansion, and no value is defensible.
+- **The area is a dynamic-head reference** (`MomentumChamberNode`,
+  `CombustorNode`, `PressureLossElement`) -- default, but warn when a
+  correlation will actually consume it. `PressureLossElement` warns only for
+  head-loss correlations (which read `area`), not fraction-based ones (which
+  do not). Across 1891 tests this fires on exactly the 3 the perturbation
+  audit flagged as sensitive: no false positives, no misses.
+
+Channels keep first priority in the search so that every network which
+resolved before resolves to the same area now.
+
+## Invariant
+
+An area may be inferred only from a *known* area -- one the user set, or one
+already resolved from a known area. An auto-sized area is never a source;
+inheriting a placeholder launders one guess into another. Pinned by
+`test_auto_sized_neighbour_is_not_used_as_a_source`.
+
+## Alternatives considered
+
+- **Raise at all seven sites.** Rejected on the measurement above: it breaks
+  60 in-suite cases where nothing can be inferred and the value is never read.
+- **Warn at all six defaulting sites.** Rejected as crying wolf -- 59 of 62
+  hits are inert, and a warning that fires on correct networks trains users to
+  ignore it.
+- **Mirror the GUI's node-area lookup into the library.** The lookup in
+  `gui/backend/graph_builder.py` covered `discrete_loss` only and made GUI and
+  headless networks resolve different areas. Superseded rather than copied:
+  the shared path now covers it and the GUI-side special case was removed.
+
+## Dead end
+
+The reported symptom was a solver stall, and the stall could not be reproduced
+in a minimal fixture -- it needed the full ejector network. Mass-flow-driven
+and pressure-driven chains both converge with the fabricated area. That turned
+out to matter: in a plain chain the fabricated throat is *worse* than a stall,
+converging confidently to a wrong answer (chamber stagnation pressure inflated
+by 4% at 1 kg/s, 64% at 5 kg/s, 342% at 20 kg/s). The regression test pins
+that pressure against the physical dynamic head rather than asserting
+convergence, which the pre-fix code also satisfied.

--- a/gui/backend/graph_builder.py
+++ b/gui/backend/graph_builder.py
@@ -940,14 +940,11 @@ def build_network_from_schema(schema: NetworkGraphSchema) -> FlowNetwork:
             net.add_element(elem)
         elif elem_type == "discrete_loss":
             data = DiscreteLossData(**elem_data)
-            # area=None signals "inherit from upstream element in resolve_topology".
-            # Use a quick node-area lookup only when data.area is explicitly set or
-            # the upstream node exposes a non-zero area (combustor / momentum chamber).
+            # area=None signals "inherit from the topology in resolve_topology".
+            # The node-area lookup that used to live here is now part of the
+            # library's shared inference path, so GUI and headless networks
+            # resolve the same area (issue #262).
             area: float | None = data.area
-            if area is None and source_id in nodes_map:
-                node_area = getattr(nodes_map[source_id], "area", None)
-                if node_area and node_area > 0:
-                    area = node_area
             correlation = _build_discrete_loss_correlation(
                 data.correlation_type,
                 data.xi,

--- a/python/combaero/network/components.py
+++ b/python/combaero/network/components.py
@@ -475,6 +475,146 @@ class NetworkMixtureState:
         return cp / cv if cv > 0 else 1.4
 
 
+#: Nominal cross-section for a chamber-like node whose area could not be
+#: inferred and which nothing in the network measures against. It is a
+#: bookkeeping placeholder, not a geometry: components for which the area IS
+#: the physics (AreaChangeElement, ChannelElement, TeeJunctionElement) refuse
+#: to default and raise instead. Any consumer of a defaulted area reports
+#: ``area_source = "default"`` in its diagnostics (issue #262).
+DEFAULT_CHAMBER_AREA = 0.1
+
+
+# ---------------------------------------------------------------------------
+# Flow-area inference
+# ---------------------------------------------------------------------------
+# Elements and nodes that need a reference flow area infer one from the
+# topology when the user did not supply it.  Historically every such site
+# searched for a neighbouring ChannelElement only and, failing that, fell back
+# to a hard-coded constant (0.01 / 0.02 / 0.1 m^2).  Those constants trace to
+# "something had to be there", not to any geometry: with a non-channel
+# neighbour -- a momentum chamber, a combustor, an ejector outlet -- the
+# fallback fabricated an area change that never existed, and the resulting
+# residual is unsatisfiable at the real mass flow, so the solver stalls with a
+# message that blames the solver rather than the geometry (issue #262).
+#
+# _infer_flow_area consults every area-bearing neighbour instead.  Channels
+# keep the highest priority so that networks which resolved before resolve to
+# the same area now.
+
+
+def _known_node_area(node: "NetworkNode | None") -> float | None:
+    """Flow area of a node, but only when it is genuinely known.
+
+    A node whose area was auto-sized rather than user-supplied
+    (``_auto_area``) carries a placeholder, not a measurement; inferring from
+    it would launder one guess into another.
+    """
+    if node is None or getattr(node, "_auto_area", True):
+        return None
+    area = getattr(node, "area", None)
+    return float(area) if area is not None and area > 0.0 else None
+
+
+def _element_area_facing(elem: "NetworkElement", node_id: str) -> float | None:
+    """Flow area the element presents to ``node_id``, or None if it has none.
+
+    Orifices are deliberately excluded: a bore is a restriction, not the
+    channel area a neighbour should inherit.
+    """
+    if isinstance(elem, ChannelElement):
+        if elem.diameter is not None:
+            return math.pi * (elem.diameter / 2.0) ** 2
+        return None
+    if isinstance(elem, AreaChangeElement):
+        # The element changes area across itself, so the face matters.
+        if elem.to_node == node_id:
+            return float(elem.F1) if elem.F1 is not None else None
+        if elem.from_node == node_id:
+            return float(elem.F0) if elem.F0 is not None else None
+        return None
+    if isinstance(elem, TeeJunctionElement):
+        if elem.F_C is None:
+            return None
+        # Branch arm carries F_C/psi; straight and common arms carry F_C.
+        if node_id == elem.branch_node:
+            return float(elem.F_C) / elem.psi
+        return float(elem.F_C)
+    if isinstance(elem, (BorderCarnotLossElement, PressureLossElement)):
+        return float(elem.area) if elem.area is not None else None
+    return None
+
+
+def _infer_flow_area(
+    graph: "FlowNetwork",
+    node_ids: "list[str]",
+    exclude: "NetworkElement | None" = None,
+) -> "tuple[float | None, str]":
+    """Infer a flow area from the neighbourhood of ``node_ids``.
+
+    Returns ``(area, provenance)``; ``area`` is None when nothing in the
+    neighbourhood knows one, and ``provenance`` names the source so callers
+    can report where a resolved area came from.
+
+    Channels are searched first across all of ``node_ids`` so that a network
+    which previously resolved from a channel still resolves to that channel's
+    area regardless of what else is attached.
+    """
+    neighbours: list[tuple[str, NetworkElement]] = []
+    for node_id in node_ids:
+        for elem in graph.get_upstream_elements(node_id) + graph.get_downstream_elements(node_id):
+            if elem is exclude:
+                continue
+            neighbours.append((node_id, elem))
+
+    for node_id, elem in neighbours:
+        if isinstance(elem, ChannelElement):
+            area = _element_area_facing(elem, node_id)
+            if area is not None:
+                return area, f"channel '{elem.id}'"
+
+    for node_id, elem in neighbours:
+        area = _element_area_facing(elem, node_id)
+        if area is not None:
+            return area, f"{type(elem).__name__} '{elem.id}'"
+
+    for node_id in node_ids:
+        area = _known_node_area(graph.nodes.get(node_id))
+        if area is not None:
+            return area, f"node '{node_id}'"
+
+    for node_id, elem in neighbours:
+        for other in set(elem.all_source_nodes()) | set(elem.all_sink_nodes()):
+            if other == node_id:
+                continue
+            area = _known_node_area(graph.nodes.get(other))
+            if area is not None:
+                return area, f"node '{other}'"
+
+    return None, ""
+
+
+def _unresolved_area_error(
+    component: "NetworkNode | NetworkElement",
+    parameter: str,
+    node_ids: "list[str]",
+) -> ValueError:
+    """The error raised when a load-bearing flow area cannot be inferred.
+
+    Names the component, the parameter that clears the error, and where the
+    search looked -- a defaulted area here fabricates geometry, so failing
+    loudly is the only honest option (issue #262).
+    """
+    where = ", ".join(f"'{n}'" for n in node_ids)
+    return ValueError(
+        f"{type(component).__name__} '{component.id}': cannot determine "
+        f"{parameter} -- no neighbouring channel, area-bearing element or "
+        f"node with a known area was found at {where}. Set {parameter} "
+        f"explicitly on this component (or give a neighbour a known area). "
+        f"A default would fabricate a geometry that does not exist and the "
+        f"solver would stall on it."
+    )
+
+
 class NetworkNode(ABC):
     #: True when this node supplies a meaningful temperature-rise ratio theta
     #: (T_burned / T_unburned - 1).  Read by ``PressureLossElement`` with
@@ -796,6 +936,8 @@ class MomentumChamberNode(NetworkNode):
         super().__init__(id)
         self._auto_area = area is None
         self.area = area if area is not None else 0.0
+        #: Where self.area came from once resolved (issue #262).
+        self._area_source = "user" if area is not None else ""
         self.port_angles_deg: dict[str, float] = port_angles_deg or {}
         self.length = length
         self.Dh = Dh
@@ -988,7 +1130,23 @@ class MomentumChamberNode(NetworkNode):
             self.area = math.pi * (self.Dh / 2.0) ** 2
             self.surface.area = self.area
         elif self._auto_area:
-            self.area = 0.1  # fallback (same as original default)
+            # No channel to inherit from: widen the search to any area-bearing
+            # neighbour before falling back (issue #262).
+            area, source = _infer_flow_area(graph, [self.id])
+            if area is not None:
+                self.area = area
+                self.Dh = 2.0 * math.sqrt(area / math.pi)
+                self.surface.area = area
+                self._area_source = source
+            else:
+                # Unlike AreaChangeElement, this area is a dynamic-head
+                # reference rather than the geometry being modelled, and a
+                # network can legitimately never read it -- so a nominal
+                # default stands. It is recorded, not silent: anything that
+                # consumes it reports the provenance in diagnostics.
+                self.area = DEFAULT_CHAMBER_AREA
+                self.surface.area = self.area
+                self._area_source = "default"
 
 
 class PressureBoundary(NetworkNode):
@@ -1142,6 +1300,8 @@ class CombustorNode(NetworkNode):
         self.method = method
         self._auto_area = area is None
         self.area = area if area is not None else 0.0
+        #: Where self.area came from once resolved (issue #262).
+        self._area_source = "user" if area is not None else ""
         self.Dh = Dh
         self.surface = surface or ConvectiveSurface()
         self.t_hot = t_hot
@@ -1328,7 +1488,23 @@ class CombustorNode(NetworkNode):
             self.area = math.pi * (self.Dh / 2.0) ** 2
             self.surface.area = self.area
         elif self._auto_area:
-            self.area = 0.1  # fallback (same as original default)
+            # No channel to inherit from: widen the search to any area-bearing
+            # neighbour before falling back (issue #262).
+            area, source = _infer_flow_area(graph, [self.id])
+            if area is not None:
+                self.area = area
+                self.Dh = 2.0 * math.sqrt(area / math.pi)
+                self.surface.area = area
+                self._area_source = source
+            else:
+                # Unlike AreaChangeElement, this area is a dynamic-head
+                # reference rather than the geometry being modelled, and a
+                # network can legitimately never read it -- so a nominal
+                # default stands. It is recorded, not silent: anything that
+                # consumes it reports the provenance in diagnostics.
+                self.area = DEFAULT_CHAMBER_AREA
+                self.surface.area = self.area
+                self._area_source = "default"
 
 
 class OrificeElement(NetworkElement):
@@ -1947,6 +2123,8 @@ class PressureLossElement(NetworkElement):
         self.correlation = correlation
         self.theta_source = theta_source
         self.area = area
+        #: Where self.area came from once resolved (issue #262).
+        self._area_source = "user" if area is not None else ""
         self.surface = surface or ConvectiveSurface()
         # Resolved during resolve_topology.  Empty string sentinel disallowed
         # so callers can cleanly test ``if self._theta_source_resolved is not None``.
@@ -2003,7 +2181,32 @@ class PressureLossElement(NetworkElement):
                     self.area = math.pi / 4.0 * elem.diameter**2
                     break
             if self.area is None:
-                self.area = 0.1
+                # Widen to any area-bearing neighbour (a combustor or momentum
+                # chamber upstream is the common case) before defaulting.
+                area, source = _infer_flow_area(graph, [self.from_node, self.to_node], exclude=self)
+                if area is not None:
+                    self.area = area
+                    self._area_source = source
+            if self.area is None:
+                # A head-loss correlation reads this area as its velocity
+                # reference, so a wrong value rescales the loss rather than
+                # failing. Warn only when a correlation will actually consume
+                # it -- for a fraction-based correlation nothing reads it and
+                # a nominal value is harmless (issue #262).
+                self.area = DEFAULT_CHAMBER_AREA
+                self._area_source = "default"
+                if hasattr(self.correlation, "area"):
+                    warnings.warn(
+                        f"PressureLossElement '{self.id}': no flow area could be "
+                        f"inferred from the topology, so the nominal "
+                        f"{DEFAULT_CHAMBER_AREA} m^2 default is used as the "
+                        f"velocity reference for "
+                        f"{type(self.correlation).__name__}. The head loss scales "
+                        f"as 1/area^2 -- set 'area' explicitly to make it "
+                        f"meaningful.",
+                        UserWarning,
+                        stacklevel=2,
+                    )
             # Propagate updated area into head-loss correlations and convective surface.
             if hasattr(self.correlation, "area"):
                 self.correlation.area = self.area
@@ -2500,30 +2703,18 @@ class ChannelElement(NetworkElement):
     def resolve_topology(self, graph: "FlowNetwork") -> None:
         if self.diameter is not None:
             return
-        # Inherit diameter from the nearest upstream geometry source
-        sources = graph.get_upstream_elements(self.from_node) + graph.get_downstream_elements(
-            self.to_node
-        )
-        for elem in sources:
-            if isinstance(elem, ChannelElement) and elem.diameter is not None:
-                self.diameter = elem.diameter
-                break
-            if isinstance(elem, AreaChangeElement) and elem.F1 is not None:
-                self.diameter = math.sqrt(4.0 * elem.F1 / math.pi)
-                break
-            if isinstance(elem, TeeJunctionElement) and elem.F_C is not None:
-                # Branch arm carries F_C/psi; straight/common arm carries F_C
-                is_branch = self.from_node == elem.branch_node or self.to_node == elem.branch_node
-                area = elem.F_C / elem.psi if is_branch else elem.F_C
-                self.diameter = math.sqrt(4.0 * area / math.pi)
-                break
+        # Inherit diameter from the nearest geometry source. The channel's
+        # area sets its friction and Mach behaviour, so a defaulted diameter
+        # silently rewrites the flow; unresolvable is an error (issue #262).
+        area, _source = _infer_flow_area(graph, [self.from_node, self.to_node], exclude=self)
+        if area is not None:
+            self.diameter = math.sqrt(4.0 * area / math.pi)
         if self.diameter is None:
             if getattr(self, "_topo_pass", 0) >= 1:
-                self.diameter = 0.1  # fallback only after second pass
-            else:
-                # Defer: upstream tee may not have resolved F_C yet in this pass
-                self._topo_pass = 1
-                return
+                raise _unresolved_area_error(self, "diameter", [self.from_node, self.to_node])
+            # Defer: an upstream tee may not have resolved F_C yet this pass.
+            self._topo_pass = 1
+            return
         self.area = math.pi * (self.diameter / 2) ** 2
         if self.Dh is None:
             self.Dh = self.diameter
@@ -2554,6 +2745,9 @@ class AreaChangeElement(NetworkElement):
         self.model_type = model_type
         self.length = length if length is not None else 0.0
         self.D_h = D_h
+        # Where a resolved area came from, for diagnostics (issue #262).
+        self._F0_source = "user" if F0 is not None else ""
+        self._F1_source = "user" if F1 is not None else ""
 
     def unknowns(self) -> list[str]:
         return [f"{self.id}.m_dot"]
@@ -2562,20 +2756,18 @@ class AreaChangeElement(NetworkElement):
         return 1
 
     def resolve_topology(self, graph: "FlowNetwork") -> None:
+        # F0/F1 ARE the physics here: their ratio is the area change the
+        # element exists to model. A defaulted value invents a contraction or
+        # expansion the network does not contain, so an unresolvable area is
+        # an error rather than a guess (issue #262).
         if self.F0 is None:
-            for elem in graph.get_upstream_elements(self.from_node):
-                if isinstance(elem, ChannelElement) and elem.diameter is not None:
-                    self.F0 = math.pi * (elem.diameter / 2.0) ** 2
-                    break
+            self.F0, self._F0_source = _infer_flow_area(graph, [self.from_node], exclude=self)
             if self.F0 is None:
-                self.F0 = 0.01
+                raise _unresolved_area_error(self, "upstream area F0", [self.from_node])
         if self.F1 is None:
-            for elem in graph.get_downstream_elements(self.to_node):
-                if isinstance(elem, ChannelElement) and elem.diameter is not None:
-                    self.F1 = math.pi * (elem.diameter / 2.0) ** 2
-                    break
+            self.F1, self._F1_source = _infer_flow_area(graph, [self.to_node], exclude=self)
             if self.F1 is None:
-                self.F1 = 0.02
+                raise _unresolved_area_error(self, "downstream area F1", [self.to_node])
 
     def validate(self) -> None:
         if (self.F0 or 0.0) <= 0:
@@ -2830,10 +3022,23 @@ class TeeJunctionElement(NetworkElement):
                         found_fc = True
                         break
             if not found_fc:
+                # Widen to any area-bearing neighbour before giving up: the
+                # common/straight arms may be fed by a chamber or an area
+                # change rather than a channel (issue #262).
+                area, _source = _infer_flow_area(
+                    graph, [self.common_node, self.straight_node], exclude=self
+                )
+                if area is not None:
+                    self.F_C = area
+                    found_fc = True
+            if not found_fc:
+                # F_C sets every loss reference in the junction closure, so a
+                # default would silently rescale all of them.
                 if getattr(self, "_topo_pass", 0) >= 1:
-                    self.F_C = 0.01
-                else:
-                    self._topo_pass = 1
+                    raise _unresolved_area_error(
+                        self, "common-arm area F_C", [self.common_node, self.straight_node]
+                    )
+                self._topo_pass = 1
 
         # Step 2: resolve F_branch independently from the branch arm channel.
         if self._F_branch is None:
@@ -3498,6 +3703,7 @@ class BorderCarnotLossElement(NetworkElement):
         super().__init__(id, from_node, to_node)
         self.delta_geom_deg = float(delta_geom_deg)
         self.area = area
+        self._area_source = "user" if area is not None else ""
 
     def unknowns(self) -> list[str]:
         return [f"{self.id}.m_dot"]
@@ -3506,23 +3712,15 @@ class BorderCarnotLossElement(NetworkElement):
         return 1
 
     def resolve_topology(self, graph: "FlowNetwork") -> None:
+        # This element already refused to guess an area before #262; it now
+        # shares the widened inference path, so a chamber or area-change
+        # neighbour resolves it where only a channel used to.
         if self.area is None:
-            for elem in (
-                graph.get_upstream_elements(self.from_node)
-                + graph.get_downstream_elements(self.from_node)
-                + graph.get_upstream_elements(self.to_node)
-                + graph.get_downstream_elements(self.to_node)
-            ):
-                if elem is self:
-                    continue
-                if isinstance(elem, ChannelElement) and elem.diameter is not None:
-                    self.area = math.pi * (elem.diameter / 2.0) ** 2
-                    break
+            self.area, self._area_source = _infer_flow_area(
+                graph, [self.from_node, self.to_node], exclude=self
+            )
             if self.area is None:
-                raise ValueError(
-                    f"BorderCarnotLossElement '{self.id}': could not infer "
-                    f"area from a neighboring channel. Provide area explicitly."
-                )
+                raise _unresolved_area_error(self, "area", [self.from_node, self.to_node])
 
     def residuals(
         self, state_in: NetworkMixtureState, state_out: NetworkMixtureState

--- a/python/tests/test_area_inference.py
+++ b/python/tests/test_area_inference.py
@@ -1,0 +1,401 @@
+"""Flow-area inference from topology (issue #262).
+
+Ground truth for these tests is the network's own geometry, not the solver's
+previous output: when a component sits next to something whose area is known,
+the area it resolves MUST be that area. The bug being pinned here is that
+inference searched only for a neighbouring ChannelElement and, failing that,
+substituted a hard-coded constant -- so a chamber, combustor or area-change
+neighbour produced a fabricated area, a fabricated pressure change, and a
+solver stall whose message blamed the solver.
+
+Two behaviours are separated deliberately:
+
+* Where the area IS the geometry being modelled (AreaChangeElement F0/F1,
+  ChannelElement diameter, TeeJunctionElement F_C, BorderCarnotLossElement),
+  an unresolvable area raises. A default there invents a contraction or
+  expansion that does not exist.
+* Where the area is only a dynamic-head reference (MomentumChamberNode,
+  CombustorNode, PressureLossElement), a nominal default stands, because a
+  network can legitimately never read it. It warns only when a correlation
+  will actually consume it.
+
+Both must clear the moment the user supplies the value explicitly.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import math
+import warnings
+
+import pytest
+
+import combaero as cb
+from combaero.network import (
+    AreaChangeElement,
+    BorderCarnotLossElement,
+    ChannelElement,
+    CombustorNode,
+    FlowNetwork,
+    LosslessConnectionElement,
+    MassFlowBoundary,
+    MomentumChamberNode,
+    PlenumNode,
+    PressureBoundary,
+    PressureLossElement,
+    TeeJunctionElement,
+)
+from combaero.network.pressure_loss import ConstantFractionLoss, ConstantHeadLoss
+from combaero.network.solver import NetworkSolver
+
+_Y = list(cb.mole_to_mass(cb.species.dry_air()))
+_CHAMBER_AREA = 0.15
+_CHANNEL_D = 0.9
+_CHANNEL_AREA = math.pi * (_CHANNEL_D / 2.0) ** 2
+
+
+def _mfb(net: FlowNetwork, node_id: str = "mfb", m_dot: float = 1.0) -> None:
+    net.add_node(MassFlowBoundary(node_id, m_dot=m_dot, Tt=300.0, Y=_Y))
+
+
+def _pb(net: FlowNetwork, node_id: str = "pb", Pt: float = 1.0e5) -> None:
+    net.add_node(PressureBoundary(node_id, Pt=Pt, Tt=300.0, Y=_Y))
+
+
+# ---------------------------------------------------------------------------
+# The reported repro: chamber -> area_change -> channel -> boundary
+# ---------------------------------------------------------------------------
+
+
+def _build_repro(F0: float | None = None) -> tuple[FlowNetwork, AreaChangeElement]:
+    """The #262 network: an area change fed by a momentum chamber, not a channel.
+
+    Rebuilt programmatically rather than loaded from the reported export --
+    gui/tmp/ is gitignored, so the fixture has to carry the topology itself.
+    """
+    net = FlowNetwork()
+    _mfb(net)
+    net.add_node(MomentumChamberNode("chamber", area=_CHAMBER_AREA))
+    net.add_node(PlenumNode("mid"))
+    _pb(net)
+    net.add_element(LosslessConnectionElement("feed", "mfb", "chamber"))
+    area_change = AreaChangeElement("expansion", "chamber", "mid", F0=F0)
+    net.add_element(area_change)
+    net.add_element(ChannelElement("duct", "mid", "pb", diameter=_CHANNEL_D, length=1.0))
+    return net, area_change
+
+
+def test_area_change_takes_upstream_chamber_area_not_a_default():
+    """F0 must be the chamber's real area, not the 0.01 m^2 placeholder.
+
+    0.01 against the channel's 0.636 m^2 is a 63.6x sudden expansion that
+    exists nowhere in the network; its ~135 Pa dynamic head at the fictitious
+    throat is what the solver used to stall on.
+    """
+    net, area_change = _build_repro()
+    net.resolve_all_topology()
+
+    assert pytest.approx(_CHAMBER_AREA) == area_change.F0
+    assert pytest.approx(_CHANNEL_AREA) == area_change.F1
+
+
+def test_fabricated_area_would_corrupt_the_chamber_pressure():
+    """The consequence the fabricated area had on the answer, pinned by physics.
+
+    The reported symptom was a solver stall, but that needed the full ejector
+    network; in a plain chain the fabricated throat is worse than a stall --
+    it CONVERGES, confidently, to a badly wrong pressure. Measured against the
+    real 0.15 m^2 upstream area, the 0.01 m^2 placeholder inflated the chamber
+    stagnation pressure by 4% at 1 kg/s, 64% at 5 kg/s and 342% at 20 kg/s.
+
+    Ground truth here is the physics, not the previous output: expanding
+    0.15 -> 0.636 m^2 at 5 kg/s carries a chamber dynamic head of only ~480 Pa,
+    so the total-pressure rise above the outlet boundary cannot be more than a
+    few kPa. The fabricated throat produced 64 kPa.
+    """
+    net, _ = _build_repro()
+    net.nodes["mfb"].m_dot = 5.0
+
+    sol = NetworkSolver(net).solve(timeout=60.0)
+
+    assert sol["__success__"], f"solve failed: |F|={sol['__final_norm__']:.3e}"
+    rise = sol["chamber.Pt"] - 1.0e5
+    assert rise < 5.0e3, (
+        f"chamber Pt sits {rise:.0f} Pa above the outlet -- far beyond the "
+        f"~480 Pa dynamic head of a real 0.15 -> 0.636 m^2 expansion, which "
+        f"means a fabricated upstream area is back."
+    )
+
+
+def test_explicit_F0_is_never_overridden():
+    """A user-supplied area wins over anything inference would have found."""
+    net, area_change = _build_repro(F0=0.05)
+    net.resolve_all_topology()
+
+    assert pytest.approx(0.05) == area_change.F0
+
+
+# ---------------------------------------------------------------------------
+# Unresolvable areas raise, and manual input clears the error
+# ---------------------------------------------------------------------------
+
+
+def _build_unresolvable(F0: float | None = None, F1: float | None = None) -> FlowNetwork:
+    """An area change whose neighbours carry no area at all.
+
+    Plenums have no flow area and lossless connections have no geometry, so
+    there is genuinely nothing to infer from.
+    """
+    net = FlowNetwork()
+    _mfb(net)
+    net.add_node(PlenumNode("up"))
+    net.add_node(PlenumNode("down"))
+    _pb(net)
+    net.add_element(LosslessConnectionElement("feed", "mfb", "up"))
+    net.add_element(AreaChangeElement("expansion", "up", "down", F0=F0, F1=F1))
+    net.add_element(LosslessConnectionElement("exit", "down", "pb"))
+    return net
+
+
+def test_unresolvable_area_raises_instead_of_fabricating_one():
+    net = _build_unresolvable()
+
+    with pytest.raises(ValueError) as excinfo:
+        net.resolve_all_topology()
+
+    message = str(excinfo.value)
+    assert "AreaChangeElement 'expansion'" in message, "the error must name the component"
+    assert "F0" in message, "the error must name the parameter that clears it"
+    assert "'up'" in message, "the error must say where it looked"
+
+
+def test_manual_areas_clear_the_error():
+    """The user's fix path: supply the areas, and the network resolves."""
+    net = _build_unresolvable(F0=0.05, F1=0.08)
+
+    net.resolve_all_topology()  # must not raise
+
+    element = net.elements["expansion"]
+    assert pytest.approx(0.05) == element.F0
+    assert pytest.approx(0.08) == element.F1
+
+
+def test_manual_area_on_the_neighbour_also_clears_the_error():
+    """Giving a NEIGHBOUR a known area resolves it too -- inference, not just override."""
+    net = FlowNetwork()
+    _mfb(net)
+    net.add_node(MomentumChamberNode("up", area=0.2))
+    net.add_node(MomentumChamberNode("down", area=0.4))
+    _pb(net)
+    net.add_element(LosslessConnectionElement("feed", "mfb", "up"))
+    net.add_element(AreaChangeElement("expansion", "up", "down"))
+    net.add_element(LosslessConnectionElement("exit", "down", "pb"))
+
+    net.resolve_all_topology()
+
+    element = net.elements["expansion"]
+    assert pytest.approx(0.2) == element.F0
+    assert pytest.approx(0.4) == element.F1
+
+
+# ---------------------------------------------------------------------------
+# The same inference gap at the sibling sites named in the issue
+# ---------------------------------------------------------------------------
+
+
+def test_channel_inherits_diameter_from_a_chamber():
+    net = FlowNetwork()
+    _mfb(net)
+    net.add_node(MomentumChamberNode("chamber", area=_CHAMBER_AREA))
+    _pb(net)
+    net.add_element(LosslessConnectionElement("feed", "mfb", "chamber"))
+    channel = ChannelElement("duct", "chamber", "pb", length=1.0)
+    net.add_element(channel)
+
+    net.resolve_all_topology()
+
+    assert math.pi * (channel.diameter / 2.0) ** 2 == pytest.approx(_CHAMBER_AREA)
+
+
+def test_tee_junction_inherits_F_C_from_a_chamber():
+    net = FlowNetwork()
+    _mfb(net)
+    net.add_node(MomentumChamberNode("common", area=_CHAMBER_AREA))
+    net.add_node(PlenumNode("straight"))
+    net.add_node(PlenumNode("branch"))
+    _pb(net, "pb_straight")
+    _pb(net, "pb_branch")
+    net.add_element(LosslessConnectionElement("feed", "mfb", "common"))
+    tee = TeeJunctionElement(
+        "tee", common_node="common", straight_node="straight", branch_node="branch", theta=90.0
+    )
+    net.add_element(tee)
+    net.add_element(LosslessConnectionElement("out_s", "straight", "pb_straight"))
+    net.add_element(LosslessConnectionElement("out_b", "branch", "pb_branch"))
+
+    net.resolve_all_topology()
+
+    assert pytest.approx(_CHAMBER_AREA) == tee.F_C
+
+
+def test_border_carnot_loss_inherits_area_from_a_chamber():
+    net = FlowNetwork()
+    _mfb(net)
+    net.add_node(MomentumChamberNode("chamber", area=_CHAMBER_AREA))
+    net.add_node(PlenumNode("mid"))
+    _pb(net)
+    net.add_element(LosslessConnectionElement("feed", "mfb", "chamber"))
+    loss = BorderCarnotLossElement("turn", "chamber", "mid", delta_geom_deg=90.0)
+    net.add_element(loss)
+    net.add_element(LosslessConnectionElement("exit", "mid", "pb"))
+
+    net.resolve_all_topology()
+
+    assert loss.area == pytest.approx(_CHAMBER_AREA)
+
+
+def test_chamber_node_inherits_area_from_a_combustor():
+    net = FlowNetwork()
+    _mfb(net)
+    net.add_node(CombustorNode("burner", area=_CHAMBER_AREA))
+    chamber = MomentumChamberNode("chamber")
+    net.add_node(chamber)
+    _pb(net)
+    net.add_element(LosslessConnectionElement("feed", "mfb", "burner"))
+    net.add_element(LosslessConnectionElement("mid", "burner", "chamber"))
+    net.add_element(LosslessConnectionElement("exit", "chamber", "pb"))
+
+    net.resolve_all_topology()
+
+    assert chamber.area == pytest.approx(_CHAMBER_AREA)
+    assert chamber._area_source != "default"
+
+
+def test_pressure_loss_inherits_area_from_a_chamber():
+    net = FlowNetwork()
+    _mfb(net)
+    net.add_node(MomentumChamberNode("chamber", area=_CHAMBER_AREA))
+    net.add_node(PlenumNode("mid"))
+    _pb(net)
+    net.add_element(LosslessConnectionElement("feed", "mfb", "chamber"))
+    loss = PressureLossElement("loss", "chamber", "mid", correlation=ConstantHeadLoss(zeta=5.0))
+    net.add_element(loss)
+    net.add_element(LosslessConnectionElement("exit", "mid", "pb"))
+
+    net.resolve_all_topology()
+
+    assert loss.area == pytest.approx(_CHAMBER_AREA)
+    assert loss.correlation.area == pytest.approx(_CHAMBER_AREA), "correlation must see it too"
+
+
+# ---------------------------------------------------------------------------
+# Guards on the inference itself
+# ---------------------------------------------------------------------------
+
+
+def test_channel_wins_over_a_chamber():
+    """Channels keep priority so networks that resolved before resolve the same.
+
+    A chamber and a channel both border the area change; the channel's area is
+    the one the pre-#262 code would have picked, and it must stay that way.
+    """
+    net = FlowNetwork()
+    _mfb(net)
+    net.add_node(MomentumChamberNode("chamber", area=_CHAMBER_AREA))
+    net.add_node(PlenumNode("mid"))
+    _pb(net)
+    net.add_element(ChannelElement("duct", "mfb", "chamber", diameter=_CHANNEL_D, length=1.0))
+    area_change = AreaChangeElement("expansion", "chamber", "mid")
+    net.add_element(area_change)
+    # Give the downstream side a resolvable area of its own, so this test
+    # isolates the upstream (channel-vs-chamber) priority question.
+    net.add_element(ChannelElement("exit", "mid", "pb", diameter=0.4, length=1.0))
+
+    net.resolve_all_topology()
+
+    assert pytest.approx(_CHANNEL_AREA) == area_change.F0
+
+
+def test_auto_sized_neighbour_is_not_used_as_a_source():
+    """An auto-sized area is a placeholder; inheriting it launders a guess.
+
+    The chamber here never received an area, so the area change must raise
+    rather than adopt the chamber's own nominal default.
+    """
+    net = FlowNetwork()
+    _mfb(net)
+    net.add_node(MomentumChamberNode("chamber"))
+    net.add_node(PlenumNode("mid"))
+    _pb(net)
+    net.add_element(LosslessConnectionElement("feed", "mfb", "chamber"))
+    net.add_element(AreaChangeElement("expansion", "chamber", "mid"))
+    net.add_element(LosslessConnectionElement("exit", "mid", "pb"))
+
+    with pytest.raises(ValueError, match="cannot determine"):
+        net.resolve_all_topology()
+
+
+# ---------------------------------------------------------------------------
+# The dynamic-head tier: default allowed, but never silent when it is read
+# ---------------------------------------------------------------------------
+
+
+def _build_defaulting_loss(correlation: object) -> FlowNetwork:
+    net = FlowNetwork()
+    _mfb(net)
+    net.add_node(PlenumNode("up"))
+    net.add_node(PlenumNode("down"))
+    _pb(net)
+    net.add_element(LosslessConnectionElement("feed", "mfb", "up"))
+    net.add_element(PressureLossElement("loss", "up", "down", correlation=correlation))
+    net.add_element(LosslessConnectionElement("exit", "down", "pb"))
+    return net
+
+
+def test_defaulted_area_warns_when_a_head_loss_will_consume_it():
+    """A head loss scales as 1/area^2, so a nominal area silently rescales it."""
+    net = _build_defaulting_loss(ConstantHeadLoss(zeta=5.0))
+
+    with pytest.warns(UserWarning, match="no flow area could be inferred"):
+        net.resolve_all_topology()
+
+    assert net.elements["loss"]._area_source == "default"
+
+
+@contextlib.contextmanager
+def _no_area_warning():
+    """Assert that no flow-area warning is emitted inside the block."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        yield
+    offending = [
+        str(w.message) for w in caught if "no flow area could be inferred" in str(w.message)
+    ]
+    assert not offending, f"unexpected area warning: {offending}"
+
+
+def test_defaulted_area_is_silent_when_nothing_reads_it():
+    """A fraction-based loss never touches the area -- warning there is noise."""
+    net = _build_defaulting_loss(ConstantFractionLoss(xi=0.02))
+
+    with _no_area_warning():
+        net.resolve_all_topology()
+
+
+def test_explicit_area_suppresses_the_warning():
+    """Manual input clears the warning as well as the error."""
+    net = FlowNetwork()
+    _mfb(net)
+    net.add_node(PlenumNode("up"))
+    net.add_node(PlenumNode("down"))
+    _pb(net)
+    net.add_element(LosslessConnectionElement("feed", "mfb", "up"))
+    net.add_element(
+        PressureLossElement("loss", "up", "down", correlation=ConstantHeadLoss(zeta=5.0), area=0.25)
+    )
+    net.add_element(LosslessConnectionElement("exit", "down", "pb"))
+
+    with _no_area_warning():
+        net.resolve_all_topology()
+
+    assert net.elements["loss"].area == pytest.approx(0.25)


### PR DESCRIPTION
Closes #262.

## The defect

Seven `resolve_topology` sites searched only for a neighbouring `ChannelElement` and, failing that, assigned a hard-coded constant (0.01 / 0.02 / 0.1 m^2). With a non-channel neighbour -- a momentum chamber, a combustor, an ejector outlet -- that fabricated a geometry the network does not contain.

## Audit first (all seven sites probed with a non-channel, area-bearing neighbour)

| site | before | after |
|---|---|---|
| `AreaChangeElement.F0` | 0.01 (default) | 0.15 (real) |
| `AreaChangeElement.F1` | 0.02 (default) | 0.15 (real) |
| `MomentumChamberNode.area` | 0.10 (default) | 0.15 (real) |
| `CombustorNode.area` | 0.10 (default) | 0.15 (real) |
| `PressureLossElement.area` | 0.10 (default) | 0.15 (real) |
| `ChannelElement.diameter` | 0.0079 m^2 (default) | 0.15 (real) |
| `BorderCarnotLossElement.area` | raised | 0.15 (real) |
| `TeeJunctionElement.F_C` | 0.01 (default) | 0.15 (real) |

`BorderCarnotLossElement` was the one site that already refused to guess -- the precedent this fix generalises. Its *inference* was still channel-only, so it now resolves cases it used to reject.

## A second audit decided the raise-vs-default split

Rather than guess which defaults are safe to remove, I counted how often each fires across the suite and then perturbed the constant 0.1 -> 0.2 to see which ones actually change answers:

| site | suite hits | neighbour area existed | sensitive to the value |
|---|---|---|---|
| `AreaChangeElement.F0`/`.F1` | **0** | - | - |
| `TeeJunctionElement.F_C` | **0** | - | - |
| `ChannelElement.diameter` | **0** | - | - |
| `MomentumChamberNode.area` | 20 | 2 | no |
| `CombustorNode.area` | 29 | 0 | no |
| `PressureLossElement.area` | 13 | 0 | 3 tests |

The three sites #262 is actually about are **never exercised**, so raising there costs nothing. The three that fire constantly have **no neighbour area anywhere in 60 of 62 cases** -- inference cannot rescue them, and raising would force a migration on networks that are working correctly.

So the split is by what the area *means*:

- **The area IS the geometry** (`AreaChangeElement` F0/F1, `ChannelElement` diameter, `TeeJunctionElement` F_C, `BorderCarnotLossElement` area) -> **raises**, naming the component, the parameter that clears it, and where it looked.
- **The area is a dynamic-head reference** (`MomentumChamberNode`, `CombustorNode`, `PressureLossElement`) -> nominal default stands; `PressureLossElement` warns only when a head-loss correlation will consume it. Across 1891 tests that warning fires on exactly the 3 the perturbation flagged: **no false positives, no misses**.

Manual input clears both paths -- setting the value, or giving a neighbour a known area.

## The reported stall could not be reproduced minimally, and that matters

The stall needed the full ejector network; mass-flow-driven and pressure-driven chains both converge with the fabricated area. In a plain chain the fabricated throat is **worse** than a stall -- it converges, confidently, to a wrong answer:

| m_dot | chamber Pt, fabricated F0=0.01 | correct F0=0.15 | error |
|---|---|---|---|
| 1 kg/s | 104 061 Pa | 100 012 Pa | 4% |
| 5 kg/s | 164 098 Pa | 100 286 Pa | **64%** |
| 20 kg/s | 463 053 Pa | 104 677 Pa | **342%** |

So the headline regression test pins that pressure against the physical dynamic head rather than asserting convergence -- which the pre-fix code also satisfied, i.e. a convergence assertion here would have been vacuous.

## Verification

- **11 of 16 new tests falsified** against pre-fix code and go red for the right reason. The 5 that pass pre-fix are the ones that should (explicit input always worked; channel priority is the preserved old behaviour).
- **Full suite: 1907 passed**, no regressions. The 1 `xpassed` is `test_mixing_plenum_convergence`, pre-existing and documented as non-deterministic in its own xfail reason (confirmed it xpasses on `main` too).
- Channels keep first priority in the search, so every network that resolved before resolves to the same area.

## Also in this PR

The node-area lookup in `gui/backend/graph_builder.py` covered `discrete_loss` only and made GUI and headless networks resolve **different areas** for the same topology. Removed, now that the library does it for every component.

Provenance record: `docs/archive/AREA_INFERENCE_262.md` (why the split, the two audits, alternatives rejected, and the dead end). Contract documented in `docs/API_PYTHON.md`.

## Breaking change

Networks that relied on a defaulted area at one of the four raising sites now get a `ValueError` instead of a silent fabrication. That is the point -- the "working" state was the broken one -- but it is a real migration, called out in the CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RNDxZouiHoJdaLpnnPjHq
