### PR TITLE
fix(junction): add MPCEv2's missing common-port pressure Jacobian column (#271)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -222,6 +222,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.4.2] - 2026-07-09
 
 ### Fixed
+- **`MPCEv2Element`'s Jacobian was missing the common-port static-pressure
+  column (issue #271).** The Mynard loss term `K_i * q_dyn_com` depends on the
+  common port's density, and hence on its static pressure, through two paths:
+  `q_dyn_com ~ 1/rho`, and Mynard's `K` itself being a function of the port
+  velocities `U = -mdot/(rho*A)`. Neither was differentiated, so the row
+  carried a silently zero entry for a real solver unknown. This is the same
+  defect PR #230 fixed in `ConstantKTeeElement`; it survived here because
+  `test_mpce_v2_jacobian.py` FD-checks `dKQ_dmdot_separating_T` in isolation
+  and nothing pinned the assembled row against the residual it differentiates.
+  Taking only the first path is wrong by several per cent -- the second more
+  than cancels the naive `-K*q/P` -- so the analytic form is
+  `dR_i/dP_com = sign * [K_i*q_dyn/P - (mdot_com/P) * dKQ_i/dmdot_com]`, which
+  reuses the existing `dKQ/dmdot` column. **Converged roots are unchanged**
+  (a Jacobian correction moves the solver path, not the solution): scored
+  against the Bassett separating curves the K values are identical to 3
+  decimals. New whole-row FD guardrail in
+  `python/tests/test_mpce_v2_jacobian_rows.py` covers both `MPCEv2Element` and
+  `ConstantKTeeElement`.
 - **CI: `publish-gui.yml` verify job had two more release-blocking races,
   both hit on the v0.4.1 release attempt.** (1) The "wait for combaero"
   step polled PyPI's JSON API, which updated several minutes before the

--- a/python/combaero/network/mpce_v2_element.py
+++ b/python/combaero/network/mpce_v2_element.py
@@ -495,12 +495,42 @@ class MPCEv2Element(MultiPortChamberElement):
                 KQ_pert = K_pert * q_dyn_pert
                 dKQ_dmdot[:, j] = (KQ_pert - KQ_base) / mdot_eps
 
+        # Sensitivity of the loss term to the common port's STATIC pressure.
+        # This column was absent, leaving a silently zero Jacobian entry -- the
+        # same defect PR #230 fixed in ConstantKTeeElement (issue #271).
+        # Temperature is derived forward for a MomentumChamberNode rather than
+        # solved, so there is no .T unknown to differentiate against.
+        #
+        # Two paths carry the dependence, and taking only the first is wrong by
+        # a few per cent:
+        #   (a) q_dyn_com = mdot^2 / (2*rho*A^2) ~ 1/rho, and rho ~ P/T for a
+        #       near-ideal gas, so d(q_dyn)/dP = -q_dyn / P.
+        #   (b) Mynard's K is a function of the port velocities U = -mdot/(rho*A),
+        #       so it moves with rho too.
+        # For (b), U depends on P and on mdot through the same 1/rho factor:
+        #       dU/dP = -U/P     and     dU/dmdot = U/mdot
+        #   =>  dK/dP = -(mdot_com / P_com) * dK/dmdot_com,
+        # which lets the existing dKQ/dmdot column supply it. Substituting and
+        # using d(q_dyn)/dmdot_com = 2*q_dyn/mdot_com, the two paths combine to
+        #       dR_i/dP_com = sign * [ K_i*q_dyn/P - (mdot_com/P) * dKQ_i/dmdot_com ]
+        # Note the leading term ends up POSITIVE: path (b) more than cancels the
+        # naive -K*q/P. Pinned by test_mpce_v2_jacobian_rows.py.
+        P_com = float(states[common_idx].P)
+        m_com = float(port_mdots[common_idx])
+        p_var_com = f"{self.port_nodes[common_idx]}.P"
+
         jac: dict[int, dict[str, float]] = {}
         for i in range(N):
             row: dict[str, float] = {
                 f"{self.port_nodes[i]}.Pt": 1.0,
                 f"{self.id}.P_jct": -1.0,
             }
+            if P_com > 0.0:
+                dR_dP_com = float(K_per_port[i]) * q_dyn_com / P_com - (m_com / P_com) * float(
+                    dKQ_dmdot[i, common_idx]
+                )
+                if dR_dP_com != 0.0:
+                    row[p_var_com] = row.get(p_var_com, 0.0) + K_term_sign * dR_dP_com
             for j in range(N):
                 if abs(dKQ_dmdot[i, j]) > 0.0:
                     mdot_var = f"{self._port_element_ids[j]}.m_dot"

--- a/python/tests/test_mpce_v2_flow_direction.py
+++ b/python/tests/test_mpce_v2_flow_direction.py
@@ -42,10 +42,15 @@ def _merge_element() -> MPCEv2Element:
 
 
 class _State:
-    """Minimal stand-in for NetworkMixtureState (only Pt + density used)."""
+    """Minimal stand-in for NetworkMixtureState (Pt, static P and density).
 
-    def __init__(self, Pt: float, rho: float = 1.16) -> None:
+    The static pressure is required: the loss term's dependence on the common
+    port's density enters the Jacobian through it (issue #271).
+    """
+
+    def __init__(self, Pt: float, rho: float = 1.16, P: float | None = None) -> None:
         self.Pt = Pt
+        self.P = Pt if P is None else P
         self._rho = rho
 
     def density(self) -> float:

--- a/python/tests/test_mpce_v2_jacobian_rows.py
+++ b/python/tests/test_mpce_v2_jacobian_rows.py
@@ -1,0 +1,182 @@
+"""Whole-row FD guardrail for MPCEv2Element / ConstantKTeeElement.
+
+``test_mpce_v2_jacobian.py`` FD-checks ``dKQ_dmdot_separating_T`` in ISOLATION
+-- the d/dmdot block only. Nothing pinned the assembled Jacobian row against
+the residual it differentiates, so an entire column could be, and was, absent:
+the loss term ``K_i * q_dyn_com`` depends on the common port's density and
+hence on its static pressure, but ``MPCEv2Element`` emitted no ``.P`` entry.
+
+``ConstantKTeeElement`` gained exactly that term in PR #230 after an FD test
+caught a ``K*q/P`` error; the same defect survived in ``MPCEv2Element`` because
+no equivalent test existed. These tests are that test, for both classes.
+
+The unknowns a ``MomentumChamberNode`` exposes are ``.P`` and ``.Pt``
+(temperature is derived forward, not solved), so those are the entries that
+must match finite differences.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+import combaero as cb
+from combaero.network.components import NetworkMixtureState
+from combaero.network.mpce_v2_element import ConstantKTeeElement, MPCEv2Element
+
+_Y = list(cb.mole_to_mass(cb.species.dry_air()))
+_AREA = 0.01
+_PORT_MDOTS = [-0.10, 0.06, 0.04]  # junction convention: negative = into junction
+_PT_JCT = 100_300.0
+_P_COMMON = 100_000.0
+
+
+def _wire(element):
+    """Attach the topology fields resolve_topology would set, without a graph."""
+    element.id = "jct"
+    element.N = 3
+    element.port_nodes = ["p0", "p1", "p2"]
+    element.port_areas = [_AREA, _AREA, _AREA]
+    element.port_angles_deg = [180.0, 0.0, 90.0]
+    element._port_signs = [-1.0, 1.0, 1.0]
+    element._port_element_ids = ["e0", "e1", "e2"]
+    element.flow_direction = "branch"
+    element.strict = False
+    element.joining_etransfer_alpha = 0.2
+    element.jacobian_method = "sympy"
+    element.penalty_alpha = 0.0
+    return element
+
+
+def _mpce_v2():
+    return _wire(MPCEv2Element.__new__(MPCEv2Element))
+
+
+def _constant_k():
+    element = _wire(ConstantKTeeElement.__new__(ConstantKTeeElement))
+    element.K_ports = {1: 0.04, 2: 0.9}
+    return element
+
+
+def _states(p_common: float = _P_COMMON, pt_shift: float = 0.0):
+    """Port states with the common port's STATIC pressure independently movable.
+
+    Pt is held fixed while P moves, so the derivative isolates the density
+    dependence of the dynamic head rather than the trivial Pt term.
+    """
+    pressures = [p_common, 100_000.0, 100_000.0]
+    totals = [100_300.0 + pt_shift, 100_300.0, 100_300.0]
+    return [
+        NetworkMixtureState(P=pressures[i], Pt=totals[i], T=300.0, Tt=300.5, m_dot=0.0, Y=_Y)
+        for i in range(3)
+    ]
+
+
+ELEMENTS = [
+    pytest.param(_mpce_v2, id="MPCEv2Element"),
+    pytest.param(_constant_k, id="ConstantKTee"),
+]
+
+
+@pytest.mark.parametrize("factory", ELEMENTS)
+@pytest.mark.parametrize("row", [0, 1, 2])
+def test_row_derivative_wrt_common_static_pressure(factory, row: int):
+    """d(R_i)/d(P_common): the density sensitivity of the common dynamic head.
+
+    q_dyn_com = mdot^2 / (2*rho*A^2) and rho = rho(P, T), so every row carrying
+    a non-zero K depends on the common port's static pressure. Omitting it
+    leaves a silently zero Jacobian column.
+    """
+    element = factory()
+    _, jac = element.residuals(_states(), _PT_JCT, _PORT_MDOTS)
+
+    eps = 1.0
+    up = element.residuals(_states(_P_COMMON + eps), _PT_JCT, _PORT_MDOTS)[0][row]
+    down = element.residuals(_states(_P_COMMON - eps), _PT_JCT, _PORT_MDOTS)[0][row]
+    expected = (up - down) / (2.0 * eps)
+
+    actual = jac[row].get("p0.P", 0.0)
+    assert actual == pytest.approx(expected, rel=1e-4, abs=1e-9), (
+        f"row {row} d/dP_common: analytic={actual:.6e} fd={expected:.6e} "
+        f"(a missing term here is exactly K*q_dyn/P)"
+    )
+
+
+@pytest.mark.parametrize("factory", ELEMENTS)
+@pytest.mark.parametrize("row", [0, 1, 2])
+def test_row_derivative_wrt_port_total_pressure(factory, row: int):
+    """d(R_i)/d(Pt_i): the explicit Pt term, guarding the rest of the row."""
+    element = factory()
+    _, jac = element.residuals(_states(), _PT_JCT, _PORT_MDOTS)
+
+    eps = 1.0
+    base = _states()
+
+    def shifted(delta: float):
+        out = list(_states())
+        s = out[row]
+        out[row] = NetworkMixtureState(
+            P=s.P, Pt=s.Pt + delta, T=s.T, Tt=s.Tt, m_dot=s.m_dot, Y=list(s.Y)
+        )
+        return out
+
+    expected = (
+        element.residuals(shifted(eps), _PT_JCT, _PORT_MDOTS)[0][row]
+        - element.residuals(shifted(-eps), _PT_JCT, _PORT_MDOTS)[0][row]
+    ) / (2.0 * eps)
+    actual = jac[row].get(f"p{row}.Pt", 0.0)
+    assert actual == pytest.approx(expected, rel=1e-6, abs=1e-9)
+    assert base is not None
+
+
+@pytest.mark.parametrize("factory", ELEMENTS)
+@pytest.mark.parametrize("row", [0, 1, 2])
+def test_row_derivative_wrt_junction_pressure(factory, row: int):
+    element = factory()
+    _, jac = element.residuals(_states(), _PT_JCT, _PORT_MDOTS)
+
+    eps = 1.0
+    expected = (
+        element.residuals(_states(), _PT_JCT + eps, _PORT_MDOTS)[0][row]
+        - element.residuals(_states(), _PT_JCT - eps, _PORT_MDOTS)[0][row]
+    ) / (2.0 * eps)
+    assert jac[row].get("jct.P_jct", 0.0) == pytest.approx(expected, rel=1e-6, abs=1e-9)
+
+
+@pytest.mark.parametrize("factory", ELEMENTS)
+@pytest.mark.parametrize("row", [0, 1, 2])
+@pytest.mark.parametrize("port", [0, 1, 2])
+def test_row_derivative_wrt_port_mass_flow(factory, row: int, port: int):
+    """d(R_i)/d(mdot_j), including the loss term's dependence on the common flow."""
+    element = factory()
+    _, jac = element.residuals(_states(), _PT_JCT, _PORT_MDOTS)
+
+    eps = 1e-6
+    up, down = list(_PORT_MDOTS), list(_PORT_MDOTS)
+    up[port] += eps
+    down[port] -= eps
+    expected = (
+        element.residuals(_states(), _PT_JCT, up)[0][row]
+        - element.residuals(_states(), _PT_JCT, down)[0][row]
+    ) / (2.0 * eps)
+
+    # Rows are assembled in OUTER element unknowns; port_mdots carry the sign map.
+    actual = jac[row].get(f"e{port}.m_dot", 0.0) * element._port_signs[port]
+    assert actual == pytest.approx(expected, rel=1e-3, abs=1e-6), (
+        f"row {row} d/dmdot_{port}: analytic={actual:.6e} fd={expected:.6e}"
+    )
+
+
+def test_mass_row_is_the_signed_port_sum():
+    element = _mpce_v2()
+    residuals, jac = element.residuals(_states(), _PT_JCT, _PORT_MDOTS)
+    assert residuals[3] == pytest.approx(sum(_PORT_MDOTS))
+    for i in range(3):
+        assert jac[3][f"e{i}.m_dot"] == pytest.approx(element._port_signs[i])
+
+
+def test_angle_is_in_radians_where_the_closure_expects_it():
+    """Guard against a degree/radian slip in the port-angle plumbing."""
+    element = _mpce_v2()
+    assert math.isclose(math.radians(element.port_angles_deg[2]), math.pi / 2.0)


### PR DESCRIPTION
Step 1 of #271 -- the standalone correctness fix that must precede the C++ port, so the port has a correct Jacobian to transcribe.

## The defect

`MPCEv2Element`'s Mynard loss term `K_i * q_dyn_com` depends on the common port's density, and hence on its **static pressure** -- a solver unknown. The row emitted no `.P` entry for it: a silently zero Jacobian column.

`ConstantKTeeElement` gained exactly that term in PR #230 after an FD test caught a `K*q/P` error. It survived in `MPCEv2Element` because `test_mpce_v2_jacobian.py` FD-checks `dKQ_dmdot_separating_T` **in isolation** -- the `d/dmdot` block only -- and nothing pinned the assembled row against the residual it differentiates.

**Red first.** The new whole-row FD test fails at rows 1 and 2 with `analytic=0.0` against `fd=-3.84e-04`, while `ConstantKTee` passes every case -- so the term is genuinely absent, not merely untested.

## Deriving it properly, not fitting it

Two paths carry the dependence, and taking only the obvious one is wrong by 4.5%:

- **(a)** `q_dyn_com = mdot^2/(2*rho*A^2) ~ 1/rho`, so `d(q_dyn)/dP = -q_dyn/P`.
- **(b)** Mynard's `K` is a function of `U = -mdot/(rho*A)`, so it moves with `rho` too.

For (b), `U` carries `P` and `mdot` through the same `1/rho` factor -- `dU/dP = -U/P`, `dU/dmdot = U/mdot` -- hence `dK/dP = -(mdot_com/P) * dK/dmdot_com`, which lets the **existing** `dKQ/dmdot` column supply it. Substituting, with `d(q_dyn)/dmdot_com = 2*q_dyn/mdot_com`:

```
dR_i/dP_com = sign * [ K_i*q_dyn/P - (mdot_com/P) * dKQ_i/dmdot_com ]
```

The leading term ends up **positive** -- path (b) more than cancels the naive `-K*q/P`. Implementing only (a) gives `analytic=-4.015e-04` against `fd=-3.843e-04`; the full form matches to FD tolerance. That intermediate failure is why this is derived rather than tuned.

## Grounded against data

Scored over the Bassett separating curves, 315 points, before and after:

| | before | after |
|---|---|---|
| MAE | 0.1446 | 0.1465 |
| bias | -0.0141 | -0.0138 |
| converged | 187/315 | 184/315 |
| median wall time | 5.6 ms | 5.2 ms |

**Converged roots are unchanged to 3 decimals** -- the expected signature of a Jacobian correction, which moves the solver path and not the solution.

**Honest note: this does not measurably improve convergence.** The missing entry is small next to the row scale, and 187 -> 184 is within noise on near-threshold cases. The value here is correctness *before* the port, where a wrong partial would be transcribed into the kernel and become much harder to find.

## Also in this PR

- **Whole-row FD guardrail** (`test_mpce_v2_jacobian_rows.py`), 38 cases covering both `MPCEv2Element` and `ConstantKTeeElement` across `.P`, `.Pt`, `.P_jct` and every `d/dmdot` entry. This is the test whose absence let the defect survive.
- `test_mpce_v2_flow_direction.py`'s `_State` stand-in advertised *"only Pt + density used"*, which the fix makes false. It now carries a static pressure, because the residual legitimately needs one.

Full suite: 1962 passed, no regressions.

## Not in this PR

The remaining #271 items -- the FD fallback for non-canonical cases (a standing violation of the CLAUDE.md `(f, J)` rule), its silent zero-column failure paths, and the whole-element C++ port -- are unchanged. This lands the correctness fix the issue sequences first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RNDxZouiHoJdaLpnnPjHq
