### PR TITLE
fix(junction): give degenerate iterates a Jacobian, classify dead ports consistently, refuse N>3 (#271 step 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -239,6 +239,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.4.2] - 2026-07-09
 
 ### Fixed
+- **`MPCEv2Element` degenerate iterates now carry a Jacobian, dead ports are
+  classified consistently, and junctions with more than three ports are
+  refused (issue #271).** Measured on the scorecard before changing anything:
+  the pre-check fallback for an all-same-sign iterate returned a lossless
+  residual with an *empty* Jacobian on 145 iterates from 26 solves, and none
+  of those 26 converged; a port at exactly zero flow (typically an initial
+  guess) was excluded from the element's supplier/collector masks but
+  classified as a supplier by the Mynard closure, so its `K` came back
+  mis-shaped and was silently zeroed -- a lossless junction at initialization,
+  384 times per scorecard. Now: an all-ports-zero iterate returns the
+  continuity residual *with* its Jacobian; an all-same-sign iterate is
+  treated as the wrong-direction state it is and reaches the strict raise or
+  the soft barrier, both of which pull the offending port back with a real
+  derivative; an excluded port is snapped to a tiny flow in its declared
+  direction before the closure sees it, so both classifications agree by
+  construction and the dead-branch limit `K -> 1` applies. `MPCEv2Element`
+  (and `ConstantKTeeElement`) raise `ValueError` at construction for more than
+  three ports, since Mynard's `K` conversion is defined for three branches
+  only and a 4-port junction returned finite residuals with an all-zero loss
+  Jacobian. **Converged results are unchanged** -- the scorecard reproduces
+  the previous tables to the digit and the 26 doomed solves remain unconverged
+  (the empty Jacobian was wrong but was not what killed them).
 - **`MPCEv2Element` no longer turns an exception inside the Mynard closure
   into a silent lossless junction (issue #271).** Three call sites wrapped
   `junction_loss_coefficient` in `except Exception`; the residual site

--- a/docs/archive/JUNCTION_JACOBIAN_271.md
+++ b/docs/archive/JUNCTION_JACOBIAN_271.md
@@ -118,17 +118,31 @@ formulation cannot rot the way a hard-coded expected value can.
 | converged | 184 / 315 | 368 / 435 |
 | median wall time | 5.2 ms | 7.8 ms |
 
-**The FD regime is the better-behaved one.** Joining is more accurate and
-converges more often than separating, and pays for it in wall time. The case
-for porting is architectural homogeneity and the CLAUDE.md `(f, J)` rule, not a
-convergence rescue -- anyone starting the port expecting robustness gains
-should recalibrate first.
+**Correction (2026-09-05): the convergence row above was measured with the
+validation adapter at `strict=True`, across all three topologies.** Production
+builds the element with `strict=False`, which steers transient wrong-sign
+iterates through the soft barrier instead of raising, and enables the
+post-solve direction verifier. Re-measured: all-topology 1578/2073 at
+`strict=True` vs 1711/2073 at `strict=False`, with `imposed_q` identical
+(602/691) and the whole difference in the pressure-driven topologies. The
+MAE/bias rows stand (they are `imposed_q`); the convergence comparison
+between regimes, and the earlier "v2 converges far less than v1" reading,
+were strict-mode artefacts and are withdrawn. Separately, Bassett Fig 7b
+`mfb_two_pb` q=0.8 converges to a mirror root (K 3.44 vs 2.77) and is reported
+as a success under **both** settings: the port signs are correct, so the
+direction-only verifier cannot see it. The adapter now defaults to
+`strict=False`; the uncaught mirror root is a pinned target.
+
+**What survives:** the case for porting is architectural homogeneity and the
+CLAUDE.md `(f, J)` rule, not a convergence rescue. Joining runs its Jacobian
+on finite differences and pays for it in wall time.
 
 ## Dead end
 
 The Jacobian fix was expected to improve convergence. It does not: roots are
-unchanged to three decimals and convergence moves 187 -> 184 of 315, which is
-noise on near-threshold cases. The missing entry is small next to the row
+unchanged to three decimals and convergence moves 187 -> 184 of 315 (all
+topologies, `strict=True` -- see the correction above), which is noise on
+near-threshold cases. The missing entry is small next to the row
 scale. Correctness before the port is the whole of the value, and saying so is
 better than implying a performance win that the numbers do not support.
 

--- a/python/combaero/network/mpce_v2_element.py
+++ b/python/combaero/network/mpce_v2_element.py
@@ -172,6 +172,17 @@ class MPCEv2Element(MultiPortChamberElement):
         # Measurement switch on Mynard's eta (MYNARD_ETA_A0/A1); 1.0 = faithful
         # port. Exposed so the term can be scored on and off (#271 step 1.3).
         self.eta_scale: float = float(eta_scale)
+        # Mynard's K conversion (Eq 18) is defined for three branches only
+        # (the reference code computes K for n <= 3). A larger junction used
+        # to return finite residuals with an entirely zero loss-term Jacobian
+        # -- silently (issue #271). Refuse at construction; the native C-form
+        # residual is the route to N > 3 (design doc sec 8 step 3b).
+        if self.N > 3:
+            raise ValueError(
+                f"MPCEv2Element '{id}': {self.N} ports, but the Mynard K closure is "
+                f"defined for 3-branch junctions only. Split the junction, or use "
+                f"MultiPortChamberElement."
+            )
 
     def verify_solution_consistent(
         self,
@@ -390,11 +401,18 @@ class MPCEv2Element(MultiPortChamberElement):
         # residual: Pt_i = Pt_jct, mass conservation.
         sup_mask = U_mynard > 1e-9
         col_mask = U_mynard < -1e-9
-        if not sup_mask.any() or not col_mask.any():
-            residuals = [float(s.Pt) - Pt_jct for s in states]
-            residuals.append(sum(port_mdots))
-            jac: dict[int, dict[str, float]] = {}
-            return residuals, jac
+        if not sup_mask.any() and not col_mask.any():
+            # Every port ~zero: a cold-start iterate. The soft barrier at zero
+            # slack IS the continuity residual -- with its Jacobian. This used
+            # to return jac = {}: N+1 zero rows, and every solve that reached
+            # it stalled (26 of 26 on the scorecard, issue #271).
+            return self._soft_barrier_residual(states, Pt_jct, port_mdots)
+        # Every port flowing the same way is not handled here: it violates
+        # mass conservation and is a wrong-direction state for at least one
+        # port, which the check below routes to the strict raise or the soft
+        # barrier -- both of which carry a Jacobian that pulls the offending
+        # port back toward zero. Returning a lossless residual without one
+        # was where those solves went to die.
 
         # Constrained topology: refuse if observed direction does not match
         # the declared one. Per-port check: port_mdots[i] should have the
@@ -426,6 +444,24 @@ class MPCEv2Element(MultiPortChamberElement):
             # ``soft_penalty_alpha``. Pulls Newton back toward the boundary
             # mdot=0 from which a sign flip can restore the declared regime.
             return self._soft_barrier_residual(states, Pt_jct, port_mdots)
+
+        # A port excluded from both masks (|U| <= 1e-9, typically an exact
+        # zero in an initial guess) must not be left for the closure to
+        # classify on its own: Mynard puts Q = -0.0 with the suppliers, the two
+        # classifications disagree, K comes back mis-shaped and was silently
+        # zeroed -- a lossless junction 384 times per scorecard (issue #271).
+        # Snap it to a tiny flow in its DECLARED direction and rebuild the
+        # masks from the snapped values, so both sides agree by construction
+        # and the FlowRatio -> 0 limit (K -> 1 for a dead outlet, step 1.4)
+        # takes over.
+        excluded = ~(sup_mask | col_mask)
+        if excluded.any():
+            U_mynard = U_mynard.copy()
+            for i in np.where(excluded)[0]:
+                # _port_signs: -1 = inlet (Mynard supplier, U > 0), +1 = outlet.
+                U_mynard[i] = -float(self._port_signs[i]) * 1e-9
+            sup_mask = U_mynard > 0.0
+            col_mask = U_mynard < 0.0
 
         try:
             mynard = junction_loss_coefficient(

--- a/python/tests/test_bassett_fig7b_case.py
+++ b/python/tests/test_bassett_fig7b_case.py
@@ -1,0 +1,113 @@
+"""Bassett 2001 Fig 7b -- his own measured case -- through the network solver.
+
+theta = 45 deg, psi = 3 (lateral one third of the main area), separating
+flow. Bassett measured this curve (Fig 7b); the K6 formula (Eq 27) fits it.
+Every point on it sits at M ~ 0.03, deep inside the incompressible regime the
+closure assumes -- so a failure here is numerical, not a physics-envelope
+limit, and a case the literature documents is the highest-priority thing to
+keep passing (issue #271).
+
+Measured 2026-09-05 with the production-faithful adapter (strict=False):
+
+    topology     q=0.2      q=0.4      q=0.6      q=0.8
+    imposed_q    ok         ok         ok         ok
+    three_pb     FAIL       ok 0.444   ok 1.246   ok 2.765     (K6: 0.444 1.247 2.769)
+    mfb_two_pb   FAIL       FAIL       ok 1.403   WRONG ROOT: converged, K 3.44 vs 2.77
+
+Under strict=True the three_pb q=0.4/0.6 cases raised on a transient
+wrong-sign iterate. mfb_two_pb q=0.8 converges -- under BOTH strict settings,
+run cold -- to a mirror root 24% off Bassett, reported as a success: the port
+signs are right, so the direction-only verifier cannot see it. The tests
+below pin what passes as passing, and what does not as strict xfails --
+targets, not tolerated failures.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from validation.junction.models import bassett2001
+from validation.junction.models.mpce_v2_network import MPCEv2Network
+
+_THETA = math.radians(45.0)
+_PSI = 3.0
+
+
+@pytest.fixture
+def model():
+    # Fresh per test: the same case has been seen to land differently after
+    # other solves on one instance, and a target must be measured cold.
+    return MPCEv2Network(strict=False)
+
+
+def _run(model, topology: str, q: float):
+    return model.evaluate_network("bassett2001", "K6", q, _PSI, _THETA, topology=topology)
+
+
+@pytest.mark.parametrize("q", [0.2, 0.4, 0.6, 0.8])
+def test_imposed_q_converges_across_the_curve(model, q):
+    r = _run(model, "imposed_q", q)
+    assert r.converged, r.message
+
+
+@pytest.mark.parametrize("q", [0.4, 0.6, 0.8])
+def test_three_pb_converges_and_lands_on_bassett_K6(model, q):
+    """The case that raised under strict=True. With the soft barrier steering
+    the reversed first iterate back, it converges to Bassett's own curve."""
+    r = _run(model, "three_pb", q)
+
+    assert r.converged, r.message
+    assert r.K_lateral == pytest.approx(bassett2001.K6(q, _PSI, _THETA), abs=0.05)
+
+
+@pytest.mark.xfail(
+    strict=False,
+    reason=(
+        "mfb_two_pb q=0.8 is NOT reliably solved, and the outcome depends on the "
+        "process: run cold in one process it converges to K_lat 3.44 against "
+        "Bassett's 2.77 and is reported as a success (the port signs are correct, "
+        "so the direction-only verifier cannot see the mirror root); under the "
+        "parallel suite the same case fails or is demoted instead. Both outcomes "
+        "are wrong, in different ways, so a strict marker would flap. This is the "
+        "one deliberately non-strict xfail in the junction tests, and the "
+        "non-determinism is itself a recorded defect (issue #271). It comes off "
+        "when the case converges to Bassett's curve every time."
+    ),
+)
+def test_mfb_two_pb_mirror_root_is_caught(model):
+    r = _run(model, "mfb_two_pb", 0.8)
+
+    assert (not r.converged) or r.K_lateral == pytest.approx(
+        bassett2001.K6(0.8, _PSI, _THETA), abs=0.15
+    ), (
+        f"reported converged at K_lat={r.K_lateral:.3f} vs Bassett {bassett2001.K6(0.8, _PSI, _THETA):.3f}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Targets: a documented case must not stay failing quietly
+# ---------------------------------------------------------------------------
+
+_TARGET = (
+    "Bassett Fig 7b at a low lateral fraction does not converge through the "
+    "pressure-driven topologies: 'iteration is not making good progress'. "
+    "It sits inside the paper's measured conditions (M ~ 0.03), so this is a "
+    "solver-path failure, not physics. Priority target for the step-3 port "
+    "and the degenerate-iterate work (issue #271). strict=True so the moment "
+    "it starts passing, this marker must come off."
+)
+
+
+@pytest.mark.xfail(strict=True, reason=_TARGET)
+def test_three_pb_low_lateral_fraction_converges(model):
+    r = _run(model, "three_pb", 0.2)
+    assert r.converged, r.message
+
+
+@pytest.mark.xfail(strict=True, reason=_TARGET)
+@pytest.mark.parametrize("q", [0.2, 0.4])
+def test_mfb_two_pb_low_lateral_fraction_converges(model, q):
+    r = _run(model, "mfb_two_pb", q)
+    assert r.converged, r.message

--- a/python/tests/test_junction_damping_band.py
+++ b/python/tests/test_junction_damping_band.py
@@ -104,11 +104,14 @@ def test_damping_is_what_bounds_C_and_nothing_else(damping):
 
 
 def test_exact_zero_flow_edge_is_not_guarded_by_damping(damping):
-    """Documented edge: at FlowRatio exactly 0, K_lat = -1 either way.
+    """Documented edge of the RAW closure: at FlowRatio exactly 0, K_lat = -1.
 
-    A sign-flipped dead branch. Pinned so that whoever fixes it as part of
-    the degenerate-iterate work (#271 step 2) sees this test fail and removes
-    it rather than discovering the edge again.
+    Not a loss at all -- Mynard classifies Q = -0.0 as a supplier, the K
+    broadcast pairs the live collector with a zero-flow supplier, and the
+    spurious entry evaluates to -1. MPCEv2Element no longer lets an exact
+    zero reach the closure (it snaps an excluded port into its declared
+    direction, #271 step 2), so this is a property of the raw closure only.
+    Pinned so a future closure change that alters it is noticed.
     """
     with np.errstate(all="ignore"):
         damping(0.02)

--- a/python/tests/test_mpce_v2_closure_errors.py
+++ b/python/tests/test_mpce_v2_closure_errors.py
@@ -163,10 +163,12 @@ def test_diagnostics_let_programming_errors_through(monkeypatch):
 
 
 def test_degenerate_split_is_handled_before_the_closure_is_called(monkeypatch):
-    """All ports flowing the same way is caught by the guard ahead of the try.
+    """All ports flowing the same way is caught ahead of the closure call.
 
-    It must reach the continuity fallback and never call the closure -- the
-    closure stand-in raising here would prove the guard was bypassed.
+    It is a wrong-direction state for at least one port, so it must reach the
+    soft barrier -- with a Jacobian (issue #271 step 2) -- and never call the
+    closure; the closure stand-in raising here would prove the guard was
+    bypassed. It once returned a lossless residual with jac = {}.
     """
     monkeypatch.setattr(
         v2, "junction_loss_coefficient", _raising(IndexError("should not be called"))
@@ -175,4 +177,4 @@ def test_degenerate_split_is_handled_before_the_closure_is_called(monkeypatch):
     residuals, jac = _element().residuals(_states(), 100_300.0, [-0.1, -0.05, -0.05])
 
     assert len(residuals) == 4
-    assert jac == {}
+    assert all(i in jac for i in range(4)), "the fallback must carry its Jacobian"

--- a/python/tests/test_mpce_v2_degenerate_iterates.py
+++ b/python/tests/test_mpce_v2_degenerate_iterates.py
@@ -1,0 +1,186 @@
+"""Degenerate iterates in MPCEv2Element: what the solver is handed.
+
+Three faces of one question, measured on the scorecard before any of this was
+written (issue #271, step 2):
+
+* the pre-check fallback returned a lossless residual with an EMPTY Jacobian
+  on 145 iterates from 26 solves -- and 0 of those 26 converged;
+* a port at exactly zero flow was excluded from MPCEv2's masks but classified
+  as a supplier by Mynard, so K came back mis-shaped and was silently zeroed
+  -- 384 times per scorecard, a lossless junction at initialization;
+* a 4-port junction returned finite residuals with an all-zero loss Jacobian.
+
+These tests pin the replacements. Ground truth is what a Newton solver needs
+-- a residual with the Jacobian that belongs to it -- and, for the dead-port
+case, the FlowRatio -> 0 limit proven in step 1.4.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import combaero as cb
+from combaero.network import mpce_v2_element as v2
+from combaero.network.components import NetworkMixtureState
+from combaero.network.mpce_v2_element import ConstantKTeeElement, MPCEv2Element
+
+_Y = list(cb.mole_to_mass(cb.species.dry_air()))
+
+
+def _element(flow_direction: str = "branch", strict: bool = False) -> MPCEv2Element:
+    element = MPCEv2Element.__new__(MPCEv2Element)
+    element.id = "jct"
+    element.N = 3
+    element.port_nodes = ["p0", "p1", "p2"]
+    element.port_areas = [0.01, 0.01, 0.01]
+    element.port_angles_deg = [180.0, 0.0, 90.0]
+    element.flow_direction = flow_direction
+    element._port_signs = [-1.0, 1.0, 1.0] if flow_direction == "branch" else [-1.0, -1.0, 1.0]
+    element._port_element_ids = ["e0", "e1", "e2"]
+    element.strict = strict
+    element.joining_etransfer_alpha = 0.2
+    element.jacobian_method = "sympy"
+    element.penalty_alpha = 0.0
+    element.eta_scale = 1.0
+    return element
+
+
+def _states(pt=(100_300.0, 100_100.0, 100_050.0)):
+    return [
+        NetworkMixtureState(P=1.0e5, Pt=pt[i], T=300.0, Tt=300.5, m_dot=0.0, Y=_Y) for i in range(3)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# (a) the pre-check fallback: never an empty Jacobian
+# ---------------------------------------------------------------------------
+
+
+def test_cold_start_all_zero_iterate_gets_continuity_with_its_jacobian():
+    """Every port ~zero is a cold start; the continuity residual is right,
+    but it has a Jacobian and the solver must receive it."""
+    residuals, jac = _element().residuals(_states(), 100_300.0, [0.0, 0.0, 0.0])
+
+    assert len(residuals) == 4
+    for i in range(3):
+        assert jac[i][f"p{i}.Pt"] == 1.0
+        assert jac[i]["jct.P_jct"] == -1.0
+    assert jac[3] == {"e0.m_dot": -1.0, "e1.m_dot": 1.0, "e2.m_dot": 1.0}
+
+
+@pytest.mark.parametrize(
+    "label, mdots",
+    [
+        ("every port flowing out", [0.0021, 0.0011, 0.0048]),
+        ("every port flowing in", [-0.05, -0.02, -0.03]),
+    ],
+)
+def test_same_sign_iterate_is_a_wrong_direction_state_with_a_jacobian(label, mdots):
+    """All ports flowing the same way violates mass conservation and is a
+    wrong-direction state for at least one port. It must reach the soft
+    barrier -- which carries the derivative that pulls the offending port back
+    toward zero -- not a lossless residual with nothing for Newton to use."""
+    residuals, jac = _element().residuals(_states(), 100_300.0, mdots)
+
+    assert len(residuals) == 4
+    assert all(i in jac for i in range(4)), f"{label}: rows missing from the Jacobian"
+    penalised = [i for i in range(3) if any(k.endswith(".m_dot") for k in jac[i])]
+    assert penalised, f"{label}: no port is being pulled back -- this is the old lossless fallback"
+
+
+def test_same_sign_iterate_raises_when_strict():
+    """Under strict=True a wrong-direction state raises, as it always did for
+    a single wrong port; the all-same-sign case is no longer exempt."""
+    with pytest.raises(ValueError, match="wrong flow direction"):
+        _element(strict=True).residuals(_states(), 100_300.0, [0.0021, 0.0011, 0.0048])
+
+
+# ---------------------------------------------------------------------------
+# (b) a port at exactly zero: both classifications must agree
+# ---------------------------------------------------------------------------
+
+
+def test_exact_zero_outlet_is_classified_as_a_dead_collector(monkeypatch):
+    """[-0.1, -0.0, 0.125]: the straight outlet at -0.0 (an initial guess).
+
+    Mynard's `Q < 0` puts -0.0 with the suppliers; MPCEv2 excluded it. The
+    closure must now be handed a tiny flow in the port's DECLARED direction,
+    so it sees one supplier and two collectors.
+    """
+    seen = {}
+    real = v2.junction_loss_coefficient
+
+    def spy(U, *args, **kwargs):
+        seen["U"] = np.array(U, dtype=float)
+        return real(U, *args, **kwargs)
+
+    monkeypatch.setattr(v2, "junction_loss_coefficient", spy)
+    _element().residuals(_states(), 100_300.0, [-0.1, -0.0, 0.125])
+
+    U = seen["U"]
+    assert U[1] < 0.0, "the dead outlet must reach the closure as a collector"
+    assert (U > 0).sum() == 1 and (U < 0).sum() == 2
+
+
+def test_exact_zero_outlet_carries_the_dead_branch_loss():
+    """FlowRatio -> 0 gives K -> 1 for a dead outlet (step 1.4). Its residual
+    row must therefore carry a loss term; it used to be pure continuity."""
+    states = _states()
+    residuals, _ = _element().residuals(states, 100_300.0, [-0.1, -0.0, 0.125])
+
+    pure_continuity = states[1].Pt - 100_300.0
+    assert residuals[1] != pytest.approx(pure_continuity), (
+        "row 1 is bare continuity: K for the dead outlet is still being zeroed"
+    )
+
+
+def test_exact_zero_inlet_in_a_merge_is_a_dead_supplier(monkeypatch):
+    seen = {}
+    real = v2.junction_loss_coefficient
+
+    def spy(U, *args, **kwargs):
+        seen["U"] = np.array(U, dtype=float)
+        return real(U, *args, **kwargs)
+
+    monkeypatch.setattr(v2, "junction_loss_coefficient", spy)
+    _element("merge").residuals(_states(), 100_300.0, [-0.1, 0.0, 0.1])
+
+    assert seen["U"][1] > 0.0, "a dead inlet must reach the closure as a supplier"
+
+
+# ---------------------------------------------------------------------------
+# (c) N > 3 is rejected where it can be seen
+# ---------------------------------------------------------------------------
+
+
+def _four_port(cls):
+    return cls(
+        id="jct",
+        inlet_nodes=["a"],
+        outlet_nodes=["b", "c", "d"],
+        inlet_angles_deg=[0.0],
+        outlet_angles_deg=[0.0, 90.0, 45.0],
+        port_areas=[0.01] * 4,
+    )
+
+
+@pytest.mark.parametrize("cls", [MPCEv2Element, ConstantKTeeElement])
+def test_four_port_junction_is_rejected_at_construction(cls):
+    """Mynard's K conversion is defined for three branches only. A 4-port
+    junction used to return finite residuals with an all-zero loss Jacobian,
+    silently. It is now refused with a message that says why."""
+    with pytest.raises(ValueError, match="3-branch"):
+        _four_port(cls)
+
+
+def test_three_port_junction_is_still_accepted():
+    element = MPCEv2Element(
+        id="jct",
+        inlet_nodes=["a"],
+        outlet_nodes=["b", "c"],
+        inlet_angles_deg=[0.0],
+        outlet_angles_deg=[0.0, 90.0],
+        port_areas=[0.01] * 3,
+    )
+    assert element.N == 3

--- a/python/tests/test_mpce_v2_fd_fallback_guards.py
+++ b/python/tests/test_mpce_v2_fd_fallback_guards.py
@@ -25,8 +25,6 @@ import pytest
 
 import combaero as cb
 from combaero.network._mynard2010 import junction_loss_coefficient
-from combaero.network.components import NetworkMixtureState
-from combaero.network.mpce_v2_element import MPCEv2Element
 
 _Y = list(cb.mole_to_mass(cb.species.dry_air()))
 _A3 = np.array([0.01, 0.01, 0.01])
@@ -106,69 +104,8 @@ def test_perturbing_a_near_zero_port_flips_its_velocity_sign():
     )
 
 
-# ---------------------------------------------------------------------------
-# The consequence, pinned as a known defect so a fix surfaces
-# ---------------------------------------------------------------------------
-
-
-def _four_port_element() -> MPCEv2Element:
-    element = MPCEv2Element.__new__(MPCEv2Element)
-    element.id = "jct"
-    element.N = 4
-    element.port_nodes = [f"p{i}" for i in range(4)]
-    element.port_areas = [0.01] * 4
-    element.port_angles_deg = [180.0, 0.0, 90.0, 45.0]
-    element._port_signs = [-1.0, 1.0, 1.0, 1.0]
-    element._port_element_ids = [f"e{i}" for i in range(4)]
-    element.flow_direction = "branch"
-    element.strict = False
-    element.joining_etransfer_alpha = 0.2
-    element.jacobian_method = "sympy"
-    element.penalty_alpha = 0.0
-    element.eta_scale = 1.0  # faithful-port default; see test_junction_tuned_constants
-    return element
-
-
-def _four_port_states():
-    return [
-        NetworkMixtureState(P=1.0e5, Pt=100_300.0, T=300.0, Tt=300.5, m_dot=0.0, Y=_Y)
-        for _ in range(4)
-    ]
-
-
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Known defect (issue #271): MPCEv2Element does not restrict N, and "
-        "Mynard supplies no K beyond 3 ports, so every FD column is skipped "
-        "and the whole dKQ block is silently zero. Either the element must "
-        "reject N > 3 at construction -- honest, the closure is 3-branch by "
-        "derivation -- or the closure must be extended. Returning a zero "
-        "Jacobian with finite residuals is not a third option. Remove this "
-        "xfail with whichever fix lands."
-    ),
-)
-def test_four_port_junction_has_a_nonzero_loss_jacobian():
-    element = _four_port_element()
-
-    _, jac = element.residuals(_four_port_states(), 100_300.0, [-0.12, 0.05, 0.04, 0.03])
-
-    mdot_entries = sum(1 for row in range(4) for key in jac[row] if key.endswith(".m_dot"))
-    assert mdot_entries > 0, (
-        "the entire dKQ block is zero: every mass-flow derivative of the loss "
-        "term is missing, with no error and no warning"
-    )
-
-
-def test_four_port_junction_still_returns_finite_residuals():
-    """Why the defect above is silent rather than loud: nothing looks wrong.
-
-    The residuals are perfectly well-formed; only the Jacobian is empty, so a
-    solver has no signal that anything is amiss.
-    """
-    element = _four_port_element()
-
-    residuals, _ = element.residuals(_four_port_states(), 100_300.0, [-0.12, 0.05, 0.04, 0.03])
-
-    assert len(residuals) == 5  # 4 impulse rows + mass row
-    assert all(math.isfinite(r) for r in residuals)
+# The N > 3 consequence (a silently all-zero loss Jacobian) is no longer
+# reachable: MPCEv2Element refuses more than three ports at construction, and
+# that refusal is pinned in test_mpce_v2_degenerate_iterates.py. The closure-
+# level precondition above (K is None beyond three ports) is what makes the
+# refusal necessary and stays.

--- a/validation/junction/MPCE_CPP_PORT_DESIGN.md
+++ b/validation/junction/MPCE_CPP_PORT_DESIGN.md
@@ -347,7 +347,7 @@ Consequences:
 
 | # | defect | evidence | fix | cost |
 |---|---|---|---|---|
-| 1 | `N > 3` returns finite residuals with an all-zero `dKQ` block | pinned by strict xfail in `test_mpce_v2_fd_fallback_guards.py` | reject `N > 3` at construction with a message naming the Mynard 3-branch K limit; the C-form is the eventual lift | 1 line + test |
+| 1 | ~~`N > 3` returns finite residuals with an all-zero `dKQ` block~~ | **fixed, step 2.** `MPCEv2Element.__init__` raises for N > 3 naming the Mynard 3-branch limit; ConstantKTee inherits it. The strict xfail is retired (the state is unconstructible); the closure-level precondition test stays | done |
 | 2 | ~~Residual-level silent physics switch: `mpce_v2_element.py` catches *any* exception from Mynard and returns a **lossless** continuity residual with an **empty** Jacobian `{}`~~ | **fixed, step 2.1.** Measured first: 0 hits across 2073 scorecard records + the full suite (the pre-check guard ahead of the call fired 145 times -- that is the legitimate degenerate path). All three wide `except`s (residual, FD loop, diagnostics) narrowed to `(IndexError, ValueError)`; residual and FD paths raise a named `RuntimeError` with the cause chained, diagnostics annotates `closure_error`. Falsified 8/9 against pre-fix; scorecard identical to the digit | done |
 | 3 | Hager and Idelchik unscored | sec 6 | extend `MPCEv2Network.evaluate_network` to `hager1984` (separating, `q -> 1 - q`) and `idelchik1966` (joining, `q` = Bassett's) | small; data + `q_transform` exist |
 | 4 | `alpha = 0.2` calibrated pre-#212 | memory + `tmp/calibrate_etransfer_join.py` | re-run the calibration on current plumbing **after** #3 lands, so its validation is in-network; if it no longer earns its place, set the default to 0 | script exists |
@@ -383,6 +383,50 @@ scorecard, on legitimate transient iterates. It works (the solves converge),
 but an empty Jacobian for a live element is the same shape of thing at a
 smaller scale, and it sits next to the `FlowRatio = 0 -> K = -1` edge from
 step 1.4 and the `N > 3` rejection. Those three are the remainder of step 2.
+
+## 7b. Step 2 result: the degenerate-iterate question (2026-09-05)
+
+Measured on the full scorecard (2073 solves) before changing anything.
+
+**(a) The pre-check fallback was where solves went to die.** Its 145 hits
+came from **26 solves, median 5 hits each, 0 of 26 converged**. It returned
+the continuity residual with `jac = {}` -- so even the trivial Jacobian it
+owns (+-1 on the `Pt` rows, the port signs on the mass row) was withheld,
+handing the solver N+1 zero rows. The iterates were all-same-sign with real
+magnitude (e.g. `[0.0021, 0.0011, 0.0048]`, every port flowing out), which
+violates mass conservation and is a wrong-direction state for at least one
+port -- exactly what the existing soft barrier handles, except the pre-check
+returned first. **Fix:** the all-ports-zero case (a cold start; never seen on
+the scorecard) returns the soft barrier at zero slack, which *is* the
+continuity residual with its Jacobian; the same-sign case now falls through
+to the wrong-direction check. No new code path.
+
+**(b) The mask mismatch was the more frequent silent lossless junction.**
+384 hits. Example `[-0.1, -0.0, 0.125]`: MPCEv2 excludes the `-0.0` port
+(`|U| <= 1e-9`), Mynard's `Q < 0` classifies it as a supplier, the two
+disagree, `K` comes back mis-shaped, the shape guard trips, and `K_per_port`
+stays all-zero. At what looks like initialization. **Fix:** an excluded port
+is snapped to a tiny flow in its *declared* direction and the masks are
+rebuilt from the snapped values, so the classifications agree by
+construction and the `FlowRatio -> 0` limit proven in step 1.4 applies
+(`K -> 1` for a dead outlet). After the fix the shape guard trips **0**
+times on the scorecard.
+
+**(c) N > 3** is refused at construction. Nothing outside the strict xfail
+ever constructed one.
+
+**Verified.** 9 of 10 new tests red against the pre-fix element (the 10th
+pins "three ports still accepted"); full suite green; the scorecard
+**identical to the digit** -- 1578/2073 converged, every imposed_q cell
+unchanged. That last number is the honest part: the 26 doomed solves are
+still doomed. The empty Jacobian was wrong, but it was not what killed them
+-- they are the true q-endpoint / artifact-root cases. What the fix buys is
+correctness of what the solver is handed on every iterate, which the port
+must preserve; it does not buy convergence here.
+
+**Dead end recorded:** re-instrumenting the element for the after-measurement
+and then reverting with `git checkout` reverted the fix as well. Commit
+first, then instrument.
 
 ## 8. The port, sequenced by provenance
 

--- a/validation/junction/MPCE_CPP_PORT_DESIGN.md
+++ b/validation/junction/MPCE_CPP_PORT_DESIGN.md
@@ -273,6 +273,54 @@ without damping -- a sign-flipped dead branch the knob never guarded. Pinned
 by test so the degenerate-iterate work (step 2) removes the test when it
 fixes the edge, rather than rediscovering it.
 
+## 4d. The strict-mode artefact, and Bassett's own case (2026-09-05)
+
+Found while characterising one of the solves the step-2 fallback could not
+rescue. The validation adapter defaulted to `strict=True`; production
+(`gui/backend/graph_builder.py`) builds `MPCEv2Element` with `strict=False`.
+`strict=True` raises on any transient wrong-sign Newton iterate instead of
+steering it back through the soft barrier, **and** disables the post-solve
+direction verifier. Measured on the full scorecard:
+
+| topology | strict=True | strict=False |
+|---|---|---|
+| imposed_q | 602 / 691 | 602 / 691 |
+| mfb_two_pb | 587 | **629** |
+| three_pb | 389 | **480** |
+| all | 1578 | **1711** |
+
+- The `imposed_q` gate tables (sec 4b, 4c) are unaffected and stand.
+- Every all-topology convergence comparison made earlier was a strict-mode
+  artefact, including "v2 converges far less than v1" -- v1 has no strict
+  raise. Withdrawn; the provenance record is corrected.
+- **Both modes report a false success** on Bassett Fig 7b `mfb_two_pb`
+  q=0.8: run cold it converges to K_lat 3.44 against 2.77 -- a mirror root
+  with the *correct port signs*, so the direction-only verifier cannot see
+  it. (An earlier run on a reused adapter instance happened to demote it;
+  measured cold, it is reported as converged every time.) A wrong root
+  reported as a success is the worst outcome the harness can produce. The v1
+  base has an energy-consistency check (#229); MPCEv2 has none. Pinned as a
+  strict xfail target.
+- **And it is not even deterministic.** The same `mfb_two_pb` q=0.8 case
+  converges to the mirror root in a cold single-process run and fails or is
+  demoted under the parallel test suite. A strict xfail on it flapped in CI.
+  It carries the junction tests' one deliberately non-strict xfail, with the
+  non-determinism stated as the reason; process-dependent outcomes in a
+  validation harness are a defect in their own right (step 3 must not
+  inherit them).
+- The adapter now defaults to `strict=False`. Never compare v1 and v2
+  convergence without matching it.
+
+**Bassett's own Fig 7b case** (theta=45, psi=3, M ~ 0.03 -- inside his
+measured conditions) converges in `three_pb` at q=0.4/0.6/0.8 onto his curve
+(K_lat 0.444/1.246/2.765 vs 0.444/1.247/2.769) once the soft barrier is
+allowed to steer the reversed first iterate. The low-lateral-fraction points
+(q=0.2 `three_pb`; q=0.2/0.4 `mfb_two_pb`) still fail with "not making good
+progress" -- a solver-path failure inside documented conditions, which is
+the highest-priority kind. They are pinned as strict xfail **targets** in
+`python/tests/test_bassett_fig7b_case.py`, alongside the passing points, so
+the moment one starts passing it is noticed.
+
 ## 5. What the papers settle about the K_straight question (#272)
 
 Three independent sources say **negative `K_straight` in dividing flow is real

--- a/validation/junction/models/mpce_v2_network.py
+++ b/validation/junction/models/mpce_v2_network.py
@@ -39,11 +39,24 @@ class MPCEv2Network:
 
     def __init__(
         self,
-        strict: bool = True,
+        strict: bool = False,
         joining_etransfer_alpha: float | None = None,
         eta_scale: float = 1.0,
     ) -> None:
-        """``strict=False`` enables the soft-barrier fallback on the underlying
+        """Defaults to ``strict=False``, which is how production builds the
+        element (``gui/backend/graph_builder.py``). ``strict=True`` raises on
+        any transient wrong-sign Newton iterate instead of steering it back
+        through the soft barrier, and it disables the post-solve direction
+        verifier -- so it both fails solves production would finish AND
+        reports artifact roots as converged. Measured on the full scorecard
+        (issue #271): strict=True 1578/2073, strict=False 1711/2073, with
+        imposed_q identical (602/691) and the difference entirely in the
+        pressure-driven topologies. Note the verifier is direction-only:
+        Bassett Fig 7b mfb_two_pb q=0.8 converges to a mirror root with the
+        right port signs (K_lat 3.44 vs 2.77) and is reported as a success
+        under either setting. Keep the adapter production-faithful.
+
+        ``strict=False`` enables the soft-barrier fallback on the underlying
         MPCEv2Element so the solver gets a quadratic pull-back when it
         starts in the wrong basin instead of an immediate raise.
 


### PR DESCRIPTION
#271 **step 2** (remainder) -- checklist items #5 (physics residual untouched), #7 (baseline reproduces), #8 (measure, don't assume), #9 (falsify; flip the xfail). Closes step 2.

Three faces of one question, each **measured on all 2073 scorecard solves before changing anything**.

## (a) The pre-check fallback was parking, not transient

| | |
|---|---|
| hits | 145 |
| distinct solves | **26** |
| hits per affected solve | median 5, max 12 |
| affected solves converged | **0 / 26** |

It returned the continuity residual with `jac = {}` -- withholding even the trivial Jacobian it owns -- so the solver received N+1 zero rows. The iterates were all-same-sign with real magnitude (`[0.0021, 0.0011, 0.0048]`, every port flowing out): a mass-conservation violation and a **wrong-direction state**, which the existing soft barrier already handles with a real derivative, except the pre-check returned first.

**Fix:** all-ports-zero (a cold start; never seen on the scorecard) -> soft barrier at zero slack, which *is* continuity with its Jacobian; same-sign -> falls through to the wrong-direction check. No new code path.

## (b) The mask mismatch was the bigger silent lossless junction: 384 hits

`[-0.1, -0.0, 0.125]`: MPCEv2 excludes the `-0.0` port, Mynard's `Q < 0` classifies it as a supplier, the two disagree, `K` comes back mis-shaped, the shape guard zeroes it -- at initialization.

**Fix:** snap an excluded port to a tiny flow in its **declared** direction and rebuild the masks, so both classifications agree by construction and the step-1.4 limit applies (`K -> 1`, dead outlet). Shape guard now trips **0** times.

## (c) N > 3 refused at construction

Mynard's `K` (Eq 18) is three-branch only. `MPCEv2Element` and `ConstantKTeeElement` raise with a message naming the limit. The strict xfail is retired -- the state is unconstructible -- and the closure-level precondition test stays.

## Verified

- **9 of 10 new tests red** against the pre-fix element (the 10th pins "three ports still accepted"); 2.1's test of the old `jac = {}` shape updated.
- Full suite **2030 passed**.
- Scorecard **identical to the digit**: 1578/2073 converged, every imposed_q cell unchanged.

**The honest number:** the 26 doomed solves are still doomed. The empty Jacobian was wrong, but it was not what killed them -- they are the true-endpoint / artifact-root cases. This step buys correctness of what the solver is handed on every iterate, which the port must preserve. It does not buy convergence.

CHANGELOG under Fixed (behaviour change: N > 3 raises; degenerate iterates carry a Jacobian; dead ports classified). Design doc sec 7b, including one dead end: reverting after-measurement instrumentation with `git checkout` reverted the fix too -- commit first, then instrument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RNDxZouiHoJdaLpnnPjHq


---

## Second commit: the strict-mode artefact, and Bassett's own case

Characterising one of the 26 unrescued solves: **Bassett K6, theta=45, psi=3, q=0.40, `three_pb`** -- his own Fig 7b curve at M ~ 0.03, inside the conditions he measured. Not a physics-envelope failure: the first iterate sat in the reversed basin and the adapter's `strict=True` default **raised** on it, where production (`strict=False`) would have steered back through the soft barrier.

| topology | strict=True | strict=False |
|---|---|---|
| imposed_q | 602 / 691 | 602 / 691 |
| mfb_two_pb | 587 | **629** |
| three_pb | 389 | **480** |

- The imposed_q gate tables stand. Every all-topology convergence comparison made earlier (incl. "v2 converges far less than v1") was a strict-mode artefact -- withdrawn in the provenance record. **Adapter now defaults to `strict=False`.**
- **Bassett Fig 7b now converges** in `three_pb` at q=0.4/0.6/0.8 onto his curve (0.444/1.246/2.765 vs 0.444/1.247/2.769) -- pinned as passing. The low-lateral-fraction points still fail -- pinned as **strict xfail targets**.
- **An uncaught mirror root:** `mfb_two_pb` q=0.8 converges to K_lat 3.44 vs 2.77 and is reported as a success under *both* settings when run cold -- the port signs are right, so the direction-only verifier cannot see it (v2 has no energy-consistency check; v1 does). And it is **not deterministic** across processes: a strict xfail on it flapped in CI, so it carries the junction tests' one deliberately non-strict xfail, reason stated. Both are recorded on #271 and in the design doc as defects for step 3.

I stated the mirror-root finding wrongly at first ("the verifier demotes it") from a run on a reused instance; corrected in all four places once measured cold.
