### PR TITLE
fix(solver): give junctions a mass-conserving, pressure-informed start (#271 step 5a, item 11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **The initial guess at a junction now conserves mass and follows the
+  boundary pressures.** `NetworkSolver`'s `analytical_pt_prop` seeding applied
+  its Bernoulli mass-flow estimate only to `ChannelElement`, and junctions are
+  wired with `LosslessConnectionElement`, so every junction port fell back to
+  the flat reference flow: on a three-port junction that is 0.1 kg/s in against
+  0.2 kg/s out, with a 1:1 split whatever the boundary pressures say. The split
+  is now a Bernoulli share of the propagated port pressure differences,
+  rescaled so continuity holds exactly at the start with every port in its
+  declared direction. The total still comes from the existing topological
+  propagator, so an upstream `MassFlowBoundary` continues to set the level and
+  no new flow-scale heuristic is introduced. On the junction validation
+  scorecard, solves rejected as landing on a physically inadmissible or
+  artifact root fall from 227 to 163, and convergence rises from 1625 to 1732
+  of 2073, with accuracy unchanged on the records scored under both. The seed
+  is opt-in per element class through `seeds_ports_by_pressure_split`, which
+  `EjectorElement` sets to false: its port flows follow choking and entrainment
+  rather than a pressure split, and it carries its own warm start. Networks
+  with more than one admissible operating mode may now report a different one
+  than before; see `docs/archive/JUNCTION_OPERATING_POINT_271.md`.
+
 - **`MPCEv2Element` now rejects converged states in which the junction would
   create flow work.** Its post-solve `verify_solution_consistent` checked only
   that port flows kept their declared direction; `MultiPortChamberElement` (v1)

--- a/docs/archive/JUNCTION_OPERATING_POINT_271.md
+++ b/docs/archive/JUNCTION_OPERATING_POINT_271.md
@@ -274,12 +274,10 @@ at x0 with every port on its declared side.
 
 `imposed_q` is untouched, as expected: the flows are boundary conditions there.
 
-**It is not answer-neutral.** It moves 22 already-converged roots, because of
-Finding 1 -- both roots exist and the seed selects one. On psi=1, theta=90,
-q=0.701 that selection is an improvement (q=0.60 instead of a near-degenerate
-q=0.0102), but "improvement" is a judgement the harness cannot currently make,
-which is why the seed change must land **with** operating-point reporting, not
-before it.
+**It is not answer-neutral.** It moves already-converged roots, because of
+Finding 1 -- both roots exist and the seed selects one. That is why it landed
+last, after the operating-point reporting and the energy check were in place to
+judge the difference. The re-measurement with all of that present is Finding 8.
 
 The baseline also moved between runs (1700 and 1711 on identical inputs).
 That is Finding 5 below, not noise in the measurement of the seed: both seeds
@@ -527,6 +525,75 @@ positive mixing term that is not counted, so on a strongly non-isothermal
 junction the check is conservative in the wrong direction. The element is
 documented for low Mach and the fixtures are isothermal, so the case does not
 arise today; it is recorded at the method.
+
+## Finding 8: what the seed is actually worth, measured with the instruments in place
+
+Re-measured after items 8, 9 and 10 landed, which changed the baseline from
+1700 to 1625 and gave the harness three things the first prototype lacked: the
+achieved operating point, the off-point count, and the energy gate.
+
+| | seed off | seed on |
+|---|---|---|
+| converged | 1625 | **1732** |
+| rejected as inadmissible or artifact | 227 | **163** |
+| on-point evidence | 1243 | 1254 |
+| RMSE on the common subset, `imposed_q` | 0.7664 | 0.7664 |
+| RMSE on the common subset, `mfb_two_pb` | 0.7845 | 0.7844 |
+
+**Read the middle row first.** The seed's real effect is not "+107 rows": it is
+that 89 solves which previously landed on an inadmissible or artifact root now
+land on an admissible one, against 20 pushed the other way. That is the
+"steer away from non-physical branches" objective, and it is only visible
+because the energy check of item 10 exists to name those roots.
+
+**The convergence count on its own would have flattered it.** Of the 153 rows
+gained, 21 are on-point and 131 are not; 47 rows are lost, 11 of them on-point.
+Net evidence at the requested operating points is +11 on 2073 records. Anyone
+quoting the +107 as the benefit is quoting mostly off-point rows.
+
+**Accuracy is unchanged.** On the records scored under both seeds, RMSE and
+bias agree to four decimals. A first pass compared full populations and showed
+`mfb_two_pb` RMSE rising 0.7806 to 0.7884, which was a population effect from
+the 36 extra rows, not a degradation -- the common-subset comparison is the
+one that answers the question.
+
+**One earlier claim is withdrawn.** The prototype note said the seed "selects
+the intended operating point" on at least one case, generalising from six
+moved roots of which five landed nearer the target. Measured across every
+record converged under both seeds, it is a wash: `three_pb` median drift 0.0949
+to 0.0944 with 167 nearer and 195 further; `mfb_two_pb` 0.0001 to 0.0001 with
+231 nearer and 205 further. **The seed does not steer toward the requested q.**
+It steers toward admissible roots, which is a different and better thing.
+
+### Two things it broke, and what they turned out to mean
+
+**The ejector.** `EjectorElement` extends `MultiPortChamberElement`, so a
+blanket junction seed reached it and overwrote the physics-based warm start it
+carries for its own port pressures and `P_jct`. The cold reference network in
+`test_gui_ejector.py` stopped converging. The seed is now opt-in through a
+class attribute, `seeds_ports_by_pressure_split`, true on the chamber junction
+and false on the ejector, because an ejector's port flows follow choking and
+entrainment rather than a Bernoulli share of the imposed pressure difference.
+
+**A bistable production fixture.** `_three_port_net` in
+`test_multi_port_chamber.py` has three pressure boundaries at 2.10, 2.05 and
+2.00 bar with friction in every channel. Two flow arrangements satisfy it:
+
+| mode | common port | straight port | branch port |
+|---|---|---|---|
+| dividing (seed on) | in, 0.450 | **out**, 0.379 | out, 0.071 |
+| ejector (seed off) | in, 0.358 | **in**, 0.211 | out, 0.569 |
+
+Both conserve mass, both are net dissipative, both pass the v1 energy check,
+and both are consistent with the boundary pressures -- in the second the 2.05
+bar boundary also feeds the junction. The seed reaches the first directly; the
+plain cold start reaches the mirror root, is demoted, and the auto-retry
+reaches the second. **Nothing available says which is "the" answer**, so the
+bistability is now pinned as a test rather than resolved, and the two solver
+machinery tests that depended on the old path force it explicitly instead of
+being weakened.
+
+The change is deterministic: 1732 under hash seeds 0, 1 and 7.
 
 ## What this changes
 

--- a/python/combaero/network/components.py
+++ b/python/combaero/network/components.py
@@ -3279,6 +3279,13 @@ class MultiPortChamberElement(NetworkElement):
     inability to represent ejector / merge-split direction natively).
     """
 
+    # Opt-in for the solver's junction split seed (`_junction_split_guess`).
+    # True here because a chamber junction's port flows DO follow a Bernoulli
+    # share of the imposed port pressure differences, which is what that seed
+    # assumes. Subclasses whose port flows are set by their own internal
+    # physics must turn it off -- see `EjectorElement`.
+    seeds_ports_by_pressure_split: bool = True
+
     def __init__(
         self,
         id: str,

--- a/python/combaero/network/ejector_element.py
+++ b/python/combaero/network/ejector_element.py
@@ -143,6 +143,13 @@ class EjectorElement(MultiPortChamberElement):
     1 outlet. Critical (double-choked), subcritical, and unchoked-primary
     (subsonic jet-pump) in one C1 residual system."""
 
+    # The ejector's port flows follow choking and entrainment, not a Bernoulli
+    # share of the imposed pressure differences, and it carries its own
+    # physics-based warm start for the port pressures and P_jct. The solver's
+    # junction split seed would overwrite that with a split the ejector does
+    # not obey, and the cold reference network then fails to converge.
+    seeds_ports_by_pressure_split: bool = False
+
     def __init__(
         self,
         id: str,

--- a/python/combaero/network/solver.py
+++ b/python/combaero/network/solver.py
@@ -511,7 +511,77 @@ class NetworkSolver:
                 if pt is None:
                     continue
                 overrides[f"{elem_id}.P_jct"] = pt
+                if getattr(elem, "seeds_ports_by_pressure_split", False):
+                    overrides.update(
+                        self._junction_split_guess(elem, common, p_guess, rho_ref, ref)
+                    )
         return overrides
+
+    def _junction_split_guess(
+        self,
+        elem: Any,
+        common: str,
+        p_guess: dict[str, float],
+        rho_ref: float,
+        ref: dict[str, Any],
+    ) -> dict[str, float]:
+        """Seed a junction's port flows so x0 conserves mass and reflects the
+        imposed pressures.
+
+        The Bernoulli seed above only reaches `ChannelElement`. Junctions in
+        both the validation harness and `gui/backend/graph_builder.py` are
+        wired with `LosslessConnectionElement`, which got nothing, so every
+        port fell back to the flat reference flow: on a three-port junction
+        that is 0.1 kg/s in against 0.2 kg/s out, with a 1:1 split whatever the
+        boundary pressures say (issue #271, defect 11).
+
+        What this changes is only the SPLIT and the CONTINUITY. The total is
+        taken from whatever the topological propagator already put on the
+        common port's element, so no new flow-scale heuristic is introduced
+        and a MassFlowBoundary upstream still sets the level. The non-common
+        ports are then given a Bernoulli share of that total,
+        ``A_i * sqrt(2 rho dPt_i)``, normalised to sum to it -- and every port
+        is seeded in its own canonical direction, since the sign mapping
+        ``port_mdots[i] = port_signs[i] * outer_mdot[i]`` makes a positive
+        outer flow the correct direction at that port.
+
+        Ports whose imposed pressure difference is unknown or zero fall back
+        to an area-weighted share, which is the incompressible answer when
+        nothing distinguishes them.
+        """
+        port_nodes = list(getattr(elem, "port_nodes", []))
+        port_elems = list(getattr(elem, "_port_element_ids", []))
+        if len(port_nodes) != len(port_elems) or common not in port_nodes:
+            return {}
+        areas = list(getattr(elem, "port_areas", [])) or [1.0] * len(port_nodes)
+        if len(areas) != len(port_nodes):
+            return {}
+
+        common_i = port_nodes.index(common)
+        pt_com = p_guess[common]
+        mdot_guess = self._propagate_mdot_guess(ref)
+        total = abs(float(mdot_guess.get(port_elems[common_i], ref["m_dot"])))
+        if total <= 0.0:
+            return {}
+
+        others = [i for i in range(len(port_nodes)) if i != common_i]
+        shares = []
+        for i in others:
+            pt_i = p_guess.get(port_nodes[i])
+            dpt = 0.0 if pt_i is None else abs(pt_com - pt_i)
+            area = abs(float(areas[i])) or 1.0
+            shares.append(area * math.sqrt(2.0 * rho_ref * dpt) if dpt > 0.0 else 0.0)
+        if sum(shares) <= 0.0:
+            shares = [abs(float(areas[i])) or 1.0 for i in others]
+
+        scale = total / sum(shares)
+        out: dict[str, float] = {}
+        if port_elems[common_i]:
+            out[f"{port_elems[common_i]}.m_dot"] = total
+        for i, share in zip(others, shares, strict=True):
+            if port_elems[i]:
+                out[f"{port_elems[i]}.m_dot"] = share * scale
+        return out
 
     def _build_x0(self) -> np.ndarray:
         """

--- a/python/tests/test_junction_score_at_achieved_q.py
+++ b/python/tests/test_junction_score_at_achieved_q.py
@@ -50,12 +50,18 @@ def model():
 def test_three_pb_K_is_the_imposed_target_whatever_the_model_does():
     """A deliberately wrong model must still reproduce three_pb's target.
 
-    eta_scale=3.0 triples Mynard's energy-transfer factor. It moves the model's
-    own answer (imposed_q) by more than 6%. If three_pb's K moved with it, the
+    ``eta_scale=0.5`` halves Mynard's energy-transfer factor, moving the
+    model's own answer (imposed_q) by 0.045. If three_pb's K moved with it, the
     topology would be scoring the model and the exclusion below would be wrong.
+
+    The perturbation used to be ``eta_scale=3.0``, which moves the model four
+    times further. It no longer serves: since the energy check of defect 10,
+    the tripled model is inadmissible in three_pb at every q and is rejected
+    before a K can be extracted. A perturbation has to stay inside the physics
+    to demonstrate anything, which is why this one is milder.
     """
     honest = MPCEv2Network(strict=False)
-    wrong = MPCEv2Network(strict=False, eta_scale=3.0)
+    wrong = MPCEv2Network(strict=False, eta_scale=0.5)
     q = 0.8
     target = bassett2001.K6(q, _PSI, _THETA)
 
@@ -63,13 +69,13 @@ def test_three_pb_K_is_the_imposed_target_whatever_the_model_does():
     wrong_imposed = wrong.evaluate_network("bassett2001", "K6", q, _PSI, _THETA)
     assert honest_imposed.converged and wrong_imposed.converged
     moved = abs(wrong_imposed.K_lateral - honest_imposed.K_lateral)
-    assert moved > 0.15, f"the perturbation must actually change the model: moved only {moved:.4f}"
+    assert moved > 0.03, f"the perturbation must actually change the model: moved only {moved:.4f}"
 
     wrong_three_pb = wrong.evaluate_network(
         "bassett2001", "K6", q, _PSI, _THETA, topology="three_pb"
     )
-    assert wrong_three_pb.converged
-    assert wrong_three_pb.K_lateral == pytest.approx(target, abs=0.01), (
+    assert wrong_three_pb.converged, wrong_three_pb.message
+    assert abs(wrong_three_pb.K_lateral - target) < 0.25 * moved, (
         "three_pb no longer reproduces the target from a wrong model -- if this "
         "fails, the topology has become informative and the exclusion in "
         "_K_SCORING_TOPOLOGIES should be revisited, not deleted"

--- a/python/tests/test_junction_split_seed.py
+++ b/python/tests/test_junction_split_seed.py
@@ -1,0 +1,217 @@
+"""The initial guess at a junction must conserve mass and follow the pressures.
+
+`analytical_pt_prop`'s Bernoulli mass-flow seed only reached `ChannelElement`.
+Junctions in both the validation harness and `gui/backend/graph_builder.py` are
+wired with `LosslessConnectionElement`, which got nothing, so every port fell
+back to the flat reference flow: on a three-port junction that is 0.1 kg/s in
+against 0.2 kg/s out, with a 1:1 split whatever the boundary pressures say
+(issue #271, defect 11).
+
+Measured effect on the junction scorecard, seed off then on:
+
+    converged                    1625 -> 1732
+    rejected as inadmissible      227 ->  163
+    on-point evidence            1243 -> 1254
+    RMSE on the common subset   unchanged to four decimals
+
+The seed is opt-in per element class, because a junction subclass whose port
+flows follow its own internal physics must not have them overwritten -- see
+`EjectorElement`.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+import combaero as cb
+from combaero.network import (
+    ChannelElement,
+    FlowNetwork,
+    LosslessConnectionElement,
+    MomentumChamberNode,
+    NetworkSolver,
+    PressureBoundary,
+)
+from combaero.network.components import MultiPortChamberElement
+from combaero.network.ejector_element import EjectorElement
+from combaero.network.mpce_v2_element import MPCEv2Element
+
+_Y = list(cb.mole_to_mass(cb.species.dry_air()))
+_A = 0.01
+
+
+def _net(pt_str: float, pt_bra: float, area_bra: float = _A) -> FlowNetwork:
+    """Common inlet at 1 bar, two pressure-driven outlets."""
+    net = FlowNetwork()
+    net.add_node(PressureBoundary("pb_in", Pt=1.0e5, Tt=300.0, Y=_Y))
+    net.add_node(PressureBoundary("pb_str", Pt=pt_str, Tt=300.0, Y=_Y))
+    net.add_node(PressureBoundary("pb_bra", Pt=pt_bra, Tt=300.0, Y=_Y))
+    net.add_node(MomentumChamberNode("port_com", area=_A))
+    net.add_node(MomentumChamberNode("port_str", area=_A))
+    net.add_node(MomentumChamberNode("port_bra", area=area_bra))
+    net.add_element(LosslessConnectionElement("lc_com", "pb_in", "port_com"))
+    net.add_element(LosslessConnectionElement("lc_str", "port_str", "pb_str"))
+    net.add_element(LosslessConnectionElement("lc_bra", "port_bra", "pb_bra"))
+    net.add_element(
+        MPCEv2Element(
+            id="jct",
+            inlet_nodes=["port_com"],
+            outlet_nodes=["port_str", "port_bra"],
+            inlet_angles_deg=[0.0],
+            outlet_angles_deg=[0.0, 45.0],
+            port_areas=[_A, _A, area_bra],
+            flow_direction="branch",
+            strict=False,
+        )
+    )
+    return net
+
+
+def _x0(net: FlowNetwork) -> dict[str, float]:
+    solver = NetworkSolver(net)
+    solver.network.resolve_all_topology()
+    solver.network.validate()
+    ref = solver._infer_reference_state()
+    solver._init_overrides = solver._propagate_analytical_pt_prop(ref)
+    x0 = solver._build_x0()
+    return dict(zip(solver.unknown_names, x0, strict=True))
+
+
+def test_the_start_state_conserves_mass_at_the_junction():
+    """The defect itself: 0.1 kg/s in against 0.2 kg/s out."""
+    x0 = _x0(_net(pt_str=99_980.0, pt_bra=99_950.0))
+
+    m_in = x0["lc_com.m_dot"]
+    m_out = x0["lc_str.m_dot"] + x0["lc_bra.m_dot"]
+    assert m_out == pytest.approx(m_in, rel=1e-9), (
+        f"x0 leaks {m_out - m_in:.4g} kg/s at the junction"
+    )
+
+
+def test_the_start_split_follows_the_propagated_pressures():
+    """The leg with the larger propagated pressure drop gets the larger seed,
+    in the Bernoulli ratio sqrt(dPt_bra / dPt_str).
+
+    Against the PROPAGATED differences, not the boundary ones: the seed reads
+    `_propagate_pressure_guess`, which walks outward from the boundaries with a
+    uniform step, so the port-face estimates are not the boundary values. That
+    is the contract being pinned -- the seed uses the best pressure estimate
+    available at x0, whatever the propagator's own accuracy.
+    """
+    net = _net(pt_str=99_990.0, pt_bra=99_960.0)
+    solver = NetworkSolver(net)
+    solver.network.resolve_all_topology()
+    solver.network.validate()
+    p_guess = solver._propagate_pressure_guess(solver._infer_reference_state())
+    d_str = abs(p_guess["port_com"] - p_guess["port_str"])
+    d_bra = abs(p_guess["port_com"] - p_guess["port_bra"])
+    assert d_str > 0.0 and d_bra > d_str, "fixture must give the legs different drops"
+
+    x0 = _x0(net)
+
+    ratio = x0["lc_bra.m_dot"] / x0["lc_str.m_dot"]
+    assert ratio == pytest.approx(math.sqrt(d_bra / d_str), rel=1e-6)
+
+
+def test_equal_pressures_fall_back_to_an_area_weighted_split():
+    """With nothing to distinguish the legs, area is the incompressible
+    answer -- not a 1:1 split between unequal areas."""
+    x0 = _x0(_net(pt_str=99_970.0, pt_bra=99_970.0, area_bra=_A / 3.0))
+
+    ratio = x0["lc_bra.m_dot"] / x0["lc_str.m_dot"]
+    assert ratio == pytest.approx(1.0 / 3.0, rel=1e-6)
+
+
+def test_every_port_is_seeded_in_its_own_canonical_direction():
+    """`port_mdots[i] = port_signs[i] * outer_mdot[i]`, so a positive outer
+    flow is the correct direction at that port. A negative seed would start
+    Newton inside the soft-barrier region."""
+    x0 = _x0(_net(pt_str=99_980.0, pt_bra=99_950.0))
+
+    for key in ("lc_com.m_dot", "lc_str.m_dot", "lc_bra.m_dot"):
+        assert x0[key] > 0.0, f"{key} seeded against its declared direction"
+
+
+def test_the_total_comes_from_the_existing_propagator():
+    """The seed fixes the SPLIT and the CONTINUITY; it introduces no new
+    flow-scale heuristic, so the level still comes from whatever the
+    topological propagator put on the common port."""
+    net = _net(pt_str=99_980.0, pt_bra=99_950.0)
+    solver = NetworkSolver(net)
+    solver.network.resolve_all_topology()
+    solver.network.validate()
+    ref = solver._infer_reference_state()
+    # `_propagate_mdot_guess` is keyed by ELEMENT ID, not by unknown name.
+    expected = abs(solver._propagate_mdot_guess(ref)["lc_com"])
+
+    assert _x0(net)["lc_com.m_dot"] == pytest.approx(expected, rel=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Opt-in
+# ---------------------------------------------------------------------------
+
+
+def test_the_chamber_junction_opts_in():
+    assert MultiPortChamberElement.seeds_ports_by_pressure_split is True
+    assert MPCEv2Element.seeds_ports_by_pressure_split is True
+
+
+def test_the_ejector_opts_out():
+    """Its port flows follow choking and entrainment, not a Bernoulli share of
+    the imposed pressure differences, and it carries its own warm start. With
+    the seed applied to it the cold reference network in test_gui_ejector.py
+    stops converging.
+    """
+    assert EjectorElement.seeds_ports_by_pressure_split is False
+
+
+def test_an_opted_out_junction_gets_no_port_seeds(monkeypatch):
+    net = _net(pt_str=99_980.0, pt_bra=99_950.0)
+    monkeypatch.setattr(
+        type(net.elements["jct"]), "seeds_ports_by_pressure_split", False, raising=False
+    )
+    x0 = _x0(net)
+
+    # Falls back to the flat reference flow on every port, which is the
+    # pre-fix behaviour and is what the ejector needs left alone.
+    assert x0["lc_str.m_dot"] == pytest.approx(x0["lc_bra.m_dot"])
+
+
+def test_a_channel_wired_junction_still_gets_a_forward_seed():
+    """The pre-existing ChannelElement seed must be untouched: the junction
+    seed adds a case, it does not replace one. Here the straight leg is a
+    channel, so it carries the older Bernoulli override, and the junction seed
+    must not fight it into a reversed start."""
+    net = FlowNetwork()
+    net.add_node(PressureBoundary("pb_in", Pt=1.0e5, Tt=300.0, Y=_Y))
+    net.add_node(PressureBoundary("pb_str", Pt=99_980.0, Tt=300.0, Y=_Y))
+    net.add_node(PressureBoundary("pb_bra", Pt=99_950.0, Tt=300.0, Y=_Y))
+    net.add_node(MomentumChamberNode("port_com", area=_A))
+    net.add_node(MomentumChamberNode("port_str", area=_A))
+    net.add_node(MomentumChamberNode("port_bra", area=_A))
+    net.add_element(LosslessConnectionElement("lc_com", "pb_in", "port_com"))
+    net.add_element(
+        ChannelElement(
+            "lc_str", "port_str", "pb_str", length=0.3, diameter=0.1, regime="incompressible"
+        )
+    )
+    net.add_element(LosslessConnectionElement("lc_bra", "port_bra", "pb_bra"))
+    net.add_element(
+        MPCEv2Element(
+            id="jct",
+            inlet_nodes=["port_com"],
+            outlet_nodes=["port_str", "port_bra"],
+            inlet_angles_deg=[0.0],
+            outlet_angles_deg=[0.0, 45.0],
+            port_areas=[_A, _A, _A],
+            flow_direction="branch",
+            strict=False,
+        )
+    )
+    x0 = _x0(net)
+
+    assert x0["lc_str.m_dot"] > 0.0
+    assert x0["lc_bra.m_dot"] > 0.0

--- a/python/tests/test_multi_port_chamber.py
+++ b/python/tests/test_multi_port_chamber.py
@@ -13,6 +13,7 @@ Hager / Bassett / Perez-Garcia / Wang reference data live in separate files.
 """
 
 import math
+import warnings
 
 import numpy as np
 import pytest
@@ -217,13 +218,23 @@ def test_v1_energy_check_tolerates_near_equal_pt():
     assert jct.verify_solution_consistent(near) is True
 
 
-def test_three_port_default_path_self_heals_from_mirror_root():
+def test_three_port_default_path_self_heals_from_mirror_root(monkeypatch):
     """End-to-end payoff of the v1 energy hook: the plain cold solve on
     this net converges onto the mirror root, the post-solve verification
     demotes it, and the outlet-ref auto-retry then reaches the physical
     ejector root -- success with forward common inflow, no manual
     strategy selection needed.
+
+    The junction split seed (#271 defect 11) is disabled here ON PURPOSE.
+    With it the cold solve no longer visits the mirror root at all: it
+    converges first time onto the OTHER admissible mode of this bistable net,
+    the plain dividing split (see
+    ``test_three_port_net_has_two_admissible_operating_modes``). That is a
+    better outcome, and it would leave the self-heal machinery -- which still
+    runs on other networks -- with no coverage. Forcing the precondition keeps
+    the machinery tested rather than quietly dropping the test.
     """
+    monkeypatch.setattr(NetworkSolver, "_junction_split_guess", lambda self, *a, **k: {})
     net = _three_port_net()
     solver = NetworkSolver(net)
     with pytest.warns(UserWarning):
@@ -244,6 +255,10 @@ def test_stall_wiring_forced_detector(monkeypatch):
     from combaero.network import solver as solver_module
 
     monkeypatch.setattr(solver_module, "_stall_detected", lambda *a, **k: True)
+    # Same reason as the test above: the junction split seed makes this net
+    # converge before the forced stall path decides anything, so the wiring
+    # under test would go unexercised. Disabled to hold the precondition.
+    monkeypatch.setattr(NetworkSolver, "_junction_split_guess", lambda self, *a, **k: {})
     net = _three_port_net()
     solver = NetworkSolver(net)
     with pytest.warns(UserWarning, match="did not converge"):
@@ -383,3 +398,44 @@ def test_border_carnot_loss_element_in_series_with_junction():
     assert abs(m_loss - m_ch_bra) < 1e-6, (
         f"loss/channel series mismatch: m_loss={m_loss}, m_ch_bra={m_ch_bra}"
     )
+
+
+def test_three_port_net_has_two_admissible_operating_modes(monkeypatch):
+    """The net of `_three_port_net` is bistable, and the initial guess picks.
+
+    Boundaries are 2.10 / 2.05 / 2.00 bar with friction in every channel and a
+    lossless junction, and two different flow arrangements satisfy that:
+
+      * the DIVIDING mode, where the 2.10 bar inlet feeds both outlets;
+      * the EJECTOR mode, where the straight boundary at 2.05 bar also feeds
+        the junction and both supply the 2.00 bar branch.
+
+    Both conserve mass, both are net dissipative, both pass the v1 energy
+    check. Found while landing the junction split seed (#271 defect 11), which
+    reaches the first while the plain cold start reaches the second. Neither is
+    an artifact, so nothing here asserts which one is "right" -- this pins that
+    the multiplicity is real, so a future change that collapses it is noticed.
+    """
+
+    def _solve(seeded: bool) -> dict:
+        if not seeded:
+            monkeypatch.setattr(NetworkSolver, "_junction_split_guess", lambda self, *a, **k: {})
+        net = _three_port_net()
+        solver = NetworkSolver(net)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            sol = solver.solve(timeout=120.0)
+        monkeypatch.undo()
+        return sol
+
+    dividing = _solve(seeded=True)
+    ejector = _solve(seeded=False)
+
+    for sol in (dividing, ejector):
+        assert sol["__success__"], sol.get("__message__")
+        assert sol["ch_in.m_dot"] > 0.0, "the common port must draw flow in"
+
+    # The straight port runs the other way between the two modes.
+    assert dividing["ch_str.m_dot"] > 0.0, "dividing mode: straight port is an outlet"
+    assert ejector["ch_str.m_dot"] < 0.0, "ejector mode: straight port feeds the junction"
+    assert dividing["ch_in.m_dot"] != pytest.approx(ejector["ch_in.m_dot"], rel=0.05)

--- a/validation/junction/MPCE_CPP_PORT_DESIGN.md
+++ b/validation/junction/MPCE_CPP_PORT_DESIGN.md
@@ -446,7 +446,7 @@ Consequences:
 | 8 | ~~`three_pb`'s K score is a tautology (sec 4e)~~ **fixed** | `eta_scale=3.0` still reproduces the q=0.8 target to 0.05% | **done.** `_K_SCORING_TOPOLOGIES` excludes it; the scorecard prints `taut`, not a dash. The perturbation is pinned in `test_junction_score_at_achieved_q.py` | done |
 | 9 | ~~K is scored at the TARGET q while the solve sits at the achieved q~~ **fixed** | drift: `three_pb` median 0.134; `mfb_two_pb` 12.6% of rows > 0.25 | **done.** `q_converged` populated and printed as `dq`; K scored on the measured curve at the achieved q (interpolation error floor measured leave-one-out: median 0.030, p90 0.175); off-curve records excluded, off-point records counted separately so the coverage loss stays visible. `imposed_q` unchanged to the digit | done |
 | 10 | ~~`verify_solution_consistent` passes near-degenerate roots~~ **fixed, and the defect was miscast** | the real gap was that v1 has an energy check and v2 had none; a small flow is not unphysical, and landing at one is the coverage question item 9 already measures | **done.** Mass-weighted energy balance `sum_in |m| Pt >= sum_out |m| Pt`, which permits a branch to gain Pt (negative K is real) while forbidding a net gain, and covers joining, which v1's form skips. Audited first: the data satisfies it by +0.19 or better, the MODEL violates it below q ~ 0.2. Costs 75 of 1700 converged records, all of them physically impossible states previously reported as successes | done |
-| 11 | `analytical_pt_prop` seeds no mass flow through `LosslessConnectionElement` | x0 violates continuity at every junction (0.1 in, 0.2 out); a junction-aware mass-conserving seed gains ~70 solves | extend the seed, but land it WITH item 9 -- it moves 22 already-converged roots between the two legitimate branches | medium |
+| 11 | ~~`analytical_pt_prop` seeds no mass flow through `LosslessConnectionElement`~~ **fixed** | x0 violates continuity at every junction (0.1 in, 0.2 out); a junction-aware mass-conserving seed gains ~70 solves | **done.** Split and continuity fixed at x0 from the propagated pressures; the total still comes from the existing propagator, so no new flow-scale heuristic. Opt-in per class (`seeds_ports_by_pressure_split`) because it must not overwrite `EjectorElement`'s own warm start. Rejections as inadmissible/artifact 227 -> 163; converged 1625 -> 1732; accuracy unchanged on the common subset; it does NOT steer toward the requested q (that earlier claim withdrawn) | done |
 | 12 | ~~Solver results depend on `PYTHONHASHSEED`~~ **fixed** | `_propagate_pressure_guess` seeds its BFS from `list(set(p_guess.keys()))`; the same case converges in 5 of 10 identical processes, and is deterministic per fixed hash seed | **done.** `queue = list(p_guess.keys())`; scorecard identical (1700/2073) under seeds 0/1/7/13, against 1700 or 1711 before | done |
 
 Items 1, 2, 5, 6 are an afternoon. Item 3 is the one that changes what the
@@ -590,7 +590,7 @@ correction into the closure (it is already in `tee_junction.h`, templated, with
 the v3 spec's derivation). Gate: Wang 2014 (digitised) and Perez-Garcia
 (digitise first). This is the step that restores what the retired tee had.
 
-**Step 5a -- operating-point instrumentation (items 8-11).** Independent of
+**Step 5a -- operating-point instrumentation (items 8-11). COMPLETE.** Independent of
 the port and a prerequisite for gating it: return the converged q, score
 against the paper there, demote the `three_pb` K column, tighten the
 verifier, then land the junction-aware seed. Doing the seed first would


### PR DESCRIPTION
The last of the four operating-point defects, deliberately landed last because it moves roots between branches and needed items 9 and 10 in place to judge the difference.

## The defect

`analytical_pt_prop`'s Bernoulli mass-flow estimate only reached `ChannelElement`. Junctions in both the harness and `gui/backend/graph_builder.py` are wired with `LosslessConnectionElement`, which got nothing, so every port fell back to the flat reference flow: **0.1 kg/s in against 0.2 kg/s out**, with a 1:1 split whatever the boundary pressures say.

The split is now a Bernoulli share of the propagated port pressure differences, rescaled so continuity holds exactly at the start with every port in its declared direction. **The total still comes from the existing propagator**, so an upstream `MassFlowBoundary` still sets the level and no new flow-scale heuristic enters.

## What it is worth

| | seed off | seed on |
|---|---|---|
| converged | 1625 | **1732** |
| rejected as inadmissible or artifact | 227 | **163** |
| on-point evidence | 1243 | 1254 |
| RMSE common subset, `imposed_q` | 0.7664 | 0.7664 |
| RMSE common subset, `mfb_two_pb` | 0.7845 | 0.7844 |

**Read the middle row first.** The real effect is not "+107 rows": **89 solves that previously landed on an inadmissible or artifact root now land on an admissible one**, against 20 pushed the other way. That is the steer-away-from-unphysical objective, and it is only visible because item 10's energy check exists to name those roots.

The convergence count alone would have flattered it: of 153 rows gained, 21 are on-point and 131 are not; 47 are lost, 11 of them on-point. **Net evidence at the requested operating points is +11** on 2073 records.

Accuracy is unchanged on records scored under both seeds. A first pass compared full populations and showed `mfb_two_pb` RMSE rising 0.7806 to 0.7884 -- a population effect from the 36 extra rows, not a degradation.

Deterministic: 1732 under hash seeds 0, 1 and 7.

## Withdrawn: "the seed selects the intended operating point"

The prototype note generalised that from six moved roots, five of which landed nearer the target. Measured across every record converged under both: `three_pb` median drift 0.0949 to 0.0944, 167 nearer and 195 further; `mfb_two_pb` 0.0001 to 0.0001, 231 nearer and 205 further. **A wash.** The seed does not steer toward the requested q. It steers toward admissible roots, which is a different and better thing.

## Two things it broke

**The ejector.** `EjectorElement` extends `MultiPortChamberElement`, so a blanket junction seed reached it and overwrote the physics-based warm start it carries; the cold reference network in `test_gui_ejector.py` stopped converging. The seed is now **opt-in** through `seeds_ports_by_pressure_split`, false on the ejector because its port flows follow choking and entrainment, not a Bernoulli split.

**A bistable production fixture.** `_three_port_net` (2.10 / 2.05 / 2.00 bar, friction in every channel) has two flow arrangements that both satisfy it:

| mode | common | straight | branch |
|---|---|---|---|
| dividing (seed on) | in 0.450 | **out** 0.379 | out 0.071 |
| ejector (seed off) | in 0.358 | **in** 0.211 | out 0.569 |

Both conserve mass, both are net dissipative, both pass the v1 energy check, both are consistent with the boundary pressures. **Nothing available says which is "the" answer**, so the bistability is pinned as a new test rather than resolved, and the two solver-machinery tests that relied on the old path force their precondition explicitly instead of being weakened.

Also updated: the `three_pb` tautology demonstration now perturbs with `eta_scale=0.5` instead of 3.0. Since item 10 the tripled model is inadmissible in `three_pb` at every q and is rejected before a K can be extracted; a perturbation has to stay inside the physics to demonstrate anything.

Suite 2131 passed, 15 xfailed. CHANGELOG entry included: this can change which admissible operating mode a bistable network reports.

**Step 5a is complete.** The C++ port gate is next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RNDxZouiHoJdaLpnnPjHq
