### PR TITLE
test(junction): prove eta and alpha against the data; alpha stays at 0.2 (#271 step 1.3)

### DIFF
--- a/python/combaero/network/_mynard2010.py
+++ b/python/combaero/network/_mynard2010.py
@@ -72,7 +72,14 @@ class MynardResult:
 #: 90 deg between collectors, orientation swept 0-90 deg, lambda = 0.5,
 #: Re 1363-1817 (blood flow). That is not our regime, so the values are held
 #: to the Bassett K5/K6 + Hager xi_t dividing-flow cells, not to the CFD.
-#: Proving table: pending (#271 step 1.3). Switch: ``eta_scale``.
+#: PROVEN 2026-09-05 (#271 step 1.3, imposed_q, on/off at fixed alpha):
+#:   Hager xi_t   MAE 0.3385 -> 0.2859, bias +0.338 -> +0.055
+#:   Bassett K5   MAE 0.3812 -> 0.3440, bias +0.235 -> +0.033
+#:   Bassett K6   MAE 0.0700 -> 0.0526, bias -0.047 -> -0.002
+#: Improves every dividing cell of both independent sources, chiefly by
+#: removing a large positive bias. No effect on any joining cell (its
+#: (1 - lambda) factor is zero there), verified to 4 decimals.
+#: Switch: ``eta_scale``.
 MYNARD_ETA_A0: float = 0.8
 MYNARD_ETA_A1: float = -0.2
 
@@ -81,7 +88,8 @@ MYNARD_ETA_A1: float = -0.2
 #: only justification is "avoids infinite C when FlowRatio approaches zero".
 #: NOT in the paper and NOT physics -- a numerical knob whose effect is
 #: confined to FlowRatio -> 0, i.e. the q -> 0 / q -> 1 endpoints of the
-#: Bassett curves. Proving table: pending (#271 step 1.3).
+#: Bassett curves. Proving table: pending (#271 step 1.4, endpoint
+#: sensitivity).
 FLOW_RATIO_DAMPING: float = 0.02
 
 

--- a/python/combaero/network/mpce_v2_element.py
+++ b/python/combaero/network/mpce_v2_element.py
@@ -113,7 +113,19 @@ class MPCEv2Element(MultiPortChamberElement):
     #:   - It is measured together with Mynard's eta (both live in
     #:     ``etransfer``; see ``eta_scale``), never one half of the pair.
     #:
-    #: Proving table: pending (#271 step 1.3). Switch: pass 0.0.
+    #: PROVEN 2026-09-05 (#271 step 1.3, imposed_q, eta on, alpha swept):
+    #:   alpha        0.0     0.1     0.15    0.20    0.25    0.30
+    #:   Idelchik all 0.512   0.404   0.380   0.377   0.385   0.411   (MAE)
+    #:   Idelchik K11 bias    -0.309  ...    -0.025  +0.046  +0.116
+    #: In-network optimum is 0.2, shallow over [0.15, 0.25]; sources pull
+    #: slightly apart (Bassett K11 prefers ~0.25, Bassett K12 and Idelchik
+    #: K11 ~0.15). The corrected-axis ANCHOR refit (#283) said 0.28-0.31 and
+    #: is worse here (Idelchik +0.034): the anchors are Bassett's analytical
+    #: curves, this table is measured/tabulated data, and measured wins.
+    #: No alpha fixes Idelchik K12 (bias -0.27 at the MAE minimum) -- that
+    #: is the closure's K12@90 shape limit, not a tuning question.
+    #: No effect on any dividing cell or any psi = 1 cell, verified.
+    #: Switch: pass 0.0.
     DEFAULT_JOINING_ETRANSFER_ALPHA: float = 0.2
 
     def __init__(

--- a/python/tests/test_junction_tuned_constants_proof.py
+++ b/python/tests/test_junction_tuned_constants_proof.py
@@ -1,0 +1,111 @@
+"""The on/off proofs for the tuned constants, pinned against the data.
+
+``test_junction_tuned_constants.py`` pins the *values*. This file pins the
+*reason they are allowed to have those values*: each term must improve
+agreement with the digitised data on the cells it acts on, and must not act
+anywhere else. If a change to the closure or the data flips one of these,
+the constant's label on issue #271 is no longer true and it needs a new
+table before it can stay.
+
+Each assertion is a direction with a margin, not a stored number, so a small
+re-digitisation does not trip it while a real regression does. Runs the
+imposed_q scorecard, ~4 s per configuration.
+"""
+
+from __future__ import annotations
+
+import statistics
+
+import pytest
+
+from validation.junction.models.mpce_v2_network import MPCEv2Network
+from validation.junction.network_runner import run_network
+
+
+def _mae_bias(alpha: float, eta: float, paper: str, K_ids: set[str]) -> tuple[float, float, int]:
+    recs = [
+        r
+        for r in run_network(
+            MPCEv2Network(joining_etransfer_alpha=alpha, eta_scale=eta),
+            topologies=("imposed_q",),
+        )
+        if r.paper == paper and r.K_id in K_ids and r.converged and r.K_extracted is not None
+    ]
+    errs = [r.K_extracted - r.K_measured for r in recs]
+    return statistics.fmean(abs(e) for e in errs), statistics.fmean(errs), len(errs)
+
+
+@pytest.fixture(scope="module")
+def hager():
+    return {eta: _mae_bias(0.2, eta, "hager1984", {"xi_t"}) for eta in (0.0, 1.0)}
+
+
+@pytest.fixture(scope="module")
+def bassett_dividing():
+    return {eta: _mae_bias(0.2, eta, "bassett2001", {"K5", "K6"}) for eta in (0.0, 1.0)}
+
+
+@pytest.fixture(scope="module")
+def idelchik_by_alpha():
+    return {a: _mae_bias(a, 1.0, "idelchik1966", {"K11", "K12"}) for a in (0.0, 0.2, 0.3)}
+
+
+def test_eta_improves_the_independent_straight_flow_data(hager):
+    """Hager xi_t is the one K_straight source that is not Bassett.
+
+    With eta off the closure over-predicts by a third of a dynamic head;
+    with it on the bias falls by ~0.28 and MAE by ~0.05.
+    """
+    mae_off, bias_off, n_off = hager[0.0]
+    mae_on, bias_on, n_on = hager[1.0]
+
+    assert n_on == n_off == 45
+    assert mae_on < mae_off - 0.03
+    assert abs(bias_on) < abs(bias_off) - 0.2
+
+
+def test_eta_improves_bassett_dividing_flow(bassett_dividing):
+    mae_off, bias_off, _ = bassett_dividing[0.0]
+    mae_on, bias_on, _ = bassett_dividing[1.0]
+
+    assert mae_on < mae_off - 0.01
+    assert abs(bias_on) < abs(bias_off)
+
+
+def test_eta_does_not_touch_joining_cells():
+    """Its (1 - lambda) factor is zero for a single collector, so joining
+    coefficients must be identical with the term on and off -- a difference
+    here is a plumbing defect, not a physics result."""
+    off = _mae_bias(0.2, 0.0, "idelchik1966", {"K11", "K12"})
+    on = _mae_bias(0.2, 1.0, "idelchik1966", {"K11", "K12"})
+
+    assert on[2] == off[2]
+    assert on[0] == pytest.approx(off[0], abs=2e-3)
+
+
+def test_alpha_improves_joining_flow_over_off(idelchik_by_alpha):
+    """alpha = 0 leaves Idelchik K11 under-predicted by ~0.3; 0.2 removes it."""
+    mae0, bias0, n0 = idelchik_by_alpha[0.0]
+    mae2, bias2, n2 = idelchik_by_alpha[0.2]
+
+    assert n0 == n2
+    assert mae2 < mae0 - 0.1
+    assert abs(bias2) < abs(bias0) - 0.2
+
+
+def test_alpha_default_beats_the_anchor_refit_in_network(idelchik_by_alpha):
+    """The corrected-axis anchor refit (#283) proposed ~0.3; the measured and
+    tabulated data prefer 0.2. Pins that the in-network table, not the
+    analytical anchors, decides the value."""
+    mae2, _, _ = idelchik_by_alpha[0.2]
+    mae3, _, _ = idelchik_by_alpha[0.3]
+
+    assert mae2 < mae3 - 0.02
+
+
+def test_alpha_does_not_touch_dividing_cells():
+    """It needs two suppliers; a dividing tee has one."""
+    a0 = _mae_bias(0.0, 1.0, "hager1984", {"xi_t"})
+    a2 = _mae_bias(0.2, 1.0, "hager1984", {"xi_t"})
+
+    assert a0 == pytest.approx(a2)

--- a/validation/junction/MPCE_CPP_PORT_DESIGN.md
+++ b/validation/junction/MPCE_CPP_PORT_DESIGN.md
@@ -174,6 +174,60 @@ figure/table it was fitted to, the range, the date, and the scorecard cell
 that proves it. `alpha` and `damping` currently carry none of this;
 `DEFAULT_JOINING_ETRANSFER_ALPHA` reads as a physics constant.
 
+## 4b. Step 1.3 result: the alpha x eta table (2026-09-05)
+
+Every (alpha, eta_scale) combination scored on every digitised cell, imposed_q
+topology, per source. Prediction written down first and confirmed: the two
+terms are structurally separable in this dataset -- `eta` moves only dividing
+cells (its `(1 - lambda)` factor is zero for a single collector), `alpha`
+moves only psi > 1 joining cells -- to 4 decimals. The baseline `(0.2, 1)`
+reproduces step 0 to the digit.
+
+**`eta` -- keep at (0.8, -0.2).** On/off at fixed alpha:
+
+| cell | eta off | eta on |
+|---|---|---|
+| Hager xi_t (45 pts) | MAE 0.3385, bias +0.338 | **0.2859, +0.055** |
+| Bassett K5 | 0.3812, +0.235 | **0.3440, +0.033** |
+| Bassett K6 | 0.0700, -0.047 | **0.0526, -0.002** |
+
+Improves every dividing cell of both independent sources, chiefly by
+removing a large positive bias -- without it the closure over-predicts
+straight-port loss by a third of a dynamic head. A CFD-fitted term from
+another regime that nonetheless earns its place on ours.
+
+**`alpha` -- keep at 0.2.** Swept at eta on, joining sources:
+
+| alpha | Bassett K11 | Bassett K12 | Idelchik K11 | Idelchik K12 | Idelchik all |
+|---|---|---|---|---|---|
+| 0.00 | 0.2268 (-0.159) | 0.1128 (+0.020) | 0.3095 (-0.309) | 0.6561 (-0.543) | 0.5116 |
+| 0.10 | 0.1980 | 0.1025 | 0.1851 | 0.5599 | 0.4037 |
+| 0.15 | 0.1887 | **0.1018** | **0.1611** | 0.5366 | 0.3801 |
+| **0.20** | 0.1803 (-0.027) | 0.1032 (+0.048) | 0.1646 (-0.025) | **0.5287** (-0.274) | **0.3770** |
+| 0.25 | 0.1738 | 0.1060 | 0.1744 | 0.5346 | 0.3845 |
+| 0.30 | **0.1708** (+0.039) | 0.1094 | 0.2107 (+0.116) | 0.5539 | 0.4109 |
+
+In-network optimum 0.2, shallow over [0.15, 0.25]; the sources pull slightly
+apart (Bassett K11 prefers ~0.25, Bassett K12 and Idelchik K11 ~0.15). A
+single scalar times area asymmetry cannot satisfy both angles at once --
+that is the form's limit, not a tuning question.
+
+**The anchor refit lost to the data.** #283's corrected-axis fit proposed
+0.28-0.31; in-network 0.3 is *worse* than 0.2 (Idelchik +0.034, and it
+over-corrects K11 at 30 deg badly). The anchors are Bassett's analytical
+curves -- including his own K11@90 anomaly (sec 5) -- while the table is
+measured and tabulated data. Checklist #1: the data decides. The calibration
+script remains the "anchor on analytical" half of the method; it does not
+set the value.
+
+**What no alpha fixes:** Idelchik K12 keeps a bias of -0.27 at the MAE
+minimum. That is the K12@90 under-prediction from step 0, growing with psi,
+and it is a closure-shape limit (and partly Idelchik-vs-Bassett source
+disagreement), not something the joining correction can reach.
+
+Pinned executably by `python/tests/test_junction_tuned_constants_proof.py`:
+each term improves its own block by a margin and does not touch the other.
+
 ## 5. What the papers settle about the K_straight question (#272)
 
 Three independent sources say **negative `K_straight` in dividing flow is real


### PR DESCRIPTION
#271 **step 1.3** -- checklist items #1 (data decides, per source), #2 (on/off table), #3 (retune after the fix), #4 (interacting terms measured together), #7 (baseline reproduces step 0).

Six `(alpha, eta_scale)` combinations on every digitised cell of Bassett K5/K6/K11/K12, Hager `xi_t`, Idelchik K11/K12. **A prediction was written before the numbers and confirmed**: `eta` moves only dividing cells, `alpha` only psi > 1 joining cells, to 4 decimals. Each term judged on its own block; baseline `(0.2, 1)` reproduces step 0 to the digit.

## `eta` (Mynard a0 = 0.8, a1 = -0.2) -- keep

| cell | off | on |
|---|---|---|
| Hager xi_t | 0.3385 (+0.338) | **0.2859 (+0.055)** |
| Bassett K5 | 0.3812 (+0.235) | **0.3440 (+0.033)** |
| Bassett K6 | 0.0700 (-0.047) | **0.0526 (-0.002)** |

Improves every dividing cell of both independent sources, chiefly by removing a large positive bias. A CFD-fitted term from blood-flow Re that earns its place on engine-Re data.

## `alpha` -- keep at 0.2; the anchor refit loses to the data

| alpha | 0.0 | 0.1 | 0.15 | **0.2** | 0.25 | 0.3 |
|---|---|---|---|---|---|---|
| Idelchik all MAE | 0.512 | 0.404 | 0.380 | **0.377** | 0.385 | 0.411 |
| Idelchik K11 bias | -0.309 | -0.167 | -0.096 | **-0.025** | +0.046 | +0.116 |

In-network optimum 0.2, shallow over [0.15, 0.25]. The corrected-axis anchor refit (#283) proposed 0.28-0.31 and is **worse** in-network (+0.034; over-corrects K11 at 30 deg). The anchors are Bassett's analytical curves -- including his own K11@90 anomaly -- the table is measured and tabulated data. **Measured wins.** Checklist #3 worked as designed: the refit was run, it was measured, and it lost.

**What no alpha fixes:** Idelchik K12 keeps a -0.27 bias at the MAE minimum -- the K12@90 shape limit from step 0, not a tuning question.

## Pinned, not just labelled

`test_junction_tuned_constants_proof.py` asserts each proof as a **direction with a margin** (eta on beats off on Hager and Bassett dividing by > 0.03 / 0.01 MAE; alpha 0.2 beats 0 on Idelchik by > 0.1 and beats 0.3 by > 0.02; neither term touches the other's block). A closure or data change that flips one fails a test instead of leaving a stale label. ~40 s; runs under the suite's `-n auto`.

Both constant labels now carry their proof tables and date. Design doc sec 4b has the full grid.

No behaviour change; no CHANGELOG entry. Full suite: 2002 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RNDxZouiHoJdaLpnnPjHq
