### PR TITLE
docs(junction): D(q) is a quadratic -- monotonicity is not the target, the equal-area identity is (#271, #272)

### DIFF
--- a/docs/archive/JUNCTION_OPERATING_POINT_271.md
+++ b/docs/archive/JUNCTION_OPERATING_POINT_271.md
@@ -75,9 +75,15 @@ model's `K_straight` spans -0.13 to +0.93 where Bassett's K5 spans -0.06 to
 +0.46: wrong sign and magnitude at low q, which lifts `D` above where the
 measured targets sit. Sec 5 of [MPCE_CPP_PORT_DESIGN.md] establishes that a
 negative `K_straight` in dividing flow is real physics; the defect is its
-size and where it crosses zero, not its existence. This gives #272 a second,
-independent motivation: **a monotonic `D` would leave one operating point.**
-Uniqueness here is a model property, not a solver property.
+size and where it crosses zero, not its existence.
+
+**Correction (2026-09-05, Finding 6).** This section first read "a monotonic
+`D` would leave one operating point", offering that to #272 as a second
+motivation. That is wrong: `D` is a quadratic whose vertex lies inside (0,1)
+for every unequal-area geometry in the dataset, so **Bassett's own `D` is not
+monotone either** and monotonicity is not available to aim at. What fixing the
+model does deliver is feasibility everywhere, and the removal of a *spurious*
+multiplicity at equal areas. See Finding 6.
 
 ## Finding 2: where there are two roots, both are physical
 
@@ -339,12 +345,121 @@ inherited it, and a validation harness that counts convergences inherited it
 twice. Landed with this record because the Fig 7b tests cannot be
 deterministic without it.
 
+## Finding 6: monotonicity is not the right target, and D is a quadratic
+
+Asked whether the coefficients could be reformulated to force monotonicity.
+They cannot, and they should not be. Bassett's separating pair has closed
+forms (Eq 15 and Eq 27), so their difference does too:
+
+    K5(q)          = q^2 - 1.5 q + 0.5
+    K6(q,psi,th)   = q^2 psi^2 + 1 - 2 q psi cos(0.75 th)
+
+    D(q) = K6 - K5 = q^2 (psi^2 - 1) + q (1.5 - 2 psi c) + 0.5,  c = cos(0.75 th)
+
+A quadratic, verified against the functions to 1e-16 over the geometry grid.
+Three consequences follow directly from its coefficients.
+
+**(a) At equal areas D is exactly LINEAR.** `psi = 1` kills the quadratic term:
+`D = q (1.5 - 2c) + 0.5`. So the operating point is unique for every
+equal-area geometry, at every q, with no appeal to numerics.
+
+**(b) At unequal areas D is a cup whose vertex sits inside the range**, so
+Bassett's own coefficients are non-monotone there:
+
+| psi | theta | vertex q* | monotone on (0,1)? |
+|---|---|---|---|
+| 1 | any | linear | yes |
+| 2 | 45 | 0.304 | no |
+| 3 | 45 | 0.218 | no |
+| 4 | 45 | 0.172 | no |
+| 3.333 | 90 | 0.052 | no |
+| 10 | 90 | 0.031 | no |
+
+Forcing monotonicity would contradict the source. It is not a defect to fix.
+
+**(c) Non-monotone does not mean two operating points.** For a target
+`D_t = D(q_t)` the second root is the mirror about the vertex,
+`q_2 = 2 q* - q_t`, which is physical only when `0 < 2 q* - q_t < 1`. Counted
+over every separating point in the dataset, with Bassett's own coefficients:
+
+| verdict | points | share |
+|---|---|---|
+| unique -- psi = 1, D linear | 86 | 81.9% |
+| unique -- mirror outside [0,1] | 9 | 8.6% |
+| genuinely two roots | 10 | 9.5% |
+
+**90.5% of the dataset has a unique physical operating point.** The 10 that do
+not are all psi=3, theta=45 at q_t < 0.436.
+
+### The model's multiplicity is in the wrong place
+
+Every two-root case measured in Finding 2 was at **psi = 1**, where the physics
+is provably unique. The model manufactures an extremum where Bassett has a
+straight line:
+
+| psi=1 | Bassett D | model D |
+|---|---|---|
+| theta=45 | linear, slope -0.163 | monotone, slope -0.7 to -2.9, goes negative |
+| theta=90 | linear, slope +0.735 | hump, turning at q=0.30 |
+| theta=120 | linear, slope +1.500 | hump, turning at q=0.50 |
+
+Mynard's energy-transfer factor is implicated but is not the whole story:
+`eta_scale=0` removes the hump at theta=90, and at theta=120 it leaves `D`
+essentially flat (1.000 to 0.994) where Bassett rises from 0.5 to 1.925. The
+equal-area defect is structural, not a mis-tuned constant.
+
+### The reformulation that IS available, and it is exact
+
+Not "force monotonicity" but **"reproduce the analytical identity the source
+already gives you"**:
+
+    at psi = 1:   K_lateral(q) - K_straight(q) = q (1.5 - 2 cos(0.75 theta)) + 0.5
+
+Linear in q, with a slope and intercept fixed by geometry alone. That is a
+sharper acceptance criterion for #272 than any error metric: a structural
+identity the model must satisfy exactly in the equal-area limit, currently
+violated in both slope and shape. It also disposes of the spurious multiplicity
+by construction, since a linear D cannot have two roots.
+
+### What selects the root where multiplicity is genuine
+
+Not monotonicity. Stability. Quasi-steady momentum on the two legs, with the
+split as the only freedom (m_com fixed, both outlet Pt fixed):
+
+    2 L d(m_lat)/dt = (Pt_str - Pt_bra) - D(q) Q
+
+Perturbing about a root gives `d(dq)/dt = -Q D'(q) dq / (2 L m_com)`, so
+
+    a root is dynamically stable iff D'(q) > 0.
+
+Checked on every two-root case measured: exactly one root has `D' > 0`.
+
+| psi | theta | q_t | roots | D' at each | stable |
+|---|---|---|---|---|---|
+| 1 | 120 | 0.406 | 0.055, 0.935 | +1.87, -2.08 | 0.055 |
+| 1 | 120 | 0.490 | 0.135, 0.865 | +1.54, -1.51 | 0.135 |
+| 1 | 120 | 0.637 | 0.325, 0.675 | +0.75, -0.70 | 0.325 |
+
+`D'` is already available analytically inside the element -- it is what the
+Jacobian carries -- so this costs nothing to evaluate. It is the principled
+form of defect 10's "reject roots that are not physical", and it is a stronger
+criterion than the present minimum-flow test because it rests on a stability
+argument rather than a threshold.
+
+**Caveat, stated because it bounds the claim.** The argument is quasi-steady
+and one-dimensional, and it says a pressure-driven tee cannot sit on the
+falling branch. Bassett measured those low-q points in a flow-controlled rig,
+where the split is imposed and stability does not select, so there is no
+conflict with the data. The criterion applies to pressure-driven networks, not
+to the validation of the coefficients themselves.
+
 ## What this changes
 
 - The 26 unrescued solves are no longer a mystery: most are infeasible, and
   the infeasibility measures the `K_straight` gap.
-- #272 gains a second motivation independent of accuracy: uniqueness of the
-  operating point.
+- #272 gains a sharper acceptance criterion than any error metric: the
+  equal-area identity in Finding 6, which the model currently violates in both
+  slope and shape.
 - The step-3 C++ port gate must not be "reproduce the `three_pb` K table" --
   that table is reproducible by any model at all.
 - `verify_solution_consistent` needs a minimum-flow criterion, not an

--- a/python/tests/test_junction_coefficient_difference.py
+++ b/python/tests/test_junction_coefficient_difference.py
@@ -1,0 +1,129 @@
+"""The structure of D(q) = K_lateral - K_straight, and what it settles.
+
+The pressure-driven topologies constrain this difference, not the two
+coefficients separately, so its shape decides whether an operating point
+exists and whether it is unique (issue #271, record in
+docs/archive/JUNCTION_OPERATING_POINT_271.md Finding 6).
+
+Bassett's separating pair has closed forms, so the difference does too:
+
+    K5(q)         = q^2 - 1.5 q + 0.5                       (Eq 15)
+    K6(q,psi,th)  = q^2 psi^2 + 1 - 2 q psi cos(0.75 th)    (Eq 27)
+    D(q)          = q^2 (psi^2 - 1) + q (1.5 - 2 psi c) + 0.5
+
+Two things follow that are worth pinning, because a change to either
+coefficient can silently break them:
+
+* at psi = 1 the quadratic term vanishes and D is LINEAR, so the operating
+  point is unique for every equal-area geometry;
+* at psi != 1 D is a cup, and the second root is the mirror about its vertex,
+  which is physical only for low targets.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from validation.junction.models import bassett2001
+from validation.junction.models.mpce_v2_network import MPCEv2Network
+
+_GEOMS = [(1.0, 45), (1.0, 90), (1.0, 120), (2.0, 45), (3.0, 45), (3.333, 90)]
+
+
+def _D_closed(q: float, psi: float, theta: float) -> float:
+    c = math.cos(0.75 * theta)
+    return q * q * (psi * psi - 1.0) + q * (1.5 - 2.0 * psi * c) + 0.5
+
+
+def _D_bassett(q: float, psi: float, theta: float) -> float:
+    return bassett2001.K6(q, psi, theta) - bassett2001.K5(q)
+
+
+@pytest.mark.parametrize("psi, theta_deg", _GEOMS)
+@pytest.mark.parametrize("q", [0.0, 0.2, 0.5, 0.8, 1.0])
+def test_the_difference_is_the_quadratic_the_analysis_assumes(q, psi, theta_deg):
+    theta = math.radians(theta_deg)
+    assert _D_bassett(q, psi, theta) == pytest.approx(_D_closed(q, psi, theta), abs=1e-12)
+
+
+@pytest.mark.parametrize("theta_deg", [30, 45, 60, 90, 120, 180])
+def test_at_equal_areas_the_difference_is_linear_in_q(theta_deg):
+    """psi = 1 kills the quadratic term, so a pressure-driven equal-area tee
+    has exactly one operating point. 82% of the separating dataset is here."""
+    theta = math.radians(theta_deg)
+    slope = 1.5 - 2.0 * math.cos(0.75 * theta)
+
+    for q in (0.0, 0.25, 0.5, 0.75, 1.0):
+        assert _D_bassett(q, 1.0, theta) == pytest.approx(0.5 + slope * q, abs=1e-12)
+
+
+@pytest.mark.parametrize(
+    "psi, theta_deg, expected_vertex",
+    [(2.0, 45, 0.304), (3.0, 45, 0.218), (4.0, 45, 0.172), (3.333, 90, 0.052)],
+)
+def test_at_unequal_areas_the_vertex_is_inside_the_operating_range(psi, theta_deg, expected_vertex):
+    """So Bassett's own difference is NOT monotone there. Monotonicity is not a
+    property of the physics and cannot be an objective for the model."""
+    theta = math.radians(theta_deg)
+    a = psi * psi - 1.0
+    b = 1.5 - 2.0 * psi * math.cos(0.75 * theta)
+    vertex = -b / (2.0 * a)
+
+    assert vertex == pytest.approx(expected_vertex, abs=0.001)
+    assert 0.0 < vertex < 1.0
+    assert _D_bassett(vertex, psi, theta) < min(
+        _D_bassett(0.0, psi, theta), _D_bassett(1.0, psi, theta)
+    )
+
+
+@pytest.mark.parametrize("q_t, has_second_root", [(0.2, True), (0.4, True), (0.6, False)])
+def test_the_second_operating_point_is_the_mirror_about_the_vertex(q_t, has_second_root):
+    """psi=3, theta=45: vertex 0.218, so a second physical root needs
+    q_t < 0.436. Ten of the 105 separating dataset points qualify; the rest
+    have a unique operating point under the true coefficients.
+    """
+    psi, theta = 3.0, math.radians(45.0)
+    a = psi * psi - 1.0
+    b = 1.5 - 2.0 * psi * math.cos(0.75 * theta)
+    q2 = -b / a - q_t
+
+    assert (0.0 < q2 < 1.0) is has_second_root
+    if has_second_root:
+        assert _D_bassett(q2, psi, theta) == pytest.approx(_D_bassett(q_t, psi, theta), abs=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# The target for #272
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "The model does not reproduce the equal-area identity "
+        "D(q) = q (1.5 - 2 cos(0.75 theta)) + 0.5. At theta=45 its slope is "
+        "-0.7 to -2.9 against a required -0.163 and D goes negative; at "
+        "theta=90 and 120 it puts a HUMP where the source has a straight line, "
+        "which manufactures a second operating point in the 82% of the dataset "
+        "where the physics has exactly one. This is the sharpest available "
+        "acceptance criterion for the K_straight work (#272): an exact "
+        "identity, not an error metric. It comes off when the model satisfies "
+        "it in the equal-area limit."
+    ),
+)
+@pytest.mark.parametrize("theta_deg", [45, 90, 120])
+def test_model_reproduces_the_equal_area_identity(theta_deg):
+    theta = math.radians(theta_deg)
+    slope = 1.5 - 2.0 * math.cos(0.75 * theta)
+    model = MPCEv2Network(strict=False)
+
+    got = []
+    for q in (0.2, 0.5, 0.8):
+        r = model.evaluate_network("bassett2001", "K6", q, 1.0, theta)
+        assert r.converged, r.message
+        got.append(r.K_lateral - r.K_straight)
+
+    for q, d in zip((0.2, 0.5, 0.8), got, strict=True):
+        assert d == pytest.approx(0.5 + slope * q, abs=0.05)

--- a/validation/junction/MPCE_CPP_PORT_DESIGN.md
+++ b/validation/junction/MPCE_CPP_PORT_DESIGN.md
@@ -341,8 +341,12 @@ the port can be gated on:
    at the **achieved** q is the missing instrument.
 3. **Where the BC set is feasible it often has two roots**, both exactly
    reproducing the model at their own q, with the initial guess deciding.
-   Uniqueness is a property of `K_lat - K_str` being monotonic, i.e. of
-   #272, not of the solver.
+   Uniqueness is NOT a matter of making `K_lat - K_str` monotonic: it is a
+   quadratic whose vertex lies inside (0,1) for every unequal-area geometry,
+   so Bassett's own is not monotone either. Where multiplicity is genuine the
+   selector is stability (`D' > 0`), and at equal areas -- 82% of the dataset
+   -- Bassett's `D` is exactly linear and the model's multiplicity is
+   spurious. Finding 6 of [JUNCTION_OPERATING_POINT_271.md].
 
 Consequences for sec 8: the step-4 gate cannot include "reproduce the
 `three_pb` K table", and the `mfb_two_pb` table is only meaningful once K is
@@ -353,8 +357,12 @@ scored at the achieved q.
 **Second motivation, added 2026-09-05:** `K_straight`'s size at low q also
 decides whether the pressure-driven problem has a unique solution. The
 model's `K_lat - K_str` is U-shaped, which makes low-q targets infeasible
-and mid-range targets doubly-rooted. A monotonic difference leaves one
-operating point. See [JUNCTION_OPERATING_POINT_271.md].
+and mid-range targets doubly-rooted. The acceptance criterion this yields is
+an exact identity, not an error metric: at `psi = 1` the source gives
+`K_lateral - K_straight = q (1.5 - 2 cos(0.75 theta)) + 0.5`, linear in q with
+slope and intercept fixed by geometry. The model violates it in both slope and
+shape, and satisfying it also removes the spurious multiplicity seen at equal
+areas. Finding 6 of [JUNCTION_OPERATING_POINT_271.md].
 
 Three independent sources say **negative `K_straight` in dividing flow is real
 physics**, not a solver artefact:
@@ -437,7 +445,7 @@ Consequences:
 | 7 | Bassett K4/K7/K8/K9 unscored | sec 6 | add a type-4 joining builder and a K4 separating case to the adapter | medium |
 | 8 | ~~`three_pb`'s K score is a tautology (sec 4e)~~ **fixed** | `eta_scale=3.0` still reproduces the q=0.8 target to 0.05% | **done.** `_K_SCORING_TOPOLOGIES` excludes it; the scorecard prints `taut`, not a dash. The perturbation is pinned in `test_junction_score_at_achieved_q.py` | done |
 | 9 | ~~K is scored at the TARGET q while the solve sits at the achieved q~~ **fixed** | drift: `three_pb` median 0.134; `mfb_two_pb` 12.6% of rows > 0.25 | **done.** `q_converged` populated and printed as `dq`; K scored on the measured curve at the achieved q (interpolation error floor measured leave-one-out: median 0.030, p90 0.175); off-curve records excluded, off-point records counted separately so the coverage loss stays visible. `imposed_q` unchanged to the digit | done |
-| 10 | `verify_solution_consistent` passes near-degenerate roots | a root at q=0.0102 (lateral leg at 1% of the flow) is reported as a success; its only criterion is `m_dot > 1e-6` | add a minimum-flow-fraction criterion | small |
+| 10 | `verify_solution_consistent` passes near-degenerate roots; the principled criterion is stability, `D' > 0` (Finding 6) | a root at q=0.0102 (lateral leg at 1% of the flow) is reported as a success; its only criterion is `m_dot > 1e-6` | add a minimum-flow-fraction criterion | small |
 | 11 | `analytical_pt_prop` seeds no mass flow through `LosslessConnectionElement` | x0 violates continuity at every junction (0.1 in, 0.2 out); a junction-aware mass-conserving seed gains ~70 solves | extend the seed, but land it WITH item 9 -- it moves 22 already-converged roots between the two legitimate branches | medium |
 | 12 | ~~Solver results depend on `PYTHONHASHSEED`~~ **fixed** | `_propagate_pressure_guess` seeds its BFS from `list(set(p_guess.keys()))`; the same case converges in 5 of 10 identical processes, and is deterministic per fixed hash seed | **done.** `queue = list(p_guess.keys())`; scorecard identical (1700/2073) under seeds 0/1/7/13, against 1700 or 1711 before | done |
 


### PR DESCRIPTION
**Question:** if the coefficients need to be monotone for the pressure-driven problem to have a unique solution, can they be reformulated analytically to force it?

**Answer:** no, and they should not be. This also corrects a claim I put in the record two days ago.

## D is a quadratic, in closed form

Bassett's separating pair (Eq 15, Eq 27) gives

```
D(q) = K_lateral - K_straight = q^2 (psi^2 - 1) + q (1.5 - 2 psi cos(0.75 th)) + 0.5
```

verified against the functions to 1e-12. Everything below is read off its coefficients rather than sampled.

- **At psi = 1 the quadratic term vanishes.** D is linear, so an equal-area tee has exactly one operating point at every q.
- **At psi != 1 it is a cup whose vertex sits inside (0,1)** for every unequal-area geometry in the dataset (0.304 at psi=2, 0.218 at psi=3, 0.172 at psi=4, 0.052 at psi=3.333/th=90). **Bassett's own D is non-monotone.** Forcing monotonicity would contradict the source.
- **Non-monotone does not imply two operating points.** The second root is the mirror about the vertex, `q2 = 2 q* - q_t`, physical only when it lands in (0,1).

| verdict, over all 105 separating dataset points | points | share |
|---|---|---|
| unique -- psi = 1, D linear | 86 | 81.9% |
| unique -- mirror outside [0,1] | 9 | 8.6% |
| genuinely two roots | 10 | 9.5% |

## Withdrawn: "a monotonic D would leave one operating point"

Recorded on 2026-09-05 and offered to #272 as a second motivation. Monotonicity is not available to aim at. What fixing the model delivers is feasibility everywhere, plus removal of a **spurious** multiplicity, which is the more interesting half.

## The model's multiplicity is in the wrong place

Every two-root case measured earlier was at **psi = 1**, where the physics is provably unique. The model puts an extremum where Bassett has a straight line:

| psi=1 | Bassett D | model D |
|---|---|---|
| th=45 | linear, slope -0.163 | monotone, slope -0.7 to -2.9, goes negative |
| th=90 | linear, slope +0.735 | hump, turning at q=0.30 |
| th=120 | linear, slope +1.500 | hump, turning at q=0.50 |

Mynard's eta is implicated but is not the whole story: `eta_scale=0` removes the hump at th=90, and at th=120 leaves D essentially flat (1.000 to 0.994) where Bassett rises 0.5 to 1.925. The equal-area defect is structural.

## The reformulation that IS available, and it is exact

Not "force monotonicity" but **"reproduce the identity the source already gives you"**:

```
at psi = 1:   K_lateral(q) - K_straight(q) = q (1.5 - 2 cos(0.75 theta)) + 0.5
```

Linear, slope and intercept fixed by geometry alone. A sharper acceptance criterion for #272 than any error metric, currently violated in both slope and shape, and satisfying it removes the spurious multiplicity by construction. Pinned as a strict xfail.

## Where multiplicity is genuine, stability selects the root

Quasi-steady momentum on the two legs with the split as the only freedom gives `d(dq)/dt = -Q D'(q) dq / (2 L m_com)`, so **a root is stable iff D'(q) > 0**. Checked on every two-root case, exactly one qualifies:

| psi | th | q_t | roots | D' at each | stable |
|---|---|---|---|---|---|
| 1 | 120 | 0.406 | 0.055, 0.935 | +1.87, -2.08 | 0.055 |
| 1 | 120 | 0.490 | 0.135, 0.865 | +1.54, -1.51 | 0.135 |
| 1 | 120 | 0.637 | 0.325, 0.675 | +0.75, -0.70 | 0.325 |

`D'` is what the Jacobian already carries, so this is free to evaluate, and it is the principled form of **defect 10**, resting on a stability argument rather than a threshold.

**Caveat, stated because it bounds the claim:** the argument is quasi-steady and 1D, and says a pressure-driven tee cannot sit on the falling branch. Bassett measured those low-q points under flow control, where the split is imposed and stability does not select, so there is no conflict with the data.

Suite 2113 passed, 11 xfailed. No CHANGELOG entry: docs, validation records and tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RNDxZouiHoJdaLpnnPjHq
