### PR TITLE
fix(junction): narrow MPCEv2's wide except clauses to loud, named failures (#271 step 2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -239,6 +239,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.4.2] - 2026-07-09
 
 ### Fixed
+- **`MPCEv2Element` no longer turns an exception inside the Mynard closure
+  into a silent lossless junction (issue #271).** Three call sites wrapped
+  `junction_loss_coefficient` in `except Exception`; the residual site
+  returned a lossless continuity residual with an *empty* Jacobian for any
+  error at all, and the FD-fallback site left a Jacobian column at zero.
+  Measured across 2073 scorecard records (three sources, three topologies)
+  and the full test suite, those handlers never caught a legitimate degenerate
+  flow split -- the guard ahead of the call already routes those to the
+  continuity fallback -- and the only thing they ever caught was a plumbing
+  error, which they disguised as a plausible-looking lossless junction
+  mid-solve. Now: the closure's two possible exceptions (`IndexError`,
+  `ValueError`) are re-raised as a `RuntimeError` naming the element, the
+  port mass flows and the supplier/collector masks, with the cause chained;
+  every other exception propagates untouched. `diagnostics()` narrows the
+  same way and, post-solve, reports a `closure_error` key instead of silently
+  omitting the `K` fields. **Converged results are unchanged** -- the
+  scorecard reproduces the previous tables to the digit -- because the
+  removed path was never taken on a legitimate state.
 - **`MPCEv2Element`'s Jacobian was missing the common-port static-pressure
   column (issue #271).** The Mynard loss term `K_i * q_dyn_com` depends on the
   common port's density, and hence on its static pressure, through two paths:

--- a/python/combaero/network/mpce_v2_element.py
+++ b/python/combaero/network/mpce_v2_element.py
@@ -252,7 +252,11 @@ class MPCEv2Element(MultiPortChamberElement):
                 joining_etransfer_alpha=self.joining_etransfer_alpha,
                 eta_scale=self.eta_scale,
             )
-        except Exception:
+        except (IndexError, ValueError) as exc:
+            # The two exceptions the closure can raise on a degenerate flow
+            # split. Post-solve, so report rather than raise -- but never
+            # silently: an absent K field must be attributable.
+            diag["closure_error"] = type(exc).__name__
             return diag
 
         if mynard.K is None:
@@ -431,11 +435,22 @@ class MPCEv2Element(MultiPortChamberElement):
                 joining_etransfer_alpha=self.joining_etransfer_alpha,
                 eta_scale=self.eta_scale,
             )
-        except Exception:
-            # Numerical failure (e.g. singular pseudosupplier). Same fallback.
-            residuals = [float(s.Pt) - Pt_jct for s in states]
-            residuals.append(sum(port_mdots))
-            return residuals, {}
+        except (IndexError, ValueError) as exc:
+            # The closure can raise only on a degenerate flow split (empty
+            # supplier or collector mask), and the guard above already routes
+            # those to the continuity fallback before this call. Reaching
+            # here therefore means the two classifications disagree -- an
+            # anomaly worth seeing, not one to paper over. This used to
+            # return a lossless residual with an EMPTY Jacobian for *any*
+            # exception, which turned a plumbing error into a plausible-
+            # looking lossless junction mid-solve (issue #271). Programming
+            # errors now propagate untouched.
+            raise RuntimeError(
+                f"MPCEv2Element '{self.id}': Mynard closure failed on a "
+                f"non-degenerate state (port_mdots={list(port_mdots)}, "
+                f"suppliers={sup_mask.tolist()}, collectors={col_mask.tolist()}). "
+                f"The degenerate-split guard should have caught this first."
+            ) from exc
 
         # ITERATION-2: use mynard.K (Matlab line 73) with common-side q_dyn.
         # This is the physically correct normalization: K is defined such
@@ -516,8 +531,15 @@ class MPCEv2Element(MultiPortChamberElement):
                         joining_etransfer_alpha=self.joining_etransfer_alpha,
                         eta_scale=self.eta_scale,
                     )
-                except Exception:
-                    continue
+                except (IndexError, ValueError) as exc:
+                    # The sign-flip guard above already skips perturbations
+                    # that cross zero; a raise here is a state the closure
+                    # cannot classify at all. Leaving the column zero was a
+                    # silent wrong derivative (issue #271, #280).
+                    raise RuntimeError(
+                        f"MPCEv2Element '{self.id}': Mynard closure failed on the "
+                        f"FD perturbation of port {j} (perturbed mdots={mdot_pert})."
+                    ) from exc
                 if m_pert.K is None or len(m_pert.K) != len(non_common_idxs):
                     continue
                 K_pert = np.zeros(N)

--- a/python/tests/test_mpce_v2_closure_errors.py
+++ b/python/tests/test_mpce_v2_closure_errors.py
@@ -1,0 +1,178 @@
+"""What happens when the Mynard closure raises inside MPCEv2Element.
+
+Three call sites wrapped ``junction_loss_coefficient`` in ``except Exception``.
+The residual site returned a lossless residual with an EMPTY Jacobian for any
+exception at all -- which, measured across 2073 scorecard records and the
+full suite, never caught a legitimate degenerate state (the guard before the
+call handles those) and did catch a plumbing error, disguising it as a
+plausible-looking lossless junction (issue #271, step 1.2).
+
+These tests pin the replacement rule: the two exceptions the closure can
+raise become a loud, named failure with the cause chained; anything else
+propagates untouched. Errors are injected by monkeypatching the closure so
+the tests do not depend on finding a real degenerate state.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import combaero as cb
+from combaero.network import mpce_v2_element as v2
+from combaero.network.components import NetworkMixtureState
+from combaero.network.mpce_v2_element import MPCEv2Element
+
+_Y = list(cb.mole_to_mass(cb.species.dry_air()))
+
+
+def _element(flow_direction: str = "branch") -> MPCEv2Element:
+    element = MPCEv2Element.__new__(MPCEv2Element)
+    element.id = "jct"
+    element.N = 3
+    element.port_nodes = ["p0", "p1", "p2"]
+    element.port_areas = [0.01, 0.01, 0.01]
+    element.port_angles_deg = [180.0, 0.0, 90.0]
+    element.flow_direction = flow_direction
+    element._port_signs = [-1.0, 1.0, 1.0] if flow_direction == "branch" else [-1.0, -1.0, 1.0]
+    element._port_element_ids = ["e0", "e1", "e2"]
+    element.strict = False
+    element.joining_etransfer_alpha = 0.2
+    element.jacobian_method = "sympy"
+    element.penalty_alpha = 0.0
+    element.eta_scale = 1.0
+    return element
+
+
+def _states():
+    return [
+        NetworkMixtureState(P=1.0e5, Pt=100_300.0, T=300.0, Tt=300.5, m_dot=0.0, Y=_Y)
+        for _ in range(3)
+    ]
+
+
+_BRANCH_MDOTS = [-0.10, 0.06, 0.04]  # one supplier -> sympy Jacobian path
+_MERGE_MDOTS = [-0.06, -0.04, 0.10]  # two suppliers -> FD Jacobian path
+
+
+def _raising(exc: BaseException, after_calls: int = 0):
+    """A closure stand-in that raises ``exc`` on call number ``after_calls``."""
+    calls = {"n": 0}
+    real = v2.junction_loss_coefficient
+
+    def fake(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] > after_calls:
+            raise exc
+        return real(*args, **kwargs)
+
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# Residual path
+# ---------------------------------------------------------------------------
+
+
+def test_programming_error_in_the_closure_propagates(monkeypatch):
+    """The 1.2 failure mode, pinned: an AttributeError must surface as itself.
+
+    The old handler turned this into a lossless residual with jac = {} and
+    19 tests failed with KeyError instead of the real error.
+    """
+    monkeypatch.setattr(v2, "junction_loss_coefficient", _raising(AttributeError("plumbing")))
+
+    with pytest.raises(AttributeError, match="plumbing"):
+        _element().residuals(_states(), 100_300.0, _BRANCH_MDOTS)
+
+
+@pytest.mark.parametrize("exc_type", [IndexError, ValueError])
+def test_degenerate_split_error_becomes_a_named_failure(monkeypatch, exc_type):
+    """The closure's own two exceptions become a RuntimeError naming the element
+    and the state, with the original chained -- not a lossless junction."""
+    monkeypatch.setattr(v2, "junction_loss_coefficient", _raising(exc_type("mask")))
+
+    with pytest.raises(RuntimeError) as info:
+        _element().residuals(_states(), 100_300.0, _BRANCH_MDOTS)
+
+    message = str(info.value)
+    assert "MPCEv2Element 'jct'" in message
+    assert "port_mdots" in message
+    assert isinstance(info.value.__cause__, exc_type)
+
+
+def test_residual_never_returns_an_empty_jacobian_on_error(monkeypatch):
+    """The specific defect: a residual with jac = {} looks like a solved row."""
+    monkeypatch.setattr(v2, "junction_loss_coefficient", _raising(IndexError("mask")))
+
+    with pytest.raises(RuntimeError):
+        _element().residuals(_states(), 100_300.0, _BRANCH_MDOTS)
+    # If we get here without a raise, the old fallback is back.
+
+
+# ---------------------------------------------------------------------------
+# FD-fallback path (joining flow, two suppliers)
+# ---------------------------------------------------------------------------
+
+
+def test_fd_perturbation_error_becomes_a_named_failure(monkeypatch):
+    """First call (the residual's own) succeeds; a perturbed call raises.
+
+    Leaving that Jacobian column zero was a silent wrong derivative.
+    """
+    monkeypatch.setattr(
+        v2, "junction_loss_coefficient", _raising(IndexError("mask"), after_calls=1)
+    )
+
+    with pytest.raises(RuntimeError, match="FD perturbation"):
+        _element("merge").residuals(_states(), 100_300.0, _MERGE_MDOTS)
+
+
+def test_fd_perturbation_programming_error_propagates(monkeypatch):
+    monkeypatch.setattr(
+        v2, "junction_loss_coefficient", _raising(TypeError("plumbing"), after_calls=1)
+    )
+
+    with pytest.raises(TypeError, match="plumbing"):
+        _element("merge").residuals(_states(), 100_300.0, _MERGE_MDOTS)
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics (post-solve): report, never silently omit
+# ---------------------------------------------------------------------------
+
+
+def test_diagnostics_annotate_a_closure_error_instead_of_dropping_K(monkeypatch):
+    monkeypatch.setattr(v2, "junction_loss_coefficient", _raising(ValueError("mask")))
+
+    diag = _element().diagnostics(_states(), 100_300.0, _BRANCH_MDOTS)
+
+    assert diag["closure_error"] == "ValueError"
+    assert not any(k.endswith("_K") for k in diag)
+
+
+def test_diagnostics_let_programming_errors_through(monkeypatch):
+    monkeypatch.setattr(v2, "junction_loss_coefficient", _raising(KeyError("plumbing")))
+
+    with pytest.raises(KeyError):
+        _element().diagnostics(_states(), 100_300.0, _BRANCH_MDOTS)
+
+
+# ---------------------------------------------------------------------------
+# The legitimate degenerate case still takes the guarded path, untouched
+# ---------------------------------------------------------------------------
+
+
+def test_degenerate_split_is_handled_before_the_closure_is_called(monkeypatch):
+    """All ports flowing the same way is caught by the guard ahead of the try.
+
+    It must reach the continuity fallback and never call the closure -- the
+    closure stand-in raising here would prove the guard was bypassed.
+    """
+    monkeypatch.setattr(
+        v2, "junction_loss_coefficient", _raising(IndexError("should not be called"))
+    )
+
+    residuals, jac = _element().residuals(_states(), 100_300.0, [-0.1, -0.05, -0.05])
+
+    assert len(residuals) == 4
+    assert jac == {}

--- a/validation/junction/MPCE_CPP_PORT_DESIGN.md
+++ b/validation/junction/MPCE_CPP_PORT_DESIGN.md
@@ -348,7 +348,7 @@ Consequences:
 | # | defect | evidence | fix | cost |
 |---|---|---|---|---|
 | 1 | `N > 3` returns finite residuals with an all-zero `dKQ` block | pinned by strict xfail in `test_mpce_v2_fd_fallback_guards.py` | reject `N > 3` at construction with a message naming the Mynard 3-branch K limit; the C-form is the eventual lift | 1 line + test |
-| 2 | Residual-level silent physics switch: `mpce_v2_element.py:402` catches *any* exception from Mynard and returns a **lossless** continuity residual with an **empty** Jacobian `{}` | same pattern as the FD guards, one level up: an unrepresentable state becomes a plausible-looking lossless junction mid-solve | narrow the `except` to the two exception types Mynard actually raises (`IndexError`, `ValueError` -- pinned in the guard tests), and either raise or return the soft-barrier residual, never `{}` | small |
+| 2 | ~~Residual-level silent physics switch: `mpce_v2_element.py` catches *any* exception from Mynard and returns a **lossless** continuity residual with an **empty** Jacobian `{}`~~ | **fixed, step 2.1.** Measured first: 0 hits across 2073 scorecard records + the full suite (the pre-check guard ahead of the call fired 145 times -- that is the legitimate degenerate path). All three wide `except`s (residual, FD loop, diagnostics) narrowed to `(IndexError, ValueError)`; residual and FD paths raise a named `RuntimeError` with the cause chained, diagnostics annotates `closure_error`. Falsified 8/9 against pre-fix; scorecard identical to the digit | done |
 | 3 | Hager and Idelchik unscored | sec 6 | extend `MPCEv2Network.evaluate_network` to `hager1984` (separating, `q -> 1 - q`) and `idelchik1966` (joining, `q` = Bassett's) | small; data + `q_transform` exist |
 | 4 | `alpha = 0.2` calibrated pre-#212 | memory + `tmp/calibrate_etransfer_join.py` | re-run the calibration on current plumbing **after** #3 lands, so its validation is in-network; if it no longer earns its place, set the default to 0 | script exists |
 | 5 | `damping` 0.02 undocumented as a regulariser | Matlab comment | name it (`FLOW_RATIO_DAMPING = 0.02`) with the Matlab citation and the sentence "numerical regulariser, not physics" | trivial |
@@ -357,6 +357,32 @@ Consequences:
 
 Items 1, 2, 5, 6 are an afternoon. Item 3 is the one that changes what the
 port can be held to.
+
+## 7a. Step 2.1 note: the wide-except audit (2026-09-05)
+
+Every `except` in the junction model, adapters and Jacobian helper was
+listed. Only three were wide, all in `mpce_v2_element.py`, all around
+`junction_loss_coefficient`. `_network_builder.py`'s `except Exception` is
+the correct pattern -- it reports `converged=False` *with the message*.
+`_mpce_v2_jacobian.py:118` is narrow in type (`ZeroDivisionError`,
+`FloatingPointError`) but wide in effect (a zero Jacobian entry); it belongs
+with the degenerate-iterate work below.
+
+**Measured, not assumed.** Instrumented all three and the pre-check guard,
+then ran the full scorecard (3 sources x 3 topologies, 2073 records) and the
+full suite: the three `except`s fired **0** times; the pre-check fallback
+fired 145 times on the scorecard and once in the suite. The structural
+argument -- the guard ahead of the call already routes every degenerate
+split to the continuity fallback, so the closure cannot raise its two known
+exceptions inside the `try` -- is confirmed. The handlers only ever caught
+programming errors, and disguised them.
+
+**What is now the open degenerate-iterate item.** The pre-check fallback
+itself returns the continuity residual with `jac = {}` -- 145 times per
+scorecard, on legitimate transient iterates. It works (the solves converge),
+but an empty Jacobian for a live element is the same shape of thing at a
+smaller scale, and it sits next to the `FlowRatio = 0 -> K = -1` edge from
+step 1.4 and the `N > 3` rejection. Those three are the remainder of step 2.
 
 ## 8. The port, sequenced by provenance
 


### PR DESCRIPTION
#271 **step 2.1** -- checklist items #7 (baseline reproduces), #8 (measure, don't assume), #9 (falsify each new test once).

## The audit you asked for

Every `except` in the junction model, adapters and Jacobian helper:

| location | catches | consequence | verdict |
|---|---|---|---|
| `mpce_v2_element.py` residual | `Exception` | lossless residual + **empty Jacobian** | **narrowed -> raises** |
| `mpce_v2_element.py` FD loop | `Exception` | `continue` -> zero Jacobian column | **narrowed -> raises** |
| `mpce_v2_element.py` diagnostics | `Exception` | K fields silently dropped | **narrowed -> annotates** |
| `_mpce_v2_jacobian.py:118` | `(ZeroDivisionError, FloatingPointError)` | one zero entry | narrow in type, wide in effect -- filed with the remainder |
| `_network_builder.py:343/374` | `Exception` / `KeyError` | `converged=False` **with the message** | correct pattern -- untouched |
| `_mynard2010.py`, `components.py` junction classes, v1 adapter | -- | -- | none |

## Measured before touching

All three `except`s plus the pre-check guard instrumented; full scorecard (2073 records, 3 sources x 3 topologies) and whole suite run:

| path | hits |
|---|---|
| residual / FD / diagnostics `except` | **0 / 0 / 0** |
| pre-check fallback (`if not sup_mask.any() or not col_mask.any()`) | 145 (scorecard), 1 (suite) |

The pre-check runs *before* the `try` and routes every degenerate split to the continuity fallback, so the closure cannot raise its two known exceptions inside it. **The handlers only ever caught programming errors** -- and step 1.2 showed what they do with one: 19 `KeyError`s on an empty Jacobian instead of the real `AttributeError`.

## Fix

Per #262's rule -- a fallback that can fabricate physics becomes a loud, named failure:

- residual and FD paths: `except (IndexError, ValueError)` re-raised as a `RuntimeError` naming the element, port mass flows and masks, cause chained;
- diagnostics: same narrowing, `diag["closure_error"]` set instead of K silently missing;
- everything else propagates untouched.

## Verified

- New tests inject errors by monkeypatching the closure, so they do not depend on finding a real degenerate state. **8 of 9 red against the pre-fix element** (the 9th pins the pre-check path, which was never in the `except` -- correct); 9/9 green after.
- Full suite **2021 passed**.
- Scorecard reproduces step 0 **to the digit** -- as it must, since the removed path was never taken on a legitimate state.

## What this scopes for the rest of step 2

The pre-check fallback itself returns `jac = {}` on **145 legitimate transient iterates** per scorecard. It works, but it is the same shape at smaller scale, and it sits with the `FlowRatio = 0 -> K = -1` edge (1.4) and the `N > 3` rejection: three faces of one degenerate-iterate question.

CHANGELOG under Fixed (a swallowed exception now raises; `diagnostics` gains `closure_error`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RNDxZouiHoJdaLpnnPjHq
