### PR TITLE
fix(validation): score MPCEv2 against Hager and Idelchik (#271 step 0)

### DIFF
--- a/python/tests/test_junction_network_runner.py
+++ b/python/tests/test_junction_network_runner.py
@@ -85,6 +85,41 @@ def test_mpce_v2_joining_K11_uses_the_straight_inlet_fraction():
     assert straight.K_lateral == pytest.approx(lateral.K_lateral, rel=1e-9)
 
 
+def test_hager_xi_t_is_scored_on_the_lateral_fraction_directly():
+    """Hager's q = Delta_Q / Q is already the lateral fraction.
+
+    Unlike Bassett K5, it must NOT get the 1-q transform when building the
+    network: that transform maps Hager onto Bassett's straight-fraction axis
+    for cross-paper rollup, not onto the network. Pinned by symmetry against
+    the K6 path, which is indexed on the lateral leg too: xi_t at q and K6 at
+    the same q must build the same separating network.
+    """
+    model = MPCEv2Network()
+    hager = model.evaluate_network("hager1984", "xi_t", 0.3, 1.0, math.pi / 2.0)
+    bassett = model.evaluate_network("bassett2001", "K6", 0.3, 1.0, math.pi / 2.0)
+
+    assert hager.converged and bassett.converged
+    assert hager.K_straight == pytest.approx(bassett.K_straight, rel=1e-9)
+    assert hager.K_lateral == pytest.approx(bassett.K_lateral, rel=1e-9)
+
+
+def test_idelchik_K11_is_indexed_on_the_lateral_fraction_unlike_bassett():
+    """Idelchik tabulates EVERY diagram against Q_b/Q_c, K11 included.
+
+    Bassett re-indexes K11 on the straight leg; Idelchik does not. Applying
+    Bassett's 1-q to Idelchik K11 mirrors the curve. Pinned by symmetry:
+    Idelchik K11 and K12 at the SAME q must build the same joining network,
+    whereas Bassett K11 at q pairs with K12 at 1-q.
+    """
+    model = MPCEv2Network()
+    k11 = model.evaluate_network("idelchik1966", "K11", 0.3, 2.5, math.radians(45.0))
+    k12 = model.evaluate_network("idelchik1966", "K12", 0.3, 2.5, math.radians(45.0))
+
+    assert k11.converged and k12.converged
+    assert k11.K_straight == pytest.approx(k12.K_straight, rel=1e-9)
+    assert k11.K_lateral == pytest.approx(k12.K_lateral, rel=1e-9)
+
+
 def test_network_runner_produces_records_and_scorecard():
     """End-to-end: TeeJunctionElement run produces records across multiple
     topologies and the network-cell scorecard groups by them."""

--- a/validation/junction/data/idelchik1966/metadata.yaml
+++ b/validation/junction/data/idelchik1966/metadata.yaml
@@ -21,7 +21,10 @@
 #   F_b/F_c=0.8 -> psi=1.25
 #   F_b/F_c=1.0 -> psi=1.0
 #
-# q convention: q = Q_b/Q_c (branch flow over common flow). Same as Bassett's
+# q convention: q = Q_b/Q_c (branch flow over common flow) for EVERY diagram,
+# K11 included. This matches Bassett's K12 axis but NOT his K11 axis (Bassett
+# Table 1 indexes K11 on Q_s/Q_c, the straight leg). Adapters must not apply
+# Bassett's 1-q to Idelchik K11. Same as Bassett's
 # joining-type-6 q definition (m_lat / m_com), so all bassett2001 K11/K12
 # comparisons apply directly without unit-conversion.
 #

--- a/validation/junction/models/mpce_v2_network.py
+++ b/validation/junction/models/mpce_v2_network.py
@@ -64,10 +64,32 @@ class MPCEv2Network:
         topology: Topology = "imposed_q",
         **kwargs: float,
     ) -> NetworkResult:
-        if paper != "bassett2001":
-            return NetworkResult(converged=False, message="non-Bassett papers unsupported")
         if topology not in self.SUPPORTED_TOPOLOGIES:
             return NetworkResult(converged=False, message=f"topology {topology!r} not wired")
+        if paper == "hager1984":
+            # Hager's q = Delta_Q / Q is the LATERAL fraction (hager1984.py
+            # notation block), which is what the network is built from, so it
+            # passes straight through -- the 1-q in equivalences.py maps Hager
+            # onto Bassett's straight-fraction axis for cross-paper rollup,
+            # not onto the network. xi_t and xi_l are extracted from the same
+            # separating network as K5/K6.
+            if K_id in {"xi_t", "xi_l"}:
+                return self._separating(q, psi or 1.0, theta_rad or math.pi / 2.0, topology)
+            return NetworkResult(converged=False, message=f"hager1984 coefficient {K_id} not wired")
+        if paper == "idelchik1966":
+            # Handbook joining tables in Bassett-comparable geometry, but with
+            # a SINGLE abscissa: every diagram is tabulated against
+            # Q_b/Q_c, the lateral fraction (metadata line 5). Unlike Bassett
+            # Table 1, K11 is NOT re-indexed on the straight leg, so both
+            # coefficients pass q through unchanged. Applying Bassett's 1-q
+            # here mirrors the K11 curve -- that was the first wiring attempt.
+            if K_id in {"K11", "K12"}:
+                return self._joining(q, psi or 1.0, theta_rad or math.pi / 2.0, topology)
+            return NetworkResult(
+                converged=False, message=f"idelchik1966 coefficient {K_id} not wired"
+            )
+        if paper != "bassett2001":
+            return NetworkResult(converged=False, message=f"paper {paper!r} not wired")
         if K_id in {"K6", "K5", "K2"}:
             return self._separating(q, psi or 1.0, theta_rad or math.pi / 2.0, topology)
         if K_id in {"K11", "K12"}:

--- a/validation/junction/network_runner.py
+++ b/validation/junction/network_runner.py
@@ -14,8 +14,9 @@ production.
 from __future__ import annotations
 
 import math
+from collections.abc import Iterator
 from dataclasses import dataclass
-from typing import Iterator, Protocol
+from typing import Protocol
 
 from validation.junction.equivalences import canonical_K
 from validation.junction.models._network_builder import (
@@ -23,7 +24,7 @@ from validation.junction.models._network_builder import (
     NetworkResult,
     Topology,
 )
-from validation.junction.schema import Dataset, FileMetadata, load_dataset
+from validation.junction.schema import Dataset, load_dataset
 
 
 class NetworkModel(Protocol):
@@ -64,8 +65,16 @@ class NetworkRecord:
     message: str = ""
 
 
-_LATERAL_K_IDS = {"K1", "K6", "K12"}
-_STRAIGHT_K_IDS = {"K2", "K5", "K11"}
+# Hager 1984 names its coefficients xi_t (straight-through) and xi_l (lateral);
+# the schema stores them in `coefficient` with K_id=None, and _which_K is fed
+# `K_id or coefficient`, so both spellings must be here.
+_LATERAL_K_IDS = {"K1", "K6", "K12", "xi_l"}
+_STRAIGHT_K_IDS = {"K2", "K5", "K11", "xi_t"}
+
+# Ground truth for network scoring: digitised measurements, and handbook
+# tabulations (Idelchik) which are reference data in their own right. Not a
+# paper's own analytical curve ("calc") and not an envelope.
+_GROUND_TRUTH_KINDS = {"measured", "tabulated"}
 
 
 def _which_K(K_id: str) -> str | None:
@@ -90,7 +99,7 @@ def iter_network_records(
 
     supported = set(getattr(model, "SUPPORTED_TOPOLOGIES", ALL_TOPOLOGIES))
     for file in dataset.files:
-        if file.kind != "measured" or file.x_axis != "q":
+        if file.kind not in _GROUND_TRUTH_KINDS or file.x_axis != "q":
             continue
         K_id = file.K_id or file.coefficient or ""
         which = _which_K(K_id)

--- a/validation/junction/schema.py
+++ b/validation/junction/schema.py
@@ -8,7 +8,7 @@ load_dataset() entrypoint.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 
@@ -89,7 +89,8 @@ def _load_one_paper(paper_dir: Path) -> tuple[PaperMetadata, list[FileMetadata]]
                 K_id=e.get("K_id"),
                 coefficient=e.get("coefficient") or e.get("K_id"),
                 psi=e.get("psi"),
-                theta_deg=e.get("theta_deg"),
+                # Hager 1984 names the lateral angle delta; same quantity.
+                theta_deg=e.get("theta_deg", e.get("delta_deg")),
                 a=e.get("a"),
                 q=e.get("q"),
                 M_3=e.get("M_3"),


### PR DESCRIPTION
#271 **step 0** -- widen the acceptance gate before any C++. Checklist items #1, #7, #8.

Every network adapter returned *"non-Bassett papers unsupported"*, so **41 of 128 digitised files** -- Hager's own K_straight measurements and all 36 Idelchik joining tables -- had never been scored. These are the data the tuned constants were fitted to or must be judged on.

## Results (imposed_q)

**Hager `xi_t`** (delta=90, single + manifold laterals): **45/45 converged, MAE 0.286, bias +0.055.** Independent of Bassett, and lands in the same band as Bassett K5 (0.18-0.30). Two datasets now agree on where `K_straight` sits.

**Idelchik K11/K12**: 324/396 converged, MAE 0.377, bias -0.171.

| cell | MAE | bias | reading |
|---|---|---|---|
| K11 theta=30/45/90, psi 1..10 | 0.05-0.35 | drifts with psi | in band; psi trend is closure signal |
| K12 theta=30/45, psi <= 5 | 0.04-0.25 | small | in band |
| **K12 theta=90, psi 1..10** | 0.34-2.80 | **-0.32 -> -2.37** | systematic under-prediction growing with psi |
| K12 theta=30, psi=10 | 1.77 | +1.77 | extrapolation beyond Bassett's psi <= 4 |
| 72 unconverged | | | exactly 2 per cell -- the q -> 0 / 1 endpoints, artifact-root guard |

## The q convention bit a third way

Idelchik tabulates **every** diagram against `Q_b/Q_c`, K11 included; the metadata's "same as Bassett's" holds only for K12. The first wiring applied Bassett's K11 `1-q` and mirrored the whole K11 family: MAE 0.36-7.04 at theta=30. **Isolated before fixing**: standalone Mynard and the network path agree to 3 decimals at every probed point, so the miss was axis, not model. Corrected: 0.05-0.50. Metadata comment fixed; both conventions pinned by symmetry tests.

## Two findings for step 1 (the alpha / eta tables)

1. **Idelchik and Bassett disagree with each other** at theta=90, psi=1: at q=0.8 Idelchik K12 = 1.56 where Bassett Fig 10b reads ~0.9. The K12@90 miss is partly source-vs-source. The scorecard must show both, not average them.
2. **`alpha = 0.2` has a third provenance bug.** `tmp/calibrate_etransfer_join.py` feeds `bassett2001.K11_corr(q, ...)` the lateral fraction; Bassett K11 takes the straight one. So alpha was fitted against a **mirrored Bassett K11 anchor**, on pre-#212 plumbing, and is measured in-network here for the first time. Its retune (checklist #3) has to fix the script's axis first.

Full suite: 1971 passed. No CHANGELOG entry -- validation tree only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RNDxZouiHoJdaLpnnPjHq
