### PR TITLE
fix(solver): make results independent of PYTHONHASHSEED; record why the junction solves fail (#271)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`NetworkSolver` results no longer depend on `PYTHONHASHSEED`.**
+  `_propagate_pressure_guess` seeded its breadth-first pressure propagation
+  from `list(set(...))` over node-ID strings. Set iteration order for strings
+  follows `hash(str)`, which Python randomises per process, and every BFS hop
+  applies the same pressure decrement -- so the propagated initial guess, and
+  with it the Newton basin, changed from run to run on identical input. On
+  the junction validation scorecard (issue #271) the `mfb_two_pb` topology
+  converged 618 or 629 of 691 depending on the seed, and Bassett's own Fig 7b
+  case landed on a different root in 5 of 10 identical processes. The queue is
+  now seeded from the dict, which is insertion-ordered. Networks whose solve is
+  basin-sensitive may now select a different (deterministic) root than they
+  happened to select before; the junction scorecard is unchanged at 1700/2073
+  under every seed tested, against 1700 or 1711 before. The Python suite also
+  reported no intermittent `xpass` across three consecutive runs, where it
+  previously did.
+
 ### Added
 - **The tuned constants in the MPCEv2 junction closure are now named,
   labelled with their provenance, and switchable for measurement (issue

--- a/docs/archive/JUNCTION_JACOBIAN_271.md
+++ b/docs/archive/JUNCTION_JACOBIAN_271.md
@@ -127,11 +127,16 @@ post-solve direction verifier. Re-measured: all-topology 1578/2073 at
 (602/691) and the whole difference in the pressure-driven topologies. The
 MAE/bias rows stand (they are `imposed_q`); the convergence comparison
 between regimes, and the earlier "v2 converges far less than v1" reading,
-were strict-mode artefacts and are withdrawn. Separately, Bassett Fig 7b
-`mfb_two_pb` q=0.8 converges to a mirror root (K 3.44 vs 2.77) and is reported
-as a success under **both** settings: the port signs are correct, so the
-direction-only verifier cannot see it. The adapter now defaults to
-`strict=False`; the uncaught mirror root is a pinned target.
+were strict-mode artefacts and are withdrawn. The adapter now defaults to `strict=False`.
+
+**Second correction (same day): the "mirror root" recorded here is
+withdrawn.** Bassett Fig 7b `mfb_two_pb` q=0.8 was reported above as
+converging to a mirror root at K 3.44 against 2.77. It converges to q=0.857,
+not 0.8, and its extracted K of 3.4370 equals the model's own `imposed_q` K
+at q=0.857 -- the model's correct root at a shifted operating point. The
+error was comparing K against the paper at the target q while the solve sat
+elsewhere. Full measurement, and what the harness actually needs to detect,
+in [JUNCTION_OPERATING_POINT_271.md].
 
 **What survives:** the case for porting is architectural homogeneity and the
 CLAUDE.md `(f, J)` rule, not a convergence rescue. Joining runs its Jacobian
@@ -157,3 +162,5 @@ better than implying a performance win that the numbers do not support.
 - A coefficient is compared only against the leg its source indexes it on.
 - A change to a closure is scored against the digitised curves before it lands,
   and reverted with the numbers written down when the data says no.
+
+[JUNCTION_OPERATING_POINT_271.md]: JUNCTION_OPERATING_POINT_271.md

--- a/docs/archive/JUNCTION_OPERATING_POINT_271.md
+++ b/docs/archive/JUNCTION_OPERATING_POINT_271.md
@@ -1,0 +1,297 @@
+# MPCE Junction: Operating-Point Multiplicity and the Harness Scores (issue #271)
+
+Why the pressure-driven junction solves fail, converge twice, or score
+themselves. The code owns the formulas; this owns the reasoning and the
+measurements that decided things. Companion to
+[JUNCTION_JACOBIAN_271.md](JUNCTION_JACOBIAN_271.md), which owns the Jacobian
+and validation-wiring history.
+
+Measured 2026-09-05 on a throwaway branch, scripts under `tmp/` (gitignored),
+against `validation.junction.network_runner.run_network` at 2073 records.
+
+## The question that started it
+
+Step 2 left 26 solves the degenerate-iterate fallback could not rescue, and
+Bassett's own Fig 7b case was among them: theta=45, psi=3, M ~ 0.03, deep
+inside the conditions he measured. A documented case failing inside documented
+conditions is the highest-priority kind. The working hypothesis was seeding:
+start Newton on the physical branch, and detect and steer away from
+non-physical ones.
+
+**The hypothesis was wrong, and two claims already in this repository were
+wrong with it.** The failures are not basin failures. Most are boundary-value
+problems with no solution, and the rest have two solutions, both physical.
+
+## What the boundary conditions actually impose
+
+The three validation topologies constrain the junction very differently, and
+the difference decides everything below.
+
+| topology | imposed | free | what a root must satisfy |
+|---|---|---|---|
+| `imposed_q` | both mass flows | pressures | nothing: q is a boundary condition, the answer is single-valued |
+| `mfb_two_pb` | `m_com`, both outlet `Pt` | the split, `Pt_com` | `K_lat(q) - K_str(q) = D_target` |
+| `three_pb` | every `Pt` | the split and the flow level | `K_lat(q) / K_str(q) = R_target`, then the level follows |
+
+`imposed_q` is the only topology that pins the operating point. The other two
+impose a *relation between the coefficients* and let the junction find its own
+q. That is production-realistic, and it is exactly why they are in the harness.
+It also means the converged q is an output, not the target.
+
+## Finding 1: the model's coefficient difference is not monotonic
+
+`D(q) = K_lat_model(q) - K_str_model(q)` is U-shaped. Mapped through the
+`imposed_q` topology (where q is a boundary condition, so `D` is well defined):
+
+| geometry | min D | at q |
+|---|---|---|
+| psi=3, theta=45 | 0.551 | 0.27 |
+| psi=1, theta=90 | 0.292 | 0.97 |
+| psi=1, theta=120 | 1.036 | 0.97 |
+
+A U-shaped `D` splits the `mfb_two_pb` boundary-value problem into three
+regimes, and the curve predicts every observed outcome:
+
+| case | D_target | prediction | observed |
+|---|---|---|---|
+| psi=3, th=45, q=0.2 | 0.122 | below min: **no root** | "not making good progress" |
+| psi=3, th=45, q=0.4 | 0.385 | below min: **no root** | "not making good progress" |
+| psi=3, th=45, q=0.6 | 1.287 | one root, q=0.60 | converged at q=0.60 |
+| psi=3, th=45, q=0.8 | 2.829 | one root, q=0.86 | converged at q=0.857 |
+| psi=1, th=120, q=0.406 | 1.109 | **two roots**, 0.060 / 0.940 | 0.055 (default seed) / 0.939 (better seed) |
+| psi=1, th=120, q=0.490 | 1.235 | **two roots**, 0.120 / 0.880 | 0.129 / 0.870 |
+| psi=1, th=120, q=0.637 | 1.456 | **two roots**, 0.320 / 0.680 | 0.324 / 0.675 |
+
+So the failing Fig 7b points are **infeasible, not mis-seeded**. No initial
+guess reaches a root that does not exist, and "the iteration is not making good
+progress" is the solver reporting that honestly. Classified across the whole
+`mfb_two_pb` population: of 62 non-converged records, 31 are infeasible by
+construction and 22 are feasible failures. (The same classification was run for
+`three_pb` with the *difference* criterion, which is the wrong one for that
+topology -- its condition is the ratio -- so those numbers are not reported.)
+
+**Why the minimum sits so high is the K_straight gap (#272).** For psi=3 the
+model's `K_straight` spans -0.13 to +0.93 where Bassett's K5 spans -0.06 to
++0.46: wrong sign and magnitude at low q, which lifts `D` above where the
+measured targets sit. Sec 5 of [MPCE_CPP_PORT_DESIGN.md] establishes that a
+negative `K_straight` in dividing flow is real physics; the defect is its
+size and where it crosses zero, not its existence. This gives #272 a second,
+independent motivation: **a monotonic `D` would leave one operating point.**
+Uniqueness here is a model property, not a solver property.
+
+## Finding 2: where there are two roots, both are physical
+
+Both branches were checked against the model's own `imposed_q` curve at their
+own converged q -- the only single-valued reference available:
+
+| case | seed | q converged | K extracted | model K at that q | consistent |
+|---|---|---|---|---|---|
+| psi=1, th=120, q=0.406 | default | 0.0553 | 1.0032 | 1.0027 | yes |
+| psi=1, th=120, q=0.406 | junction-aware | 0.9393 | 1.8838 | 1.8836 | yes |
+| psi=1, th=90, q=0.701 | default | 0.0102 | 0.9986 | 0.9982 | yes |
+| psi=1, th=90, q=0.701 | junction-aware | 0.6018 | 0.9806 | 0.9801 | yes |
+| psi=3, th=45, q=0.8 | junction-aware | 0.8569 | 3.4375 | 3.4370 | yes |
+
+Every root reproduces the model to four decimals. **There is no non-physical
+branch to detect here.** The boundary conditions genuinely admit two operating
+points and the initial guess alone decides which is reported. What a detector
+can and should catch is the *degenerate* branch: q=0.0102 means a lateral leg
+carrying 1% of the flow, which passes `verify_solution_consistent` because its
+only criterion is `m_dot > 1e-6`.
+
+## Correction 1: the mirror root was not a mirror root
+
+Recorded on #271 and in [JUNCTION_JACOBIAN_271.md] on 2026-09-05: Bassett
+Fig 7b `mfb_two_pb` q=0.8 "converges to a mirror root, K_lat 3.44 against
+2.77, reported as a success -- the worst outcome the harness can produce."
+
+**Withdrawn.** The solve converges to q=0.857, not 0.8, and its extracted K of
+3.4370 equals the model's own `imposed_q` K at q=0.857 of 3.4370. It is the
+model's correct root at a shifted operating point. Against Bassett at the
+achieved q (3.3334) the model is 3.1% high, in line with its `imposed_q`
+accuracy. The 24% "error" was a comparison against the paper at the target q
+while the solve sat somewhere else.
+
+Three statements have now been made about this one case. The first claimed the
+verifier demotes it, from a run on a reused adapter instance. The second
+claimed a mirror root, from comparing K at the wrong q. Only the third is
+measured against the model's own curve. **The lesson is the comparison, not
+the care: a pressure-driven root can only be judged against the model at the q
+it actually reached.**
+
+## Correction 2: the three_pb K score is a tautology
+
+In `three_pb` every total pressure is imposed by a `PressureBoundary` through a
+`LosslessConnectionElement`, and `_extract_K` normalises by the fixed
+`m_dot_ref` rather than the converged flow. So
+
+    K_extracted = (Pt_com - Pt_lat)_imposed / q_dyn(m_dot_ref) = K_target
+
+by construction, whatever the model does.
+
+Falsified directly: a deliberately wrong model (`eta_scale=3.0`, whose
+`imposed_q` K at q=0.8 moves from 2.88 to 3.07) still reports **2.7677** in
+`three_pb` against a target of **2.7689**, a 0.05% "match".
+
+| q | eta_scale=3 imposed_q K | eta_scale=3 three_pb K | target |
+|---|---|---|---|
+| 0.6 | 1.6623 | 1.2464 | 1.2467 |
+| 0.8 | 3.0651 | 2.7677 | 2.7689 |
+
+`three_pb` measures convergence and nothing else. The residual 1e-3 differences
+are compressible/density corrections, not model content.
+`test_bassett_fig7b_case.py` asserted this tautology when it was merged in
+PR #288 and has been reduced to a convergence test.
+
+## Finding 3: the operating point drifts, and the score does not notice
+
+Drift between the intended q and the converged q, over every converged
+pressure-driven record:
+
+| topology | median drift | 90th pct | drift > 0.25 |
+|---|---|---|---|
+| `three_pb` | 0.1335 | 0.5961 | 26.2% |
+| `mfb_two_pb` | 0.0001 | 0.3899 | 12.6% |
+
+`mfb_two_pb` mostly lands where intended, which is what makes the tail
+dangerous: the score compares K against the paper at the target q with no
+signal that 12.6% of the rows are at a different operating point altogether.
+**Scoring K at the achieved q is the detector this harness is missing**, and it
+subsumes the "wrong root" question: a root 0.4 away in q is a different
+operating point, not a failed validation of the intended one.
+
+## Finding 4: the seed defect is real, and worth about 70 solves
+
+`NetworkSolver._propagate_analytical_pt_prop` seeds only `jct.P_jct` for these
+networks. Its Bernoulli mass-flow seed is restricted to `ChannelElement`, and
+both the harness and `gui/backend/graph_builder.py` wire junctions with
+`LosslessConnectionElement`, which gets nothing. Every element therefore falls
+back to the flat reference flow (0.1 kg/s), so x0 on a three-port junction
+violates continuity outright -- 0.1 in, 0.2 out -- with a 1:1 split whatever
+the boundary pressures say.
+
+A junction-aware replacement was prototyped: flow scale from a
+`MassFlowBoundary` when present, else Bernoulli on the largest imposed `dPt`;
+split proportional to `A_i * sqrt(dPt_i)`; rescaled so continuity holds exactly
+at x0 with every port on its declared side.
+
+| topology | default seed | junction-aware |
+|---|---|---|
+| `imposed_q` | 602 / 691 | 602 / 691 |
+| `mfb_two_pb` | 618 / 691 | 635 / 691 |
+| `three_pb` | 480 / 691 | 537 / 691 |
+| all | 1700 / 2073 | 1774 / 2073 |
+
+`imposed_q` is untouched, as expected: the flows are boundary conditions there.
+
+**It is not answer-neutral.** It moves 22 already-converged roots, because of
+Finding 1 -- both roots exist and the seed selects one. On psi=1, theta=90,
+q=0.701 that selection is an improvement (q=0.60 instead of a near-degenerate
+q=0.0102), but "improvement" is a judgement the harness cannot currently make,
+which is why the seed change must land **with** operating-point reporting, not
+before it.
+
+The baseline also moved between runs (1700 and 1711 on identical inputs).
+That is Finding 5 below, not noise in the measurement of the seed: both seeds
+were measured in the same process, so the comparison between the two columns
+stands.
+
+## Finding 5: the run-to-run variation is PYTHONHASHSEED, and it is one line
+
+Recorded on 2026-09-05 as "process-dependent outcomes, cause unknown". Cause
+found and proven the same day.
+
+Bassett Fig 7b `mfb_two_pb` q=0.8, run as ten separate identical processes:
+
+| outcome | wall time | count |
+|---|---|---|
+| converged at q=0.857, K=3.4370 | 23 ms | 5 |
+| degenerate root, rejected by the verifier | 8.6 ms | 5 |
+
+Bimodal, so not a timing-truncated solve (the stall detector's window is 5 s
+and these solves take milliseconds). Fixing the interpreter's hash seed makes
+it perfectly deterministic, and *which* root you get depends on the seed:
+
+| PYTHONHASHSEED | outcome, 5 runs each |
+|---|---|
+| 0 | converged, 5/5 |
+| 1 | degenerate root, 5/5 |
+| 7 | degenerate root, 5/5 |
+
+The dependence enters at `NetworkSolver._propagate_pressure_guess`:
+
+    visited = set(p_guess.keys())
+    queue = list(visited)          # <- iteration order of a set of strings
+
+`queue` seeds a breadth-first pressure propagation in which every hop applies
+`dp_est`, so the visit order decides the propagated pressures, hence x0, hence
+which basin Newton falls into. Set iteration order for strings follows
+`hash(str)`, which Python randomises per process by default.
+
+**Fixed, one line:** seed the queue from the dict, which is
+insertion-ordered.
+
+    queue = list(p_guess.keys())
+
+Full scorecard under four hash seeds, before and after:
+
+| PYTHONHASHSEED | before: mfb_two_pb | after |
+|---|---|---|
+| 0 | 618 / 691 | 618 |
+| 1 | 629 | 618 |
+| 7 | 629 | 618 |
+| 13 | 629 | 618 |
+
+(`imposed_q` 602 and `three_pb` 480 throughout; all-topology 1700 after,
+1700 or 1711 before.) The fix pins every seed to the seed-0 behaviour, which
+is 11 convergences fewer than the lucky seeds. **Fewer is not worse here:**
+by Finding 2 both branches satisfy the model, so a convergence count rewards
+landing on a degenerate root as much as on the intended one, and seed 0 is
+the ordering under which Bassett's own Fig 7b case converges to his operating
+point. A reproducible 1700 is worth more than an irreproducible 1711.
+
+It is not junction-specific: any network whose solve is basin-sensitive
+inherited it, and a validation harness that counts convergences inherited it
+twice. Landed with this record because the Fig 7b tests cannot be
+deterministic without it.
+
+## What this changes
+
+- The 26 unrescued solves are no longer a mystery: most are infeasible, and
+  the infeasibility measures the `K_straight` gap.
+- #272 gains a second motivation independent of accuracy: uniqueness of the
+  operating point.
+- The step-3 C++ port gate must not be "reproduce the `three_pb` K table" --
+  that table is reproducible by any model at all.
+- `verify_solution_consistent` needs a minimum-flow criterion, not an
+  energy-consistency one, for the branch class actually observed here.
+- The non-determinism is not an accepted cost of a hard problem. It is one
+  line, and until it is fixed no convergence count in this harness is
+  reproducible.
+
+## Dead ends
+
+- **Seeding the physical branch by hand.** A hand-built physical seed
+  (continuity-consistent, correct signs, `P_jct` at the common total pressure)
+  does not rescue the q=0.2 or q=0.4 Fig 7b cases. It cannot: there is no root.
+  This was the experiment that turned the investigation from seeding to
+  feasibility.
+- **Raising the dynamic head.** The imposed differences at q=0.2 are ~10 Pa on
+  a 1e5 Pa level, so ill-conditioning was the natural second hypothesis.
+  Sweeping `m_in` from 0.1 to 1.6 kg/s (a 256x change in dynamic head) left
+  every failing case failing. Not conditioning.
+- **Treating the second root as an artifact.** It reproduces the model exactly.
+  Rejecting it would have meant writing a detector against a correct answer.
+
+## Tests and code that pin this
+
+- `python/tests/test_bassett_fig7b_case.py` -- the passing points, the
+  infeasible ones as documented xfail targets, and no tautological assertion.
+- `validation/junction/models/_network_builder.py` -- `_extract_K` and the
+  three skeletons; the tautology lives in the combination of the two.
+- `python/combaero/network/solver.py` -- `_propagate_analytical_pt_prop`
+  (the seed) and `verify_solution_consistent`'s call site (the detector).
+
+[MPCE_CPP_PORT_DESIGN.md]: ../../validation/junction/MPCE_CPP_PORT_DESIGN.md
+[JUNCTION_JACOBIAN_271.md]: JUNCTION_JACOBIAN_271.md
+[issue #271]: https://github.com/thiemom/combaero/issues/271

--- a/python/combaero/network/solver.py
+++ b/python/combaero/network/solver.py
@@ -330,9 +330,18 @@ class NetworkSolver:
         else:
             dp_est = ref["P"] * 0.001
 
-        # BFS propagation from known nodes
+        # BFS propagation from known nodes.
+        # Seed the queue from the dict, NOT from `visited`: iterating a set of
+        # node-ID strings follows hash(str), which Python randomises per
+        # process, and every BFS hop applies dp_est -- so the propagated x0
+        # pressures, and with them the Newton basin, depended on
+        # PYTHONHASHSEED. Measured on the junction scorecard (issue #271):
+        # mfb_two_pb converged 618 or 629 of 691 depending on the seed, and
+        # Bassett's own Fig 7b case landed on a different root in 5 of 10
+        # identical processes. Dicts are insertion-ordered, so this is
+        # deterministic.
         visited = set(p_guess.keys())
-        queue = list(visited)
+        queue = list(p_guess.keys())
         while queue:
             nid = queue.pop(0)
             for elem in self.network.get_downstream_elements(nid):

--- a/python/tests/test_bassett_fig7b_case.py
+++ b/python/tests/test_bassett_fig7b_case.py
@@ -3,23 +3,38 @@
 theta = 45 deg, psi = 3 (lateral one third of the main area), separating
 flow. Bassett measured this curve (Fig 7b); the K6 formula (Eq 27) fits it.
 Every point on it sits at M ~ 0.03, deep inside the incompressible regime the
-closure assumes -- so a failure here is numerical, not a physics-envelope
-limit, and a case the literature documents is the highest-priority thing to
-keep passing (issue #271).
+closure assumes, so a case the literature documents is the highest-priority
+thing to keep passing (issue #271).
+
+What each topology can actually prove (docs/archive/JUNCTION_OPERATING_POINT_271.md):
+
+* ``imposed_q`` imposes both mass flows, so q is a boundary condition, the
+  root is unique, and the extracted K is the model's answer at that q. This
+  is the only topology whose K value means anything.
+* ``three_pb`` imposes every total pressure through lossless connections, and
+  ``_extract_K`` normalises by the fixed reference flow -- so the extracted K
+  is the imposed target BY CONSTRUCTION. Falsified directly: a model with
+  eta_scale=3.0, whose imposed_q K at q=0.8 moves 2.88 -> 3.07, still reports
+  2.7677 against a target of 2.7689. Asserting that K here (as the first
+  version of this file did) asserts nothing. Convergence only.
+* ``mfb_two_pb`` fixes the inlet flow and both outlet pressures, which
+  constrains only K_lat - K_str. The split is an outcome: q=0.8 converges at
+  q=0.857, and its K matches the model's own imposed_q K there to four
+  decimals. Comparing it against Bassett at the TARGET q is a comparison at
+  the wrong operating point, so this file does not do that either.
 
 Measured 2026-09-05 with the production-faithful adapter (strict=False):
 
-    topology     q=0.2      q=0.4      q=0.6      q=0.8
-    imposed_q    ok         ok         ok         ok
-    three_pb     FAIL       ok 0.444   ok 1.246   ok 2.765     (K6: 0.444 1.247 2.769)
-    mfb_two_pb   FAIL       FAIL       ok 1.403   WRONG ROOT: converged, K 3.44 vs 2.77
+    topology     q=0.2        q=0.4        q=0.6      q=0.8
+    imposed_q    ok           ok           ok         ok
+    three_pb     no root      ok           ok         ok
+    mfb_two_pb   no root      no root      ok         ok  (at q=0.857)
 
-Under strict=True the three_pb q=0.4/0.6 cases raised on a transient
-wrong-sign iterate. mfb_two_pb q=0.8 converges -- under BOTH strict settings,
-run cold -- to a mirror root 24% off Bassett, reported as a success: the port
-signs are right, so the direction-only verifier cannot see it. The tests
-below pin what passes as passing, and what does not as strict xfails --
-targets, not tolerated failures.
+The q=0.2 and q=0.4 failures are NOT solver-path failures. Those boundary-value
+problems have no solution: the model's K_lat - K_str has a minimum of 0.551 for
+this geometry and the targets sit at 0.122 and 0.385. They are xfail targets
+that come off when the K_straight gap (#272) closes, not when the solver or
+the seed improves.
 """
 
 from __future__ import annotations
@@ -28,7 +43,6 @@ import math
 
 import pytest
 
-from validation.junction.models import bassett2001
 from validation.junction.models.mpce_v2_network import MPCEv2Network
 
 _THETA = math.radians(45.0)
@@ -37,13 +51,23 @@ _PSI = 3.0
 
 @pytest.fixture
 def model():
-    # Fresh per test: the same case has been seen to land differently after
-    # other solves on one instance, and a target must be measured cold.
+    # Fresh per test: a target must be measured cold, not after other solves.
+    #
+    # These solves used to be PYTHONHASHSEED-dependent -- mfb_two_pb q=0.8
+    # landed on a different root in 5 of 10 identical processes -- because
+    # solver.py's _propagate_pressure_guess seeded its BFS from a set of
+    # node-ID strings. Fixed in the same change as this file; the assertions
+    # below hold under hash seeds 0, 1, 7 and 13, and would flap without it.
     return MPCEv2Network(strict=False)
 
 
 def _run(model, topology: str, q: float):
     return model.evaluate_network("bassett2001", "K6", q, _PSI, _THETA, topology=topology)
+
+
+# ---------------------------------------------------------------------------
+# imposed_q: the only topology whose K value is the model's own answer
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize("q", [0.2, 0.4, 0.6, 0.8])
@@ -52,62 +76,75 @@ def test_imposed_q_converges_across_the_curve(model, q):
     assert r.converged, r.message
 
 
-@pytest.mark.parametrize("q", [0.4, 0.6, 0.8])
-def test_three_pb_converges_and_lands_on_bassett_K6(model, q):
-    """The case that raised under strict=True. With the soft barrier steering
-    the reversed first iterate back, it converges to Bassett's own curve."""
-    r = _run(model, "three_pb", q)
+@pytest.mark.parametrize(
+    "q, expected",
+    [(0.2, 0.4534), (0.4, 0.5816), (0.6, 1.3888), (0.8, 2.8842)],
+)
+def test_imposed_q_reproduces_the_model_curve(model, q, expected):
+    """Pins the model's own Fig 7b curve, so a physics change has to state
+    itself here. These are NOT Bassett's values -- the gap to his measured
+    curve is the accuracy question, tracked on the scorecard, and it is
+    largest exactly where K_straight is worst."""
+    r = _run(model, "imposed_q", q)
 
     assert r.converged, r.message
-    assert r.K_lateral == pytest.approx(bassett2001.K6(q, _PSI, _THETA), abs=0.05)
-
-
-@pytest.mark.xfail(
-    strict=False,
-    reason=(
-        "mfb_two_pb q=0.8 is NOT reliably solved, and the outcome depends on the "
-        "process: run cold in one process it converges to K_lat 3.44 against "
-        "Bassett's 2.77 and is reported as a success (the port signs are correct, "
-        "so the direction-only verifier cannot see the mirror root); under the "
-        "parallel suite the same case fails or is demoted instead. Both outcomes "
-        "are wrong, in different ways, so a strict marker would flap. This is the "
-        "one deliberately non-strict xfail in the junction tests, and the "
-        "non-determinism is itself a recorded defect (issue #271). It comes off "
-        "when the case converges to Bassett's curve every time."
-    ),
-)
-def test_mfb_two_pb_mirror_root_is_caught(model):
-    r = _run(model, "mfb_two_pb", 0.8)
-
-    assert (not r.converged) or r.K_lateral == pytest.approx(
-        bassett2001.K6(0.8, _PSI, _THETA), abs=0.15
-    ), (
-        f"reported converged at K_lat={r.K_lateral:.3f} vs Bassett {bassett2001.K6(0.8, _PSI, _THETA):.3f}"
-    )
+    assert r.K_lateral == pytest.approx(expected, abs=0.01)
 
 
 # ---------------------------------------------------------------------------
-# Targets: a documented case must not stay failing quietly
+# Pressure-driven: convergence only, for the reasons in the module docstring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("q", [0.4, 0.6, 0.8])
+def test_three_pb_converges(model, q):
+    """The case that raised under strict=True. With the soft barrier steering
+    the reversed first iterate back it converges. No K assertion: in this
+    topology the extracted K is the imposed target whatever the model does."""
+    assert _run(model, "three_pb", q).converged
+
+
+@pytest.mark.parametrize("q", [0.6, 0.8])
+def test_mfb_two_pb_converges(model, q):
+    assert _run(model, "mfb_two_pb", q).converged
+
+
+def test_mfb_two_pb_root_is_the_models_own_answer(model):
+    """q=0.8 settles at q=0.857 and must reproduce the model there.
+
+    This was once recorded as an uncaught mirror root, from comparing K
+    against Bassett at the target q. The honest check is against the model's
+    own imposed_q curve at the q the solve actually reached.
+    """
+    r = _run(model, "mfb_two_pb", 0.8)
+    assert r.converged, r.message
+
+    reference = _run(model, "imposed_q", 0.8569)
+    assert reference.converged, reference.message
+    assert r.K_lateral == pytest.approx(reference.K_lateral, abs=0.01)
+
+
+# ---------------------------------------------------------------------------
+# Targets: infeasible until the K_straight gap closes
 # ---------------------------------------------------------------------------
 
 _TARGET = (
-    "Bassett Fig 7b at a low lateral fraction does not converge through the "
-    "pressure-driven topologies: 'iteration is not making good progress'. "
-    "It sits inside the paper's measured conditions (M ~ 0.03), so this is a "
-    "solver-path failure, not physics. Priority target for the step-3 port "
-    "and the degenerate-iterate work (issue #271). strict=True so the moment "
-    "it starts passing, this marker must come off."
+    "Bassett Fig 7b at a low lateral fraction has NO root in the "
+    "pressure-driven topologies: they constrain K_lat - K_str, the model's "
+    "value of that has a minimum of 0.551 for this geometry, and the targets "
+    "are 0.122 (q=0.2) and 0.385 (q=0.4). 'Not making good progress' is the "
+    "solver reporting an infeasible system honestly, and no initial guess "
+    "changes it. This comes off when #272 closes the K_straight gap, not "
+    "when the solver improves. strict=True so it is noticed either way."
 )
 
 
 @pytest.mark.xfail(strict=True, reason=_TARGET)
 def test_three_pb_low_lateral_fraction_converges(model):
-    r = _run(model, "three_pb", 0.2)
-    assert r.converged, r.message
+    assert _run(model, "three_pb", 0.2).converged
 
 
 @pytest.mark.xfail(strict=True, reason=_TARGET)
 @pytest.mark.parametrize("q", [0.2, 0.4])
 def test_mfb_two_pb_low_lateral_fraction_converges(model, q):
-    r = _run(model, "mfb_two_pb", q)
-    assert r.converged, r.message
+    assert _run(model, "mfb_two_pb", q).converged

--- a/validation/junction/MPCE_CPP_PORT_DESIGN.md
+++ b/validation/junction/MPCE_CPP_PORT_DESIGN.md
@@ -293,35 +293,68 @@ direction verifier. Measured on the full scorecard:
 - Every all-topology convergence comparison made earlier was a strict-mode
   artefact, including "v2 converges far less than v1" -- v1 has no strict
   raise. Withdrawn; the provenance record is corrected.
-- **Both modes report a false success** on Bassett Fig 7b `mfb_two_pb`
-  q=0.8: run cold it converges to K_lat 3.44 against 2.77 -- a mirror root
-  with the *correct port signs*, so the direction-only verifier cannot see
-  it. (An earlier run on a reused adapter instance happened to demote it;
-  measured cold, it is reported as converged every time.) A wrong root
-  reported as a success is the worst outcome the harness can produce. The v1
-  base has an energy-consistency check (#229); MPCEv2 has none. Pinned as a
-  strict xfail target.
-- **And it is not even deterministic.** The same `mfb_two_pb` q=0.8 case
-  converges to the mirror root in a cold single-process run and fails or is
-  demoted under the parallel test suite. A strict xfail on it flapped in CI.
-  It carries the junction tests' one deliberately non-strict xfail, with the
-  non-determinism stated as the reason; process-dependent outcomes in a
-  validation harness are a defect in their own right (step 3 must not
-  inherit them).
+- **The "mirror root" reading of Bassett Fig 7b `mfb_two_pb` q=0.8 is
+  withdrawn (2026-09-05, same day).** It converges to q=0.857, not 0.8, and
+  its extracted K of 3.4370 equals the model's own `imposed_q` K at q=0.857.
+  It is the model's correct root at a shifted operating point; the 24%
+  "error" was a comparison against Bassett at the target q. See
+  [JUNCTION_OPERATING_POINT_271.md] for the measurement and for what the
+  direction-only verifier does and does not need to catch.
+- **The run-to-run variation is real, and its cause is now known.** The same
+  case converges in 5 of 10 identical processes. It is `PYTHONHASHSEED`:
+  `_propagate_pressure_guess` seeds its BFS from `list(set(...))` over node-ID
+  strings, so the propagated x0 pressures depend on the process hash seed.
+  Fixed hash seed gives perfectly reproducible outcomes, and different seeds
+  give different roots. **Fixed** (defect 12 below): the scorecard is now
+  1700/2073 under every seed tested, against 1700 or 1711 before. Every
+  convergence count recorded in this document before 2026-09-05 carries that
+  uncertainty.
 - The adapter now defaults to `strict=False`. Never compare v1 and v2
   convergence without matching it.
 
 **Bassett's own Fig 7b case** (theta=45, psi=3, M ~ 0.03 -- inside his
-measured conditions) converges in `three_pb` at q=0.4/0.6/0.8 onto his curve
-(K_lat 0.444/1.246/2.765 vs 0.444/1.247/2.769) once the soft barrier is
-allowed to steer the reversed first iterate. The low-lateral-fraction points
-(q=0.2 `three_pb`; q=0.2/0.4 `mfb_two_pb`) still fail with "not making good
-progress" -- a solver-path failure inside documented conditions, which is
-the highest-priority kind. They are pinned as strict xfail **targets** in
-`python/tests/test_bassett_fig7b_case.py`, alongside the passing points, so
-the moment one starts passing it is noticed.
+measured conditions) converges in `three_pb` at q=0.4/0.6/0.8 and in
+`mfb_two_pb` at q=0.6/0.8. The low-lateral-fraction points (q=0.2/0.4) do
+not, and the follow-up investigation showed **why: those boundary-value
+problems have no solution.** The model's `K_lat - K_str` has a minimum of
+0.551 for this geometry and the targets sit at 0.122 and 0.385. No seed
+reaches a root that does not exist. They stay pinned as xfail targets in
+`python/tests/test_bassett_fig7b_case.py`, now labelled infeasible rather
+than solver-path failures, and they come off when #272 closes the
+`K_straight` gap. **The `three_pb` assertions in that test were tautological
+and have been removed** -- see the next section.
+
+## 4e. The pressure-driven topologies score less than they appear to (2026-09-05)
+
+Full record: [JUNCTION_OPERATING_POINT_271.md]. Three results that change what
+the port can be gated on:
+
+1. **`three_pb`'s K extraction is a tautology.** Every `Pt` is imposed by a
+   boundary through a lossless connection and `_extract_K` normalises by the
+   fixed `m_dot_ref`, so the extracted K is the target by construction. A
+   deliberately wrong model (`eta_scale=3.0`, `imposed_q` K 2.88 -> 3.07)
+   still reproduces the q=0.8 target to 0.05%. `three_pb` measures
+   convergence only.
+2. **The converged operating point drifts from the target q**, and the score
+   compares against the paper at the target anyway: `three_pb` median drift
+   0.134, `mfb_two_pb` 12.6% of converged rows more than 0.25 away. Scoring K
+   at the **achieved** q is the missing instrument.
+3. **Where the BC set is feasible it often has two roots**, both exactly
+   reproducing the model at their own q, with the initial guess deciding.
+   Uniqueness is a property of `K_lat - K_str` being monotonic, i.e. of
+   #272, not of the solver.
+
+Consequences for sec 8: the step-4 gate cannot include "reproduce the
+`three_pb` K table", and the `mfb_two_pb` table is only meaningful once K is
+scored at the achieved q.
 
 ## 5. What the papers settle about the K_straight question (#272)
+
+**Second motivation, added 2026-09-05:** `K_straight`'s size at low q also
+decides whether the pressure-driven problem has a unique solution. The
+model's `K_lat - K_str` is U-shaped, which makes low-q targets infeasible
+and mid-range targets doubly-rooted. A monotonic difference leaves one
+operating point. See [JUNCTION_OPERATING_POINT_271.md].
 
 Three independent sources say **negative `K_straight` in dividing flow is real
 physics**, not a solver artefact:
@@ -402,9 +435,17 @@ Consequences:
 | 5 | `damping` 0.02 undocumented as a regulariser | Matlab comment | name it (`FLOW_RATIO_DAMPING = 0.02`) with the Matlab citation and the sentence "numerical regulariser, not physics" | trivial |
 | 6 | No compressibility, no stated limit | sec 3 | short-term: document `Ma < 0.2` on the element as `tee_junction.h` does; long-term: sec 8 step 5 | trivial now |
 | 7 | Bassett K4/K7/K8/K9 unscored | sec 6 | add a type-4 joining builder and a K4 separating case to the adapter | medium |
+| 8 | `three_pb`'s K score is a tautology (sec 4e) | `eta_scale=3.0` still reproduces the q=0.8 target to 0.05% | score K at the achieved q, or demote `three_pb` to a convergence-only row in the scorecard | small |
+| 9 | K is scored at the TARGET q while the solve sits at the achieved q | drift: `three_pb` median 0.134; `mfb_two_pb` 12.6% of rows > 0.25 | return the converged q from `solve_and_extract` and score against the paper there | small |
+| 10 | `verify_solution_consistent` passes near-degenerate roots | a root at q=0.0102 (lateral leg at 1% of the flow) is reported as a success; its only criterion is `m_dot > 1e-6` | add a minimum-flow-fraction criterion | small |
+| 11 | `analytical_pt_prop` seeds no mass flow through `LosslessConnectionElement` | x0 violates continuity at every junction (0.1 in, 0.2 out); a junction-aware mass-conserving seed gains ~70 solves | extend the seed, but land it WITH item 9 -- it moves 22 already-converged roots between the two legitimate branches | medium |
+| 12 | ~~Solver results depend on `PYTHONHASHSEED`~~ **fixed** | `_propagate_pressure_guess` seeds its BFS from `list(set(p_guess.keys()))`; the same case converges in 5 of 10 identical processes, and is deterministic per fixed hash seed | **done.** `queue = list(p_guess.keys())`; scorecard identical (1700/2073) under seeds 0/1/7/13, against 1700 or 1711 before | done |
 
 Items 1, 2, 5, 6 are an afternoon. Item 3 is the one that changes what the
-port can be held to.
+port can be held to. Item 12 is done; it blocked reproducible measurement of everything else.
+Items 8-11 come from
+[JUNCTION_OPERATING_POINT_271.md] and change what the port can be *gated*
+on: 9 before 11, and 8 before either.
 
 ## 7a. Step 2.1 note: the wide-except audit (2026-09-05)
 
@@ -526,8 +567,12 @@ useless.
    stays as an offline cross-check of the canonical case (the ejector recipe),
    not as a runtime path.
 
-**Step 4 gate:** all Bassett, Hager and Idelchik tables reproduced to solver
-tolerance with no worse convergence; whole-row FD tests
+**Step 4 gate:** the `imposed_q` Bassett, Hager and Idelchik tables
+reproduced to solver tolerance with no worse convergence. **Not** the
+`three_pb` K table, which any model reproduces (sec 4e), and the
+`mfb_two_pb` table only once K is scored at the achieved q (item 9);
+until then `mfb_two_pb` contributes convergence counts, not accuracy.
+Plus whole-row FD tests
 (`test_mpce_v2_jacobian_rows.py`, extended to joining and to `N = 4` once
 item 1 is lifted) at `< 1e-6`; a ctest comparing the C++ kernel against golden
 Python values (the ejector recipe's `.h` golden-data pattern).
@@ -536,6 +581,12 @@ Python values (the ejector recipe's `.h` golden-data pattern).
 correction into the closure (it is already in `tee_junction.h`, templated, with
 the v3 spec's derivation). Gate: Wang 2014 (digitised) and Perez-Garcia
 (digitise first). This is the step that restores what the retired tee had.
+
+**Step 5a -- operating-point instrumentation (items 8-11).** Independent of
+the port and a prerequisite for gating it: return the converged q, score
+against the paper there, demote the `three_pb` K column, tighten the
+verifier, then land the junction-aware seed. Doing the seed first would
+silently move 22 roots with nothing able to tell which branch is wanted.
 
 **Step 6 -- retire v1 as a solver element** (sec 5). Keep
 `MultiPortChamberElement` as the M -> 0 regression target; close the #272
@@ -575,3 +626,5 @@ Still open:
 - `compressible_junction_model_v3.pdf` -- sec 5 (closed O(M^2) K), 8
   (residuals + Jacobian tables), 9 (C++ fragments), 11 (limitations).
 - `JunctionLossCoefficient.m` -- line 60-63 (damping), 65 (n <= 3 K).
+
+[JUNCTION_OPERATING_POINT_271.md]: ../../docs/archive/JUNCTION_OPERATING_POINT_271.md

--- a/validation/junction/models/mpce_v2_network.py
+++ b/validation/junction/models/mpce_v2_network.py
@@ -51,10 +51,14 @@ class MPCEv2Network:
         reports artifact roots as converged. Measured on the full scorecard
         (issue #271): strict=True 1578/2073, strict=False 1711/2073, with
         imposed_q identical (602/691) and the difference entirely in the
-        pressure-driven topologies. Note the verifier is direction-only:
-        Bassett Fig 7b mfb_two_pb q=0.8 converges to a mirror root with the
-        right port signs (K_lat 3.44 vs 2.77) and is reported as a success
-        under either setting. Keep the adapter production-faithful.
+        pressure-driven topologies. Keep the adapter production-faithful.
+
+        The verifier is direction-only, and its threshold is `m_dot > 1e-6`,
+        so it also passes near-degenerate roots: a solve reporting a lateral
+        leg at 1% of the common flow is a success. That matters because the
+        pressure-driven topologies often have TWO roots, both exactly
+        reproducing the model, with the initial guess deciding which is
+        reported (docs/archive/JUNCTION_OPERATING_POINT_271.md).
 
         ``strict=False`` enables the soft-barrier fallback on the underlying
         MPCEv2Element so the solver gets a quadratic pull-back when it


### PR DESCRIPTION
Investigating the solves step 2 could not rescue, starting from the hypothesis that they were seeding failures. **They are not**, and two claims this repository already carried were wrong.

Full record: [`docs/archive/JUNCTION_OPERATING_POINT_271.md`](docs/archive/JUNCTION_OPERATING_POINT_271.md).

## What the pressure-driven topologies actually constrain

Only `imposed_q` pins the operating point. `mfb_two_pb` constrains `K_lat(q) - K_str(q)`; `three_pb` constrains their ratio. **The converged q is an output, not the target.**

The model's `K_lat - K_str` is U-shaped, minimum 0.551 for Bassett's Fig 7b geometry. That one curve predicts every observed outcome:

| target q | required difference | prediction | observed |
|---|---|---|---|
| 0.2 | 0.122 | below the minimum: **no root** | fails |
| 0.4 | 0.385 | below the minimum: **no root** | fails |
| 0.6 | 1.287 | one root at q=0.60 | converges at 0.60 |
| 0.8 | 2.829 | one root at q=0.86 | converges at 0.857 |

"The iteration is not making good progress" is the solver reporting an infeasible system honestly. No seed reaches a root that does not exist.

The minimum sits that high because `K_straight` is wrong in sign and magnitude at low q, which is **#272** -- and this gives #272 a second motivation. Where the target *is* attainable the U-shape gives **two roots**, both reproducing the model exactly at their own q, with the initial guess deciding. A monotonic difference would leave one operating point. **Uniqueness is a model property here, not a solver property.**

## Two corrections

- **The "uncaught mirror root" recorded yesterday is withdrawn.** `mfb_two_pb` q=0.8 converges at q=0.857 and its K of 3.4370 equals the model's own `imposed_q` K at q=0.857. Correct root, shifted operating point; the 24% error was a comparison against Bassett at the target q. Three statements have now been made about this one case and only this one is measured against the model's own curve.
- **`three_pb`'s K score is a tautology.** Every `Pt` is imposed through a lossless connection and `_extract_K` normalises by the fixed reference flow. Falsified: `eta_scale=3.0`, whose `imposed_q` K at q=0.8 moves 2.88 to 3.07, still reports **2.7677** against a target of **2.7689**. The Fig 7b test merged in #288 asserted that tautology and is reduced to a convergence test.

## The fix in this PR

`_propagate_pressure_guess` seeded its BFS from `list(set(node_ids))`. Set iteration order for strings follows `hash(str)`, randomised per process, and every hop applies `dp_est` -- so x0, and the Newton basin, depended on `PYTHONHASHSEED`. Bassett Fig 7b `mfb_two_pb` q=0.8 landed on a different root in **5 of 10 identical processes**, deterministically per fixed seed.

| PYTHONHASHSEED | 0 | 1 | 7 | 13 |
|---|---|---|---|---|
| mfb_two_pb before | 618 | 629 | 629 | 629 |
| mfb_two_pb after | 618 | 618 | 618 | 618 |

Fewer is not worse: both branches satisfy the model, so a convergence count rewards a degenerate root as much as the intended one, and this ordering is the one under which Bassett's own case converges to his operating point. A reproducible 1700/2073 beats an irreproducible 1711. The suite also reported no intermittent `xpass` across three consecutive runs.

**Not junction-specific.** Any basin-sensitive network inherited it. Hence the CHANGELOG entry.

## Not fixed here (defects 8-11 in the design doc)

- **K is scored at the target q while the solve sits elsewhere**: `three_pb` median drift 0.134, `mfb_two_pb` 12.6% of rows more than 0.25 away. `NetworkResult` already has an unpopulated `q_converged` field.
- **`verify_solution_consistent` passes near-degenerate roots** (a lateral leg at 1% of the flow); its only criterion is `m_dot > 1e-6`.
- **`analytical_pt_prop` seeds no mass flow through `LosslessConnectionElement`**, so x0 violates continuity at every junction. A junction-aware mass-conserving seed gains ~70 solves in a prototype, but moves 22 already-converged roots between the two legitimate branches, so it must land **with** operating-point reporting, not before it.

The step-4 port gate in the design doc no longer includes the `three_pb` K table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RNDxZouiHoJdaLpnnPjHq
