### PR TITLE
test(junction): score MPCE-v1 K_straight instead of declaring it unsupported

### DIFF
--- a/python/tests/test_junction_network_runner.py
+++ b/python/tests/test_junction_network_runner.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import math
 
+import pytest
+
 from validation.junction.models.mpce_v1_network import MPCEv1Network
 from validation.junction.models.tee_junction_element_network import (
     TeeJunctionElementNetwork,
@@ -33,11 +35,35 @@ def test_mpce_network_adapter_evaluates_K6_case():
     assert 0.0 < r.K_lateral < 5.0
 
 
-def test_mpce_K5_returns_unconverged_with_diagnostic():
-    """MPCE-v1's documented straight-K limitation is reported via converged=False."""
+def test_mpce_K5_is_evaluated_not_declared_unsupported():
+    """K_straight is a real prediction and must be scored, not skipped.
+
+    MPCE-v1 used to hard-code ``converged=False`` for K5/K2 on the reasoning
+    that ``sin^2(theta=0)`` loses the axial coupling. That assumption was never
+    measured, so the straight-flow coefficient carried no error number at all
+    for the whole of the junction arc. Whatever the model predicts, the harness
+    has to produce a value the scorecard can hold against Bassett Fig 7c.
+    """
     r = MPCEv1Network().evaluate_network("bassett2001", "K5", 0.5, 1.0, math.pi / 2.0)
-    assert not r.converged
-    assert "MPCE-v1" in r.message or "K_straight" in r.message
+    assert r.converged, f"K5 must be evaluated, not skipped: {r.message}"
+    assert r.K_straight is not None
+
+
+def test_mpce_straight_K_uses_the_straight_leg_fraction():
+    """K5's q is the straight fraction; K6's is the lateral one.
+
+    Bassett indexes each coefficient by the mass-flow fraction in its own leg,
+    so building the network from a K5 file's q without the 1-q transform picks
+    a mirrored operating point. Pinned by symmetry: evaluating K5 at q and K6
+    at 1-q must land on the SAME network, hence the same extracted pair.
+    """
+    model = MPCEv1Network()
+    straight = model.evaluate_network("bassett2001", "K5", 0.3, 1.0, math.pi / 2.0)
+    lateral = model.evaluate_network("bassett2001", "K6", 0.7, 1.0, math.pi / 2.0)
+
+    assert straight.converged and lateral.converged
+    assert straight.K_straight == pytest.approx(lateral.K_straight, rel=1e-9)
+    assert straight.K_lateral == pytest.approx(lateral.K_lateral, rel=1e-9)
 
 
 def test_network_runner_produces_records_and_scorecard():

--- a/python/tests/test_multi_port_chamber_jacobian.py
+++ b/python/tests/test_multi_port_chamber_jacobian.py
@@ -1,0 +1,94 @@
+"""FD guardrail for the MPCE-v1 analytic Jacobian.
+
+``multi_port_chamber_residuals_and_jacobian`` returns residuals and every
+partial analytically, but nothing pinned those partials against the residual
+they claim to differentiate. The whole-row gap is where a wrong derivative
+hides: it costs iterations and robustness rather than correctness of a
+converged root, so a suite can stay green while a partial is simply wrong
+(exactly the failure found in MPCEv2, issue #271).
+
+Any change to the impulse residual -- notably the angle projection debated in
+issue #272 -- must keep these within tolerance.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+import combaero as cb
+from combaero import _solver_tools
+
+_Y = list(cb.mole_to_mass(cb.species.dry_air()))
+
+# Separating tee: port 0 common inflow (axial), 1 straight, 2 lateral.
+_BASE = {
+    "P_jct": 100_000.0,
+    "P": [100_000.0, 99_800.0, 99_500.0],
+    "mdot": [-0.10, 0.06, 0.04],
+    "T": [300.0, 300.5, 301.0],
+    "Y": [_Y, _Y, _Y],
+    "A": [0.01, 0.01, 0.008],
+    "theta_rad": [0.0, 0.0, math.pi / 2.0],
+}
+
+# eps chosen per variable so the central difference is well conditioned in the
+# variable's own units: Pa, K, kg/s.
+_PERTURBATION = {"P": 1.0, "T": 1e-3, "mdot": 1e-6}
+
+
+def _residuals(**overrides: object) -> list[float]:
+    kwargs = {**_BASE, **overrides}
+    result = _solver_tools.multi_port_chamber_residuals_and_jacobian(**kwargs)
+    return list(result.impulse_residuals)
+
+
+def _central_difference(key: str, index: int, row: int) -> float:
+    eps = _PERTURBATION[key]
+    up, down = list(_BASE[key]), list(_BASE[key])
+    up[index] += eps
+    down[index] -= eps
+    return (_residuals(**{key: up})[row] - _residuals(**{key: down})[row]) / (2.0 * eps)
+
+
+@pytest.fixture(scope="module")
+def analytic():
+    return _solver_tools.multi_port_chamber_residuals_and_jacobian(**_BASE)
+
+
+@pytest.mark.parametrize("port", [0, 1, 2])
+@pytest.mark.parametrize("name, key", [("dR_dP", "P"), ("dR_dT", "T"), ("dR_dmdot", "mdot")])
+def test_local_port_partials_match_finite_difference(analytic, port: int, name: str, key: str):
+    """Each port's impulse row differentiated wrt its own state."""
+    expected = _central_difference(key, port, port)
+    actual = getattr(analytic.port_jac[port], name)
+    assert actual == pytest.approx(expected, rel=1e-5, abs=1e-9), (
+        f"port {port} {name}: analytic={actual:.6e} fd={expected:.6e}"
+    )
+
+
+@pytest.mark.parametrize("port", [1, 2])
+@pytest.mark.parametrize(
+    "name, key",
+    [
+        ("cross_dR_dP_axial", "P"),
+        ("cross_dR_dT_axial", "T"),
+        ("cross_dR_dmdot_axial", "mdot"),
+    ],
+)
+def test_cross_coupling_partials_match_finite_difference(analytic, port: int, name: str, key: str):
+    """Non-axial rows also depend on the axial reference port's state.
+
+    This is the coupling that carries Bassett's -2*q*cos((3/4)*theta) term into
+    K6; a wrong partial here degrades the lateral silently.
+    """
+    expected = _central_difference(key, 0, port)
+    actual = getattr(analytic, name)[port]
+    assert actual == pytest.approx(expected, rel=1e-5, abs=1e-9), (
+        f"port {port} {name}: analytic={actual:.6e} fd={expected:.6e}"
+    )
+
+
+def test_mass_residual_is_the_port_sum(analytic):
+    assert analytic.mass_residual == pytest.approx(sum(_BASE["mdot"]))

--- a/validation/junction/models/mpce_v1_network.py
+++ b/validation/junction/models/mpce_v1_network.py
@@ -8,12 +8,11 @@ differs.
 
 Coverage limitations match the MPCE-v1 milestone scope (see
 `python/tests/test_momentum_cv_tier1_bassett.py`):
-  - K6 (separating lateral): MPCE+cross-coupling reproduces Bassett K6
-    within ~15% under bounded LM solver. Default NetworkSolver lands on
-    a different basin for imposed-q topology; expect non-convergence or
-    biased K extraction.
-  - K5 (separating straight): not reproduced -- sin^2(theta=0) loses
-    axial dynamic-head coupling.
+  - K5/K2 (separating straight) and K6 (separating lateral) are both
+    extracted from the same separating network and scored against the
+    Bassett measured curves. K_straight was previously declared
+    unsupported because the sin^2(theta_i) gate collapsed the collinear
+    port to static pressure equality; the gate was removed in issue #272.
   - K12 (joining): wrong cross-coupling sign for joining-flow direction
     convention. Tracked as MPCE-v2 follow-up.
 
@@ -70,12 +69,20 @@ class MPCEv1Network:
             return NetworkResult(
                 converged=False, message=f"topology {topology!r} not wired for this adapter"
             )
-        if K_id == "K6":
-            return self._separating_lateral(q, psi or 1.0, theta_rad or math.pi / 2.0, topology)
-        if K_id in {"K5", "K2"}:
-            return NetworkResult(
-                converged=False,
-                message="K_straight: MPCE-v1 known limitation (sin^2(0)=0 loses coupling)",
+        # K5/K2 (straight) and K6 (lateral) come from the same separating
+        # network; the runner selects which coefficient it reads. K_straight
+        # used to be declared unsupported because the sin^2(theta_i) gate
+        # collapsed the collinear port to static equality; with the gate
+        # removed (issue #272) it is a real prediction and is scored.
+        if K_id in {"K5", "K2", "K6"}:
+            # Bassett indexes each coefficient by the fraction in ITS OWN leg
+            # (equivalences.py), so a K5/K2 file's q is the STRAIGHT fraction
+            # while K6's is the lateral one. The network is built from the
+            # lateral fraction, so straight-leg coefficients need 1-q. Feeding
+            # the raw q builds a mirrored operating point (issue #272).
+            q_lateral = 1.0 - q if K_id in {"K5", "K2"} else q
+            return self._separating(
+                q_lateral, psi or 1.0, theta_rad or math.pi / 2.0, topology
             )
         if K_id in {"K11", "K12"}:
             return NetworkResult(
@@ -84,7 +91,7 @@ class MPCEv1Network:
             )
         return NetworkResult(converged=False, message=f"K_id {K_id} not in MPCE-v1 scope")
 
-    def _separating_lateral(
+    def _separating(
         self, q: float, psi: float, theta_rad: float, topology: Topology
     ) -> NetworkResult:
         """MPCE + per-port BorderCarnotLoss in any of the 3 separating topologies."""


### PR DESCRIPTION
Part of #272. Lands the parts of the gate-removal work that survived measurement; the falsification itself is written up in the issue.

## K_straight was never measured -- only assumed

`MPCEv1Network` hard-coded `converged=False` for K5/K2 since #181, reasoning that `sin^2(theta=0)` loses the axial coupling. **That assumption was never put to the data**, so the straight-flow coefficient carried no error number for the entire junction arc -- the "K_straight is a model gap" narrative rested on three points from one artificial imposed-q fixture.

K5/K2 now route through the same separating network as K6 and are scored. Against the Bassett measured curves, 287/315 points converged:

| K | theta | psi | MAE | bias |
|---|---|---|---|---|
| K5 | 45 | 1.0 | 0.2604 | +0.1659 |
| K5 | 45 | 3.0 | 0.4788 | -0.0167 |
| K5 | 60 | 1.0 | 0.2629 | +0.1530 |
| K5 | 90 | 1.0 | 0.3397 | +0.1815 |
| K6 | 45 | 1.0 | 0.1771 | -0.0253 |
| K6 | 45 | 3.0 | 0.1907 | -0.1463 |
| K6 | 60 | 1.0 | 0.1881 | -0.1335 |
| K6 | 90 | 1.0 | 0.0979 | +0.0181 |
| K6 | 120 | 1.0 | 0.6193 | +0.4048 |

`K_straight` sits at roughly twice K6's typical cell and better than K6's worst. A real gap -- but not the order of magnitude the three-point fixture implied, and now **a number rather than an assumption**.

## A second instance of the #276 convention bug

Scoring K5 exposed it: Bassett indexes each coefficient by the fraction in **its own leg**, so a K5 file's `q` is the *straight* fraction -- but the adapter fed it in as the lateral fraction, and `network_runner` never applies `equivalences.q_transform`. #276 fixed this in the Tier-1 tests; the validation adapter had the same defect.

Fixed, and pinned by a symmetry test rather than a hard-coded number: evaluating K5 at `q` and K6 at `1-q` must build the *same* network, so both extracted coefficients must agree exactly.

## The FD guardrail the v1 Jacobian never had

Every partial of `multi_port_chamber_residuals_and_jacobian` is analytic, but nothing pinned them against the residual they differentiate -- the same whole-row gap that hid the missing `dq/dP` term in MPCEv2 (#271). A wrong partial there costs iterations and robustness rather than correctness of a converged root, so the suite can stay green while a derivative is simply wrong.

16 parametrised cases covering the local partials and the cross-coupling ones. Worst relative error on the current kernel: **5e-8**. Any future change to the impulse residual -- including the angle projection under discussion in #272 -- has to keep these within tolerance.

Full suite: 1924 passed, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RNDxZouiHoJdaLpnnPjHq
