### PR TITLE
test(junction): cover the MPCEv2 FD-fallback guards and pin the N>3 defect (#271)

### DIFF
--- a/docs/archive/JUNCTION_JACOBIAN_271.md
+++ b/docs/archive/JUNCTION_JACOBIAN_271.md
@@ -80,6 +80,16 @@ state into a plausible-looking zero. The right shapes are a one-sided
 difference across a sign flip, and a loud failure (or an analytic branch) where
 the closure genuinely has no value to give.
 
+Documenting that was not enough -- an untested reachable path is rediscovered,
+not remembered. `python/tests/test_mpce_v2_fd_fallback_guards.py` pins each
+guard's *precondition* against `_mynard2010`'s contract (K present at 3 ports,
+absent beyond; degenerate masks raise; the FD step crosses zero for a
+near-zero port), so a change to the closure surfaces there rather than
+silently changing which branch the Jacobian takes. The N > 3 consequence is
+pinned as a `strict=True` xfail asserting the CORRECT behaviour, so whichever
+fix lands forces the marker off rather than leaving a green test standing on a
+known-wrong result.
+
 ## The recurring bug this arc kept surfacing
 
 Bassett indexes each loss coefficient by the mass-flow fraction in **its own
@@ -127,6 +137,9 @@ better than implying a performance win that the numbers do not support.
 - Every analytic partial has an independent FD cross-check:
   `test_mpce_v2_jacobian_rows.py` (both v2 subclasses, 38 cases) and
   `test_multi_port_chamber_jacobian.py` (the v1 C++ base).
+- Every reachable-but-unexercised branch has a test on its precondition, and
+  every known defect left unfixed is a strict xfail asserting the correct
+  behaviour -- never a green test pinning the wrong one.
 - A coefficient is compared only against the leg its source indexes it on.
 - A change to a closure is scored against the digitised curves before it lands,
   and reverted with the numbers written down when the data says no.

--- a/docs/archive/JUNCTION_JACOBIAN_271.md
+++ b/docs/archive/JUNCTION_JACOBIAN_271.md
@@ -1,0 +1,132 @@
+# MPCE Junction Jacobians and Validation: Provenance Record (issue #271)
+
+Why the junction Jacobian work went the way it did. The code owns the formulas;
+this owns the reasoning, the measurements that decided things, and the dead
+ends. Contract and current state live in [issue #271]; the acceptance tables
+are reproduced from `validation.junction.network_runner.run_network`.
+
+## The defect that started it
+
+`MPCEv2Element`'s Jacobian omitted the common-port static-pressure column. The
+Mynard loss term `K_i * q_dyn_com` depends on the common port's density, hence
+on its static pressure, which is a solver unknown. `ConstantKTeeElement` gained
+that term in PR #230 after an FD test caught a `K*q/P` error; the same defect
+survived in `MPCEv2Element` because `test_mpce_v2_jacobian.py` FD-checks
+`dKQ_dmdot_separating_T` **in isolation** -- the `d/dmdot` block only -- and
+nothing pinned the assembled row against the residual it differentiates.
+
+## The derivation, and why the obvious one is wrong
+
+Two paths carry the dependence:
+
+- **(a)** `q_dyn_com = mdot^2/(2*rho*A^2) ~ 1/rho`, so `d(q_dyn)/dP = -q_dyn/P`.
+- **(b)** Mynard's `K` is a function of `U = -mdot/(rho*A)`, so it moves with
+  `rho` too.
+
+Path (a) alone gives `analytic = -4.015e-04` against `fd = -3.843e-04` -- 4.5%
+off, with a plausible-looking sign. `U` carries `P` and `mdot` through the same
+`1/rho` factor (`dU/dP = -U/P`, `dU/dmdot = U/mdot`), so
+`dK/dP = -(mdot_com/P) * dK/dmdot_com`, which lets the existing `dKQ/dmdot`
+column supply (b). With `d(q_dyn)/dmdot_com = 2*q_dyn/mdot_com` the two combine
+to
+
+    dR_i/dP_com = sign * [ K_i*q_dyn/P - (mdot_com/P) * dKQ_i/dmdot_com ]
+
+and the leading term ends up **positive**: (b) more than cancels the naive
+`-K*q/P`. **This is the trap for the C++ port.** Re-deriving only (a) lands
+4.5% off in a way inspection will not catch and FD will. Pinned by
+`python/tests/test_mpce_v2_jacobian_rows.py`.
+
+## What the FD-fallback audit found
+
+Instrumenting the branch selection and all three silent-zero paths, over 10,918
+residual evaluations of the validation dataset (and 6,135 of the test suite):
+
+| regime | sympy | FD |
+|---|---|---|
+| separating (K5, K6), all topologies | 100% | 0% |
+| joining (K11, K12), all topologies | 0% | 100% |
+| overall | 55% | 45% |
+
+**100% of declines are `suppliers != 1`.** The guard's other three conditions
+never decide anything on a real topology. What is written as a narrow
+special case is in practice a separating/joining switch, and the defect is not
+"some cases fall back to FD" but **merge junctions have no analytic Jacobian at
+all**.
+
+Of the three silent-zero paths, only `sign_flip` fired in those runs -- 8
+times, 0.16% of FD evaluations, all joining.
+
+**The other two are NOT dead code, and reading them as such was a mistake.**
+Not firing across a dataset is absence of evidence, not proof of
+unreachability; the dataset contains only 3-port junctions with well-behaved
+iterates. Checked by construction instead:
+
+| guard | reachable when | verified |
+|---|---|---|
+| `K_shape` | `_mynard2010` assigns `K` only under `len(U) <= 3`, so **K is None for any junction with more than 3 ports** | 4-port probe returns `K is None` |
+| `mynard_raised` | the collector mask is empty (`float(U[Ci][0])` -> `IndexError`) or the supplier mask is (`ValueError`) -- both are plausible transient Newton iterates | all-suppliers raises `IndexError`, all-collectors raises `ValueError` |
+
+The `K_shape` case is the serious one. `MPCEv2Element` does not restrict `N`,
+so a 4-port junction is constructible through the public API, and it produces
+**finite residuals with an entirely zero `dKQ` Jacobian block** -- every
+mass-flow derivative of the loss term absent, silently. That is not a 0.16%
+corner; it is a whole class of junction running on a systematically wrong
+Jacobian with no error and no warning.
+
+So all three guards are live and must be *handled* in the port, not deleted.
+`continue` is the wrong response in every case: it converts an unrepresentable
+state into a plausible-looking zero. The right shapes are a one-sided
+difference across a sign flip, and a loud failure (or an analytic branch) where
+the closure genuinely has no value to give.
+
+## The recurring bug this arc kept surfacing
+
+Bassett indexes each loss coefficient by the mass-flow fraction in **its own
+leg** (Table 1; `validation/junction/equivalences.py` states it). K6 and K12
+take the lateral fraction; K5/K2 and K11 take the straight one. The `1-q`
+transform exists in `equivalences.py` and **nothing on the network path applied
+it**, so the same defect appeared three times in three places:
+
+| where | fixed in |
+|---|---|
+| Tier-1 tests (local copy of the K2 formula) | #276 |
+| MPCE-v1 validation adapter | #277 |
+| MPCE-v2 joining adapter (K11, and the seeded targets) | #279 |
+
+Each is now pinned by a **symmetry** assertion rather than a stored number:
+evaluating the straight coefficient at `q` and the lateral one at `1-q` must
+build the same network, so both extracted values must agree exactly. That
+formulation cannot rot the way a hard-coded expected value can.
+
+## Measurements that must survive the port
+
+| | separating (K5/K6) | joining (K11/K12) |
+|---|---|---|
+| MAE | 0.1465 | 0.1270 |
+| bias | -0.0138 | -0.0106 |
+| converged | 184 / 315 | 368 / 435 |
+| median wall time | 5.2 ms | 7.8 ms |
+
+**The FD regime is the better-behaved one.** Joining is more accurate and
+converges more often than separating, and pays for it in wall time. The case
+for porting is architectural homogeneity and the CLAUDE.md `(f, J)` rule, not a
+convergence rescue -- anyone starting the port expecting robustness gains
+should recalibrate first.
+
+## Dead end
+
+The Jacobian fix was expected to improve convergence. It does not: roots are
+unchanged to three decimals and convergence moves 187 -> 184 of 315, which is
+noise on near-threshold cases. The missing entry is small next to the row
+scale. Correctness before the port is the whole of the value, and saying so is
+better than implying a performance win that the numbers do not support.
+
+## Invariants
+
+- Every analytic partial has an independent FD cross-check:
+  `test_mpce_v2_jacobian_rows.py` (both v2 subclasses, 38 cases) and
+  `test_multi_port_chamber_jacobian.py` (the v1 C++ base).
+- A coefficient is compared only against the leg its source indexes it on.
+- A change to a closure is scored against the digitised curves before it lands,
+  and reverted with the numbers written down when the data says no.

--- a/python/tests/test_mpce_v2_fd_fallback_guards.py
+++ b/python/tests/test_mpce_v2_fd_fallback_guards.py
@@ -1,0 +1,173 @@
+"""Coverage for the MPCEv2 FD-fallback guards, which nothing exercised.
+
+`MPCEv2Element` falls back to finite differences whenever the sympy branch
+declines, and that loop carries three guards that `continue` past a perturbed
+evaluation -- leaving the corresponding Jacobian column at its initialised
+ZERO. A zero column is a wrong derivative, not an error: indistinguishable at
+the call site from "this unknown has no influence".
+
+An audit (issue #271) found only the sign-flip guard firing across the
+validation dataset and the whole test suite, which is *not* evidence the other
+two are unreachable -- that dataset holds only 3-port junctions with
+well-behaved iterates. These tests pin the preconditions that make each guard
+reachable, so the guards surface if the closure beneath them changes.
+
+They deliberately test `_mynard2010`'s contract rather than the guard's effect,
+because the contract is what determines reachability.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+import combaero as cb
+from combaero.network._mynard2010 import junction_loss_coefficient
+from combaero.network.components import NetworkMixtureState
+from combaero.network.mpce_v2_element import MPCEv2Element
+
+_Y = list(cb.mole_to_mass(cb.species.dry_air()))
+_A3 = np.array([0.01, 0.01, 0.01])
+_THETA3 = np.array([math.pi, 0.0, math.pi / 2.0])
+
+
+# ---------------------------------------------------------------------------
+# Preconditions that make each guard reachable
+# ---------------------------------------------------------------------------
+
+
+def test_mynard_supplies_K_for_three_ports():
+    """The supported case: 3 ports, K present and one entry per non-common port."""
+    for label, U in (
+        ("separating", np.array([-10.0, 6.0, 4.0])),
+        ("joining", np.array([-6.0, -4.0, 10.0])),
+    ):
+        result = junction_loss_coefficient(U, _A3, _THETA3)
+        assert result.K is not None, f"{label}: K must be defined for a 3-port junction"
+        assert len(result.K) == 2, f"{label}: expected one K per non-common port"
+
+
+def test_mynard_returns_no_K_beyond_three_ports():
+    """Mynard's closure is 3-branch by derivation, so K is None for N > 3.
+
+    This is what makes MPCEv2's `K is None` guard reachable. If the closure ever
+    gains N > 3 support, this test fails and the guard -- and the zero-Jacobian
+    consequence pinned below -- must be revisited.
+    """
+    U = np.array([-10.0, 4.0, 3.0, 3.0])
+    A = np.array([0.01] * 4)
+    theta = np.array([math.pi, 0.0, math.pi / 2.0, math.pi / 4.0])
+
+    result = junction_loss_coefficient(U, A, theta)
+
+    assert result.K is None, "Mynard gained N > 3 support -- revisit the K-shape guard"
+
+
+@pytest.mark.parametrize(
+    "label, U",
+    [
+        ("every port a supplier", np.array([-4.0, -3.0, -3.0])),
+        ("every port a collector", np.array([4.0, 3.0, 3.0])),
+    ],
+)
+def test_mynard_raises_on_a_degenerate_flow_split(label: str, U: np.ndarray):
+    """Mynard indexes the collector and supplier masks without checking them.
+
+    Newton can pass through an iterate where every port flows the same way, so
+    the `except Exception` guard is reachable. Pinned so that a future closure
+    which returns instead of raising surfaces here rather than silently
+    changing which branch the Jacobian takes.
+    """
+    with pytest.raises((IndexError, ValueError)):
+        junction_loss_coefficient(U, _A3, _THETA3)
+
+
+def test_perturbing_a_near_zero_port_flips_its_velocity_sign():
+    """The precondition for the sign-flip guard, which the audit saw fire.
+
+    The FD loop perturbs by max(|mdot| * 1e-4, 1e-7); for a port sitting near
+    zero flow that step crosses zero, and Mynard's supplier/collector
+    classification changes underneath the difference.
+    """
+    port_mdots = np.array([-0.10, 0.10, -1e-9])
+    rho = np.full(3, 1.16)
+
+    U = -port_mdots / (rho * _A3)
+    eps = max(abs(port_mdots[2]) * 1e-4, 1e-7)
+    perturbed = port_mdots.copy()
+    perturbed[2] += eps
+    U_pert = -perturbed / (rho * _A3)
+
+    assert (np.sign(U_pert) != np.sign(U)).any(), (
+        "the perturbation no longer crosses zero -- the sign-flip guard's "
+        "trigger condition has changed"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The consequence, pinned as a known defect so a fix surfaces
+# ---------------------------------------------------------------------------
+
+
+def _four_port_element() -> MPCEv2Element:
+    element = MPCEv2Element.__new__(MPCEv2Element)
+    element.id = "jct"
+    element.N = 4
+    element.port_nodes = [f"p{i}" for i in range(4)]
+    element.port_areas = [0.01] * 4
+    element.port_angles_deg = [180.0, 0.0, 90.0, 45.0]
+    element._port_signs = [-1.0, 1.0, 1.0, 1.0]
+    element._port_element_ids = [f"e{i}" for i in range(4)]
+    element.flow_direction = "branch"
+    element.strict = False
+    element.joining_etransfer_alpha = 0.2
+    element.jacobian_method = "sympy"
+    element.penalty_alpha = 0.0
+    return element
+
+
+def _four_port_states():
+    return [
+        NetworkMixtureState(P=1.0e5, Pt=100_300.0, T=300.0, Tt=300.5, m_dot=0.0, Y=_Y)
+        for _ in range(4)
+    ]
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Known defect (issue #271): MPCEv2Element does not restrict N, and "
+        "Mynard supplies no K beyond 3 ports, so every FD column is skipped "
+        "and the whole dKQ block is silently zero. Either the element must "
+        "reject N > 3 at construction -- honest, the closure is 3-branch by "
+        "derivation -- or the closure must be extended. Returning a zero "
+        "Jacobian with finite residuals is not a third option. Remove this "
+        "xfail with whichever fix lands."
+    ),
+)
+def test_four_port_junction_has_a_nonzero_loss_jacobian():
+    element = _four_port_element()
+
+    _, jac = element.residuals(_four_port_states(), 100_300.0, [-0.12, 0.05, 0.04, 0.03])
+
+    mdot_entries = sum(1 for row in range(4) for key in jac[row] if key.endswith(".m_dot"))
+    assert mdot_entries > 0, (
+        "the entire dKQ block is zero: every mass-flow derivative of the loss "
+        "term is missing, with no error and no warning"
+    )
+
+
+def test_four_port_junction_still_returns_finite_residuals():
+    """Why the defect above is silent rather than loud: nothing looks wrong.
+
+    The residuals are perfectly well-formed; only the Jacobian is empty, so a
+    solver has no signal that anything is amiss.
+    """
+    element = _four_port_element()
+
+    residuals, _ = element.residuals(_four_port_states(), 100_300.0, [-0.12, 0.05, 0.04, 0.03])
+
+    assert len(residuals) == 5  # 4 impulse rows + mass row
+    assert all(math.isfinite(r) for r in residuals)


### PR DESCRIPTION
Closes out #271 step 1 with the provenance record, plus executable coverage for the three FD-fallback guards -- and a correction to what I claimed about two of them.

## Correction: two "dead" guards are live

The audit reported that only `sign_flip` fires, and I called the other two dead code. **That was wrong, and wrong in the way this whole arc has been catching**: not firing across a dataset is absence of evidence, not proof of unreachability. The dataset holds only 3-port junctions with well-behaved iterates. Checked by construction instead:

| guard | reachable when | verified |
|---|---|---|
| `K_shape` | `_mynard2010` assigns `K` only under `len(U) <= 3` -- **`K is None` for any junction beyond 3 ports** | 4-port probe returns `K is None` |
| `mynard_raised` | empty collector mask -> `IndexError`, empty supplier mask -> `ValueError`; both are plausible transient Newton iterates | both raise as predicted |

## The `K_shape` case is a real defect

`MPCEv2Element` does not restrict `N`, so a 4-port junction is constructible through the public API. It returns **finite residuals with an entirely zero `dKQ` block**:

```
row 0: {}  <-- ENTIRE dKQ BLOCK ZERO
row 1: {}
row 2: {}
row 3: {}
total dKQ mdot entries across all rows: 0
Residuals are finite: True
```

Every mass-flow derivative of the loss term absent, no error, no warning. A whole class of junction on a systematically wrong Jacobian.

## What this PR adds

**Guard coverage** (`test_mpce_v2_fd_fallback_guards.py`) -- pinning each guard's **precondition** against `_mynard2010`'s contract rather than the guard's effect, because the contract is what determines reachability:

- `K` present with one entry per non-common port at 3 ports, `None` beyond;
- a degenerate flow split raises `IndexError`/`ValueError`;
- the FD step `max(|mdot|*1e-4, 1e-7)` crosses zero for a near-zero port.

If Mynard gains `N > 3` support, or stops raising on a degenerate mask, the relevant test fails and the guard gets revisited -- instead of silently changing which branch the Jacobian takes.

**The N > 3 defect as a `strict=True` xfail** asserting the *correct* behaviour, so whichever fix lands (reject `N > 3` at construction, or extend the closure) forces the marker off. Never a green test pinning a known-wrong result. A companion test records *why* the defect is silent: the residuals themselves are perfectly well-formed.

**Provenance record** (`docs/archive/JUNCTION_JACOBIAN_271.md`) -- the two-path derivation and why the one-path version is 4.5% off, the FD audit, the leg-indexed `q` bug that appeared three times, the measurements any port must reproduce, and the dead end (the Jacobian fix did not improve convergence, and saying so beats implying a win the numbers do not support).

Full suite: 1969 passed, 6 xfailed.

## Still needing a decision

`N > 3` wants a call independent of the port: reject at construction -- honest, since Mynard's closure is 3-branch by derivation -- or extend the closure. Silently returning zeros is not a third option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RNDxZouiHoJdaLpnnPjHq
