### PR TITLE
test(junction): band the damping regulariser and show it is cancelled in the K form (#271 step 1.4)

### DIFF
--- a/python/combaero/network/_mynard2010.py
+++ b/python/combaero/network/_mynard2010.py
@@ -86,10 +86,23 @@ MYNARD_ETA_A1: float = -0.2
 #: Regulariser on the collector loss coefficient, (1 - exp(-FlowRatio/tau)).
 #: Source: the Matlab reference JunctionLossCoefficient.m lines 60-63, whose
 #: only justification is "avoids infinite C when FlowRatio approaches zero".
-#: NOT in the paper and NOT physics -- a numerical knob whose effect is
-#: confined to FlowRatio -> 0, i.e. the q -> 0 / q -> 1 endpoints of the
-#: Bassett curves. Proving table: pending (#271 step 1.4, endpoint
-#: sensitivity).
+#: NOT in the paper and NOT physics. Not tuned to data -- shown not to
+#: matter to it (#271 step 1.4, 2026-09-05, 150 dividing points, 3 sources):
+#:   tau in (0, 0.02]  identical to 4 decimals on every interior point and
+#:                     identical convergence at every endpoint, damping ON
+#:                     or OFF; the "infinite C" case occurs nowhere in the
+#:                     data.
+#:   tau >= 0.05       degrades monotonically (interior MAE +0.0007 at 0.05,
+#:                     +0.016 at 0.2).
+#: Why it is cancelled here: C ~ 1/FlowRatio without damping, but the K
+#: conversion (Mynard Eq 18, what MPCEv2 uses) multiplies by FlowRatio^2,
+#: so K -> 1 (the dead-branch limit) with or without it. The knob bounds a
+#: quantity the production path never exposes. It WOULD matter for
+#: Mynard's native C-form residual (p_i - p_j = C_j rho u_j^2), which is why
+#: it is kept at the reference value rather than removed. Band: (0, 0.02].
+#: Known edge: at FlowRatio exactly 0, K_lat = -1 with or without damping
+#: (a sign-flipped dead branch) -- a degenerate-iterate case for the
+#: solver-robustness work, not something this knob guards.
 FLOW_RATIO_DAMPING: float = 0.02
 
 

--- a/python/tests/test_junction_damping_band.py
+++ b/python/tests/test_junction_damping_band.py
@@ -1,0 +1,121 @@
+"""FLOW_RATIO_DAMPING: the regulariser's band, and why it is cancelled.
+
+``damping = 1 - exp(-FlowRatio / tau)`` multiplies Mynard's collector
+coefficient C. The Matlab reference justifies it as "avoids infinite C when
+FlowRatio approaches zero". In the K form MPCEv2 uses (Mynard Eq 18) that
+divergence is multiplied by FlowRatio^2, so K reaches the dead-branch limit
+with or without the knob. These tests pin that -- exactly, because it is a
+limit, not a tuning -- and pin the band over which the knob is inert.
+
+Direct closure calls, no network: the scorecard evidence lives on #271.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from combaero.network import _mynard2010 as mynard
+
+_A = np.array([0.01, 0.01, 0.01])
+_THETA = np.array([math.pi, 0.0, math.pi / 2.0])  # common, straight, lateral
+
+
+def _dividing(fr_lateral: float) -> np.ndarray:
+    """Supplier at port 0; lateral collector carries fraction fr of it."""
+    return np.array([10.0, -10.0 * (1.0 - fr_lateral), -10.0 * fr_lateral])
+
+
+@pytest.fixture
+def damping(monkeypatch):
+    def _set(tau: float):
+        monkeypatch.setattr(mynard, "FLOW_RATIO_DAMPING", tau)
+
+    return _set
+
+
+@pytest.mark.parametrize("tau", [1e-9, 0.005, 0.01, 0.02])
+def test_band_is_inert_in_the_interior(damping, tau):
+    """Over (0, 0.02] the knob changes nothing where the data lives."""
+    U = _dividing(0.5)
+    damping(0.02)
+    reference = mynard.junction_loss_coefficient(U, _A, _THETA).K
+    damping(tau)
+    K = mynard.junction_loss_coefficient(U, _A, _THETA).K
+
+    assert reference is not None and K is not None
+    np.testing.assert_allclose(K, reference, rtol=1e-9)
+
+
+def test_above_the_band_it_distorts(damping):
+    """The label's upper bound is real: tau = 0.2 moves an interior point."""
+    U = _dividing(0.5)
+    damping(0.02)
+    reference = mynard.junction_loss_coefficient(U, _A, _THETA).K
+    damping(0.2)
+    K = mynard.junction_loss_coefficient(U, _A, _THETA).K
+
+    assert reference is not None and K is not None
+    assert not np.allclose(K, reference, rtol=1e-3)
+
+
+@pytest.mark.parametrize("fr", [1e-3, 1e-4, 1e-6])
+def test_K_reaches_the_dead_branch_limit_with_or_without_damping(damping, fr):
+    """Eq 18 multiplies C by FlowRatio^2, cancelling the 1/FlowRatio blow-up.
+
+    K_lat -> 1 (all of the common dynamic head lost into a dead branch) is the
+    physical limit, and it is reached identically with the knob on or off --
+    the knob protects a quantity the K form never exposes.
+    """
+    U = _dividing(fr)
+    with np.errstate(all="ignore"):
+        damping(0.02)
+        K_on = mynard.junction_loss_coefficient(U, _A, _THETA).K
+        damping(1e-300)
+        K_off = mynard.junction_loss_coefficient(U, _A, _THETA).K
+
+    assert K_on is not None and K_off is not None
+    assert K_on[1] == pytest.approx(1.0, abs=1e-3)
+    assert K_off[1] == pytest.approx(1.0, abs=1e-3)
+
+
+def test_damping_is_what_bounds_C_and_nothing_else(damping):
+    """The knob's one real effect: C stays bounded as FlowRatio -> 0.
+
+    This is the quantity the Matlab comment is about. It would matter for
+    Mynard's native C-form residual; it is why the knob is retained.
+    """
+    with np.errstate(all="ignore"):
+        damping(0.02)
+        C_on = [
+            abs(float(mynard.junction_loss_coefficient(_dividing(fr), _A, _THETA).C[2]))
+            for fr in (1e-2, 1e-4, 1e-6)
+        ]
+        damping(1e-300)
+        C_off = [
+            abs(float(mynard.junction_loss_coefficient(_dividing(fr), _A, _THETA).C[2]))
+            for fr in (1e-2, 1e-4, 1e-6)
+        ]
+
+    assert max(C_on) < 20.0, "damping no longer bounds C"
+    assert C_off[-1] > 1e4, "C no longer diverges without damping -- the knob has lost its reason"
+
+
+def test_exact_zero_flow_edge_is_not_guarded_by_damping(damping):
+    """Documented edge: at FlowRatio exactly 0, K_lat = -1 either way.
+
+    A sign-flipped dead branch. Pinned so that whoever fixes it as part of
+    the degenerate-iterate work (#271 step 2) sees this test fail and removes
+    it rather than discovering the edge again.
+    """
+    with np.errstate(all="ignore"):
+        damping(0.02)
+        K_on = mynard.junction_loss_coefficient(_dividing(0.0), _A, _THETA).K
+        damping(1e-300)
+        K_off = mynard.junction_loss_coefficient(_dividing(0.0), _A, _THETA).K
+
+    assert K_on is not None and K_off is not None
+    assert K_on[1] == pytest.approx(-1.0)
+    assert K_off[1] == pytest.approx(-1.0)

--- a/validation/junction/MPCE_CPP_PORT_DESIGN.md
+++ b/validation/junction/MPCE_CPP_PORT_DESIGN.md
@@ -228,6 +228,51 @@ disagreement), not something the joining correction can reach.
 Pinned executably by `python/tests/test_junction_tuned_constants_proof.py`:
 each term improves its own block by a margin and does not touch the other.
 
+## 4c. Step 1.4 result: the damping regulariser (2026-09-05)
+
+`damping = 1 - exp(-FlowRatio / tau)` on Mynard's collector `C`, from the
+Matlab reference only ("avoids infinite C when FlowRatio approaches zero").
+Swept tau over {off, 0.005, 0.01, 0.02, 0.05, 0.1, 0.2} on all 150 dividing
+points (Bassett K5/K6, Hager xi_t) at the proven eta and alpha. A regulariser
+is not tuned to data; the task was to show it does not matter to it.
+
+| tau | interior MAE (101 pts) | endpoint MAE (49 pts) | endpoint converged |
+|---|---|---|---|
+| off | 0.1437 | **0.3809** | 38 / 49 |
+| 0.005 | 0.1437 | 0.3822 | 38 / 49 |
+| 0.01 | 0.1437 | 0.3837 | 38 / 49 |
+| **0.02** | 0.1437 | 0.3859 | 38 / 49 |
+| 0.05 | 0.1445 | 0.3986 | 38 / 49 |
+| 0.1 | 0.1491 | 0.4196 | 38 / 49 |
+| 0.2 | 0.1595 | 0.4425 | 38 / 49 |
+
+- **(a) inert in the interior** over (0, 0.02], to 4 decimals.
+- **(c) value-insensitive** over that band; degrades monotonically above it.
+- **(b) necessary for convergence -- no.** Convergence is identical with the
+  knob off at every endpoint (the same 11 Bassett failures at every tau,
+  which are the artifact-root guard at true q -> 0/1, not a C blow-up), and
+  the endpoint MAE is slightly *better* off. The "infinite C" case occurs
+  nowhere in the data.
+
+**Why it is cancelled.** Probing the FlowRatio -> 0 limit directly: `C`
+diverges as 1/FlowRatio without damping (-21 -> -2.2e5 from 1e-2 to 1e-6)
+and damping bounds it (~ -10.9). But MPCEv2 uses `K`, and Mynard Eq 18
+multiplies `C` by FlowRatio^2, so `K_lat -> 1` -- the correct dead-branch
+limit -- identically with or without the knob. The regulariser protects a
+quantity the production path never exposes. It *would* matter for Mynard's
+native `C_j` residual (sec 8 step 3b), which is the honest reason to keep it
+at the reference value rather than delete it.
+
+**Verdict:** band (0, 0.02], retained at 0.02 for fidelity to the reference
+and for the C-form option. Labelled as such; pinned by
+`python/tests/test_junction_damping_band.py` with exact tolerances (a limit,
+not a tuning).
+
+**Edge found on the way:** at FlowRatio exactly 0, `K_lat = -1` with or
+without damping -- a sign-flipped dead branch the knob never guarded. Pinned
+by test so the degenerate-iterate work (step 2) removes the test when it
+fixes the edge, rather than rediscovering it.
+
 ## 5. What the papers settle about the K_straight question (#272)
 
 Three independent sources say **negative `K_straight` in dividing flow is real


### PR DESCRIPTION
#271 **step 1.4** -- checklist items #1 (data), #2 (labelled; for a regulariser the label is a *band*), #7 (baseline). Closes step 1: all three tuned constants now carry source, proof, and date.

## A regulariser is not tuned to data -- it is shown not to matter to it

`FLOW_RATIO_DAMPING = 0.02` multiplies Mynard's collector `C` by `1 - exp(-FlowRatio/tau)`. Matlab-only provenance: *"avoids infinite C when FlowRatio approaches zero"*. Swept over {off ... 0.2} on all 150 dividing points at the proven `eta`/`alpha`:

| tau | interior MAE (101) | endpoint MAE (49) | endpoint conv |
|---|---|---|---|
| off | 0.1437 | **0.3809** | 38/49 |
| **0.02** | 0.1437 | 0.3859 | 38/49 |
| 0.2 | 0.1595 | 0.4425 | 38/49 |

- **Inert** in the interior over (0, 0.02] to 4 decimals; degrades monotonically above.
- **Not necessary for convergence.** Identical convergence with it *off* at every endpoint -- the same 11 failures at every tau are the artifact-root guard at true q -> 0/1, not a C blow-up -- and the endpoint MAE is slightly better off. The "infinite C" case occurs nowhere in the data.

## Why: it is cancelled in the form MPCEv2 uses

Probing FlowRatio -> 0 directly, `C` does diverge as 1/FR without damping (-21 -> -2.2e5) and damping does bound it (~ -10.9). But Eq 18 multiplies `C` by `FR^2` to get `K`, so **`K_lat -> 1` -- the correct dead-branch limit -- identically either way.** The knob protects a quantity the production path never exposes. It *would* matter for Mynard's native `C_j` residual (design doc sec 8, step 3b) -- the honest reason to keep it at the reference value rather than delete it.

**Verdict:** keep 0.02, band (0, 0.02]. Pinned by `test_junction_damping_band.py` with **exact** tolerances (a limit, not a tuning): inert across the band, distorting above it, `K` at the dead-branch limit on or off, `C` bounded only with the knob.

## Edge found on the way

At FlowRatio exactly 0, `K_lat = -1` with or without damping -- a sign-flipped dead branch nothing guards. Pinned by test so the degenerate-iterate work in step 2 removes the test when it fixes the edge, rather than rediscovering it.

No behaviour change; no CHANGELOG entry. Full suite: 2012 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RNDxZouiHoJdaLpnnPjHq
