### PR TITLE
fix(validation): correct the joining q convention and baseline K11/K12 (#271)

### DIFF
--- a/python/tests/test_junction_network_runner.py
+++ b/python/tests/test_junction_network_runner.py
@@ -7,6 +7,7 @@ import math
 import pytest
 
 from validation.junction.models.mpce_v1_network import MPCEv1Network
+from validation.junction.models.mpce_v2_network import MPCEv2Network
 from validation.junction.models.tee_junction_element_network import (
     TeeJunctionElementNetwork,
 )
@@ -60,6 +61,24 @@ def test_mpce_straight_K_uses_the_straight_leg_fraction():
     model = MPCEv1Network()
     straight = model.evaluate_network("bassett2001", "K5", 0.3, 1.0, math.pi / 2.0)
     lateral = model.evaluate_network("bassett2001", "K6", 0.7, 1.0, math.pi / 2.0)
+
+    assert straight.converged and lateral.converged
+    assert straight.K_straight == pytest.approx(lateral.K_straight, rel=1e-9)
+    assert straight.K_lateral == pytest.approx(lateral.K_lateral, rel=1e-9)
+
+
+def test_mpce_v2_joining_K11_uses_the_straight_inlet_fraction():
+    """K11's q is the straight inlet fraction; K12's is the lateral one.
+
+    Bassett Table 1 indexes each joining coefficient by the fraction in its own
+    inlet leg -- K11 on mdot_A/mdot_C, K12 on mdot_B/mdot_C. Building the
+    network from a K11 file's q without the 1-q transform picks a mirrored
+    operating point, the same defect the separating side carried. Pinned by
+    symmetry: K11 at q and K12 at 1-q must be the SAME network.
+    """
+    model = MPCEv2Network()
+    straight = model.evaluate_network("bassett2001", "K11", 0.3, 1.0, math.pi / 2.0)
+    lateral = model.evaluate_network("bassett2001", "K12", 0.7, 1.0, math.pi / 2.0)
 
     assert straight.converged and lateral.converged
     assert straight.K_straight == pytest.approx(lateral.K_straight, rel=1e-9)

--- a/validation/junction/models/mpce_v2_network.py
+++ b/validation/junction/models/mpce_v2_network.py
@@ -71,7 +71,14 @@ class MPCEv2Network:
         if K_id in {"K6", "K5", "K2"}:
             return self._separating(q, psi or 1.0, theta_rad or math.pi / 2.0, topology)
         if K_id in {"K11", "K12"}:
-            return self._joining(q, psi or 1.0, theta_rad or math.pi / 2.0, topology)
+            # Bassett Table 1 indexes each joining coefficient by the fraction
+            # in ITS OWN inlet leg: K11's q is mdot_A/mdot_C (the STRAIGHT
+            # inlet), K12's is mdot_B/mdot_C (the lateral). The network is
+            # built from the lateral inlet fraction, so K11 files need 1-q.
+            # Feeding the raw q builds a mirrored operating point -- the same
+            # defect as the separating side (#276, #277).
+            q_lateral = 1.0 - q if K_id == "K11" else q
+            return self._joining(q_lateral, psi or 1.0, theta_rad or math.pi / 2.0, topology)
         return NetworkResult(
             converged=False,
             message=f"K_id {K_id} not yet wired for MPCE-v2",
@@ -126,7 +133,7 @@ class MPCEv2Network:
         )
 
     def _joining(self, q: float, psi: float, theta_rad: float, topology: Topology) -> NetworkResult:
-        """Build a joining-flow MPCE-v2 network.
+        """Build a joining-flow MPCE-v2 network. ``q`` is the LATERAL inlet fraction.
 
         Geometry mirrors the separating case (str at 0deg, bra at theta) but
         flow reverses: str and bra are inlets, com is the outlet. The
@@ -138,7 +145,9 @@ class MPCEv2Network:
         if topology == "imposed_q":
             net = build_joining_imposed_q_skeleton(m_in=m_in, m_lateral=q * m_in)
         else:
-            K11 = bassett2001.K11_corr(q, psi, theta_rad)
+            # Each target is evaluated on ITS OWN leg fraction: K11 on the
+            # straight inlet (1 - q_lateral), K12 on the lateral inlet.
+            K11 = bassett2001.K11_corr(1.0 - q, psi, theta_rad)
             K12 = bassett2001.K12_corr(q, psi, theta_rad)
             if topology == "three_pb":
                 net = build_joining_three_pb_skeleton(K11_target=K11, K12_target=K12)


### PR DESCRIPTION
Groundwork for the #271 C++ port. Joining is the regime the port changes most -- it runs **100% on finite differences** today (see the FD audit on the issue) -- but the acceptance gate covered separating K5/K6 only. Building the joining baseline first exposed a third instance of the leg-indexed `q` bug.

## The bug

Bassett Table 1 indexes each joining coefficient by the fraction in **its own inlet leg**: K11 on `mdot_A/mdot_C` (the straight inlet), K12 on `mdot_B/mdot_C` (the lateral). `equivalences.py` states the same thing in its Wang `K_23` entry -- *"q is straight / common per Bassett"*.

The adapter built the network from `q * m_in` as the lateral fraction for **both**, so every K11 point was evaluated at a mirrored operating point. The non-`imposed_q` topologies were worse: they seeded `K11_corr(q)` and `K12_corr(q)` from the same `q`, so one of the two targets was always on the wrong leg.

This is the same defect #276 fixed in the Tier-1 tests and #277 fixed in the v1 adapter -- third instance, same root: the `q` transform exists in `equivalences.py` and nothing on the network path applies it.

Both fixed, pinned by **symmetry rather than a magic number**: K11 at `q` and K12 at `1-q` must build the same network, so both extracted coefficients agree exactly.

```
K11 @ q=0.3  ->  K_straight=0.346321  K_lateral=0.745888
K12 @ q=0.7  ->  K_straight=0.346321  K_lateral=0.745888   identical: True
```

## Joining baseline for the equivalence gate

435 measured points:

| | joining (K11/K12) | separating (K5/K6) |
|---|---|---|
| MAE | **0.1270** | 0.1465 |
| bias | -0.0106 | -0.0138 |
| converged | **368 / 435 (85%)** | 184 / 315 (58%) |
| median wall time | 7.8 ms | **5.2 ms** |
| Jacobian | 100% finite differences | 100% analytic sympy |

**Worth knowing before the port:** the FD regime is currently the *better-behaved* of the two on both accuracy and convergence, and pays for it in wall time -- the N+1 extra Mynard calls per evaluation. So the case for porting joining is architectural homogeneity and the CLAUDE.md `(f, J)` rule, **not** a convergence rescue. Anyone expecting the port to fix joining robustness should recalibrate.

Full suite: 1963 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RNDxZouiHoJdaLpnnPjHq
