### PR TITLE
fix(solver): return the best iterate a failed solve actually reached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **A failed solve now really does return its best iterate.**
+  `NetworkSolver.solve` warns "Returning best iterate" on non-convergence, but
+  the returned state and its residual norm were captured immediately after the
+  primary root-finding phase. Later phases -- above all the
+  Levenberg-Marquardt fallback -- keep evaluating through the same wrapper and
+  improve the tracked best, yet only re-pointed the returned state when they
+  reached the convergence tolerance, so an improvement that fell short was
+  discarded. Measured over 38 non-converged junction solves, 30 returned a
+  state worse than the best they had evaluated, by a median factor of 5.8 and
+  up to 2e5. The returned state is now re-pointed at the tracked best whenever
+  that is closer, before the junction consistency checks run, so those checks
+  judge the state actually handed back. **This does not change whether any
+  solve converges** -- the junction validation scorecard and the random
+  boundary-condition sweep are identical either side of the change.
+- **The automatic warm-start retry no longer replaces a closer result with a
+  worse one.** When both the primary attempt and the retry failed, the retry's
+  result was returned unconditionally. Whichever got closer is now returned,
+  with the other's residual norm quoted in the message.
+- **The junction validation harness records a real residual norm.** It read
+  `__residual_norm__`, a key `NetworkSolver` has never set, so every record's
+  residual norm was silently infinity; the solver's key is `__final_norm__`.
+
+
+### Fixed
 - **A network driven only by pressures no longer starts from a hard-coded
   0.1 kg/s.** `NetworkSolver._infer_reference_state` fell back to that constant
   whenever no `MassFlowBoundary` set the scale, so the initial guess was

--- a/docs/archive/JUNCTION_OPERATING_POINT_271.md
+++ b/docs/archive/JUNCTION_OPERATING_POINT_271.md
@@ -962,6 +962,50 @@ weakness when it is the model being used past where it is documented. The
 draws past the range are still swept and still reported -- they are simply
 reported as what they are.
 
+## Finding 13: the solver was not returning the iterate it promised
+
+Asked what a non-converged solve returns and whether the best iterate is kept.
+It is tracked, and it was usually not what came back.
+
+`solve` warns "Returning best iterate" and hands back a full solution
+dictionary: every unknown by name, derived node states, per-element
+diagnostics, and the bookkeeping keys `__success__`, `__message__`,
+`__final_norm__`, `__x_solution__`, `__unknown_names__` and
+`__convergence_history__`. The best point is tracked in real unscaled space,
+stored for warm-starting, and the derived states are re-propagated from it so
+they match rather than trailing the last trial point.
+
+But `final_x` and `final_norm` are captured immediately after the primary
+root() call, and every later phase -- the hybr fallback, and above all the LM
+fallback -- keeps evaluating through the same wrapper. Those phases improve the
+tracked best but only re-point the returned state when they REACH the
+convergence tolerance. An improvement that fell short was thrown away.
+
+| non-converged junction solves examined | 38 |
+|---|---|
+| returned a state worse than the best evaluated | **30** |
+| median ratio returned / best | 5.8x |
+| worst | 2.2e5x |
+
+In every case inspected the better point was found after the LM fallback
+started. Two smaller defects sat beside it: when the automatic retry also
+failed, its result was returned unconditionally even if the primary had got
+closer; and this harness read `__residual_norm__`, a key the solver has never
+set, so every record's residual norm had always been infinity.
+
+**None of the three changes whether a solve converges.** The scorecard stays at
+1708 of 2073 and the random sweep at 92.0% overall and 98.5% inside the
+documented Mach range, either side of the fix. That is the point: it corrects
+the answer that comes back, not the decision about success. Which also means
+the residual norms this harness has recorded until now carry no information,
+and any earlier reasoning that leaned on them should be re-checked -- nothing
+in this record does, because the norm was never used to decide anything.
+
+One behaviour left alone deliberately: a solution demoted by the junction
+consistency checks is still returned, with the success flag false. That is
+consistent with returning a best iterate, but a caller who ignores the flag
+receives a state the solver has just identified as physically inadmissible.
+
 ## What this changes
 
 - The 26 unrescued solves are no longer a mystery: most are infeasible, and

--- a/python/combaero/network/solver.py
+++ b/python/combaero/network/solver.py
@@ -1773,6 +1773,24 @@ class NetworkSolver:
             f"'{init_strategy}' attempt failed at |F|={primary_norm:.3e} "
             f"with: {primary_msg[:120]}]"
         )
+        # Neither attempt converged, so hand back whichever got closer. The
+        # retry used to be returned unconditionally, which could replace a
+        # near-miss with something far worse and still warn that the best
+        # iterate was being returned.
+        retry_norm = retry_sol.get("__final_norm__")
+        if (
+            primary_norm is not None
+            and retry_norm is not None
+            and float(retry_norm) > float(primary_norm)
+        ):
+            if _primary_diag is not None:
+                self._diagnostic_data = _primary_diag
+            sol["__message__"] = (
+                f"{primary_msg} [{_seed_kind} warm-start auto-retry also "
+                f"failed, at |F|={float(retry_norm):.3e}, so the closer "
+                f"primary result is returned]"
+            )
+            return sol
         return retry_sol
 
     def _outlet_ref_incompressible_seed(
@@ -2457,6 +2475,27 @@ class NetworkSolver:
                     message = (
                         f"{message} LM fallback also stalled at |F|={float(best_res_norm):.3e}."
                     )
+
+        # Honour the promise made in the non-convergence warning: return the
+        # BEST iterate, not the one that happened to be current when the
+        # primary phase ended.
+        #
+        # `final_x` and `final_norm` are captured immediately after the primary
+        # root() call. Every later phase -- the hybr fallback, and above all
+        # the LM fallback -- keeps evaluating through the same wrapper, so
+        # `best_x` and `best_res_norm` go on improving; but those phases only
+        # re-point `final_x` when they REACH the convergence tolerance. An
+        # improvement that falls short of it was being thrown away. Measured
+        # over 38 non-converged junction solves before this guard: 30 returned
+        # a state worse than the best they had evaluated, by a median of 5.8x
+        # and up to 2e5x, and in every case inspected the better point was
+        # found after the LM fallback started.
+        #
+        # Placed before the consistency verification below so the junction
+        # checks judge the state that is actually returned.
+        if float(best_res_norm) < final_norm:
+            final_x = best_x
+            final_norm = float(best_res_norm)
 
         # Post-solve physical-consistency verification for junctions.
         # Two known ways a junction net converges (|F| ~ 1e-10) onto an

--- a/python/tests/test_solver_returns_best_iterate.py
+++ b/python/tests/test_solver_returns_best_iterate.py
@@ -1,0 +1,307 @@
+"""What a failed solve hands back.
+
+`NetworkSolver.solve` warns "Returning best iterate" when it fails, and the
+returned dictionary is the same shape as a successful one: every unknown by
+name, derived node states, per-element diagnostics, and the bookkeeping keys
+`__success__`, `__message__`, `__final_norm__`, `__x_solution__`,
+`__unknown_names__` and `__convergence_history__`.
+
+It was not doing what it said. Three defects, all in what a FAILED solve
+reports rather than in whether it succeeds:
+
+1. `final_x` and `final_norm` are captured immediately after the primary
+   root() call. Later phases -- above all the LM fallback -- keep evaluating
+   through the same wrapper and improve the tracked best, but only re-point
+   `final_x` when they reach the convergence tolerance. An improvement that
+   fell short was thrown away. Measured over 38 non-converged junction solves:
+   30 returned a state worse than the best they had evaluated, by a median of
+   5.8x and up to 2e5x.
+2. When the automatic retry ran and also failed, its result was returned
+   unconditionally, even when the primary attempt had got closer.
+3. `_network_builder` read `__residual_norm__`, a key the solver never sets, so
+   every validation record's residual norm was silently infinity.
+
+None of the three changes whether a solve converges. The junction scorecard
+(1708 of 2073) and the random-boundary sweep (92.0%, 98.5% inside the
+documented Mach range) are identical either side of the fix, which is the point:
+this corrects the answer that comes back, not the decision about success.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+import warnings
+
+import numpy as np
+import pytest
+
+from combaero.network import NetworkSolver
+from validation.junction import random_robustness as rr
+
+
+def _a_failing_solve():
+    """A junction network that does not converge, from the random sweep."""
+    rng = random.Random(20260906)
+    for _ in range(400):
+        case = rr.sample(rng)
+        if rr.has_root(case) is not True:
+            continue
+        solver = NetworkSolver(rr.build(case))
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            sol = solver.solve(timeout=20.0)
+        if not sol["__success__"] and sol["__convergence_history__"]:
+            return solver, sol
+    pytest.skip("no failing case found in the sampled draws")
+
+
+@pytest.fixture(scope="module")
+def failed():
+    return _a_failing_solve()
+
+
+# ---------------------------------------------------------------------------
+# What comes back at all
+# ---------------------------------------------------------------------------
+
+
+def test_a_failed_solve_returns_a_full_solution(failed):
+    _, sol = failed
+
+    assert sol["__success__"] is False
+    assert sol["__message__"]
+    physical = [k for k in sol if not k.startswith("__")]
+    assert len(physical) > 10, "a failed solve must still describe the state it reached"
+    assert "lc_com.m_dot" in sol
+
+
+def test_the_bookkeeping_keys_are_the_ones_callers_read(failed):
+    """Pinned because a consumer read `__residual_norm__` for months and got
+    infinity every time: the solver has never set that name."""
+    _, sol = failed
+
+    for key in (
+        "__success__",
+        "__message__",
+        "__final_norm__",
+        "__x_solution__",
+        "__unknown_names__",
+        "__convergence_history__",
+    ):
+        assert key in sol, f"{key} missing from the returned solution"
+    assert "__residual_norm__" not in sol
+
+
+def test_a_failed_solve_warns():
+    """A caller who ignores `__success__` must at least see a warning, since
+    the state handed back is the best iterate and not a solution."""
+    rng = random.Random(20260906)
+    for _ in range(400):
+        case = rr.sample(rng)
+        if rr.has_root(case) is not True:
+            continue
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            sol = NetworkSolver(rr.build(case)).solve(timeout=20.0)
+        if sol["__success__"]:
+            continue
+        assert any("did not converge" in str(w.message) for w in caught), (
+            f"failed silently: {sol['__message__'][:80]}"
+        )
+        return
+    pytest.skip("no failing case found in the sampled draws")
+
+
+# ---------------------------------------------------------------------------
+# It is the BEST iterate
+# ---------------------------------------------------------------------------
+
+
+def test_the_returned_norm_is_the_best_one_evaluated(failed):
+    _, sol = failed
+    best = min(h["norm"] for h in sol["__convergence_history__"])
+
+    assert sol["__final_norm__"] == pytest.approx(best, rel=1e-9), (
+        "the solve evaluated a better point than the one it returned"
+    )
+
+
+def test_the_returned_state_really_has_that_residual(failed):
+    """The norm and the state must describe the same point, or a caller
+    warm-starting from the result gets something other than it was told."""
+    solver, sol = failed
+    x = np.array(sol["__x_solution__"])
+
+    assert float(np.linalg.norm(solver._residuals(x))) == pytest.approx(
+        sol["__final_norm__"], rel=1e-6
+    )
+
+
+def test_the_warm_start_point_matches_what_was_returned(failed):
+    solver, sol = failed
+
+    assert np.allclose(solver._last_x, np.array(sol["__x_solution__"]))
+    assert np.allclose(solver._diagnostic_data["solution"], np.array(sol["__x_solution__"]))
+
+
+@pytest.mark.parametrize("seed", [20260906, 4242])
+def test_no_solve_returns_worse_than_it_reached(seed):
+    """The whole class, swept. Before the fix this failed on 30 of 38."""
+    rng = random.Random(seed)
+    checked = 0
+    for _ in range(250):
+        case = rr.sample(rng)
+        if rr.has_root(case) is not True:
+            continue
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            sol = NetworkSolver(rr.build(case)).solve(timeout=20.0)
+        history = sol["__convergence_history__"]
+        if sol["__success__"] or not history:
+            continue
+        checked += 1
+        best = min(h["norm"] for h in history)
+        assert sol["__final_norm__"] <= best * 1.01 + 1e-12, (
+            f"returned |F|={sol['__final_norm__']:.4e} against a best of {best:.4e}"
+        )
+        if checked >= 12:
+            break
+    assert checked > 0, "no failing solves sampled"
+
+
+# ---------------------------------------------------------------------------
+# The validation harness records a real number again
+# ---------------------------------------------------------------------------
+
+
+def test_the_junction_harness_records_a_finite_residual_norm():
+    from validation.junction.models.mpce_v2_network import MPCEv2Network
+
+    model = MPCEv2Network(strict=False)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        converged = model.evaluate_network("bassett2001", "K6", 0.6, 3.0, math.radians(45.0))
+
+    assert converged.converged
+    assert math.isfinite(converged.residual_norm), (
+        "the harness is reading a key the solver does not set"
+    )
+    assert converged.residual_norm < 1e-3
+
+
+# ---------------------------------------------------------------------------
+# The automatic retry must not replace a closer result with a worse one
+# ---------------------------------------------------------------------------
+
+
+def _retryable_network():
+    """A junction network with a compressible element, so the auto-retry path
+    is applicable at all (it needs an MPCE element AND something compressible)."""
+    import combaero as cb
+    from combaero.network import (
+        ChannelElement,
+        FlowNetwork,
+        LosslessConnectionElement,
+        MomentumChamberNode,
+        PressureBoundary,
+    )
+    from combaero.network.mpce_v2_element import MPCEv2Element
+
+    Y = list(cb.mole_to_mass(cb.species.dry_air()))
+    net = FlowNetwork()
+    net.add_node(PressureBoundary("pb_in", Pt=2.1e5, Tt=300.0, Y=Y))
+    net.add_node(PressureBoundary("pb_str", Pt=2.05e5, Tt=300.0, Y=Y))
+    net.add_node(PressureBoundary("pb_bra", Pt=2.0e5, Tt=300.0, Y=Y))
+    for pid in ("port_com", "port_str", "port_bra"):
+        net.add_node(MomentumChamberNode(pid, area=0.01))
+    net.add_element(
+        ChannelElement(
+            "ch_in", "pb_in", "port_com", length=0.3, diameter=0.05, regime="compressible"
+        )
+    )
+    net.add_element(LosslessConnectionElement("lc_str", "port_str", "pb_str"))
+    net.add_element(LosslessConnectionElement("lc_bra", "port_bra", "pb_bra"))
+    net.add_element(
+        MPCEv2Element(
+            id="jct",
+            inlet_nodes=["port_com"],
+            outlet_nodes=["port_str", "port_bra"],
+            inlet_angles_deg=[0.0],
+            outlet_angles_deg=[0.0, 90.0],
+            port_areas=[0.01, 0.01, 0.01],
+            flow_direction="branch",
+            strict=False,
+        )
+    )
+    return net
+
+
+def test_the_retry_is_only_returned_when_it_got_closer(monkeypatch):
+    """Both attempts fail and the retry lands FURTHER away.
+
+    The retry used to be returned unconditionally, so a near-miss could be
+    replaced by something far worse while the warning still promised the best
+    iterate. Driven through `_solve_impl` rather than a real stiff network, so
+    the comparison is tested rather than a particular network's luck.
+    """
+    solver = NetworkSolver(_retryable_network())
+    calls = {"n": 0}
+
+    def fake_impl(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return {
+                "__success__": False,
+                "__message__": "primary",
+                "__final_norm__": 1.0,
+                "marker": "primary",
+            }
+        return {
+            "__success__": False,
+            "__message__": "retry",
+            "__final_norm__": 100.0,
+            "marker": "retry",
+        }
+
+    monkeypatch.setattr(solver, "_solve_impl", fake_impl)
+    monkeypatch.setattr(solver, "_outlet_ref_incompressible_seed", lambda **kw: np.zeros(3))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        sol = solver.solve(timeout=20.0)
+
+    assert calls["n"] == 2, "the auto-retry did not run, so nothing was compared"
+    assert sol["marker"] == "primary", "a worse retry replaced the closer primary"
+    assert "auto-retry also" in sol["__message__"]
+
+
+def test_a_closer_retry_is_returned(monkeypatch):
+    """The other side of the comparison, so the guard cannot just always
+    return the primary."""
+    solver = NetworkSolver(_retryable_network())
+    calls = {"n": 0}
+
+    def fake_impl(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return {
+                "__success__": False,
+                "__message__": "primary",
+                "__final_norm__": 100.0,
+                "marker": "primary",
+            }
+        return {
+            "__success__": False,
+            "__message__": "retry",
+            "__final_norm__": 1.0,
+            "marker": "retry",
+        }
+
+    monkeypatch.setattr(solver, "_solve_impl", fake_impl)
+    monkeypatch.setattr(solver, "_outlet_ref_incompressible_seed", lambda **kw: np.zeros(3))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        sol = solver.solve(timeout=20.0)
+
+    assert calls["n"] == 2
+    assert sol["marker"] == "retry"

--- a/validation/junction/models/_network_builder.py
+++ b/validation/junction/models/_network_builder.py
@@ -388,7 +388,9 @@ def solve_and_extract(
         )
     wall_time = time.perf_counter() - t0
     converged = bool(sol.get("__success__", False))
-    res_norm = float(sol.get("__residual_norm__", math.inf))
+    # `__final_norm__` is the key the solver sets; `__residual_norm__` never
+    # existed, so every record's residual norm was silently infinity.
+    res_norm = float(sol.get("__final_norm__", math.inf))
     if not converged:
         return NetworkResult(
             converged=False,


### PR DESCRIPTION
Follow-up to #296, kept separate so any shift is attributable: this changes what **every** non-converged solve returns, which is a wider reach than anything in that PR.

## What comes back

`solve` warns "Returning best iterate" and hands back a full solution dictionary, the same shape as on success: every unknown by name, derived node states, per-element diagnostics, and the bookkeeping keys `__success__`, `__message__`, `__final_norm__`, `__x_solution__`, `__unknown_names__`, `__convergence_history__`. The best point is tracked in real unscaled space, stored for warm-starting, and the derived states are re-propagated from it.

## The defect

`final_x` and `final_norm` are captured immediately after the primary `root()` call. Every later phase -- the hybr fallback, and above all the **LM fallback** -- keeps evaluating through the same wrapper, so the tracked best goes on improving; but those phases only re-point the returned state when they **reach the convergence tolerance**. An improvement that fell short was thrown away.

| non-converged junction solves examined | 38 |
|---|---|
| returned a state worse than the best evaluated | **30** |
| median ratio returned / best | 5.8x |
| worst | 2.2e5x |

In every case inspected the better point was found *after* the LM fallback started. The returned state is now re-pointed at the tracked best whenever that is closer, placed **before** the junction consistency checks so they judge the state actually handed back.

## Two smaller ones beside it

- When the automatic warm-start retry also failed, its result was returned **unconditionally**, so a near-miss could be replaced by something far worse while the warning still promised the best iterate. Whichever attempt got closer is now returned.
- The junction validation harness read `__residual_norm__`, a key `NetworkSolver` has never set, so **every record's residual norm was silently infinity**. The solver's key is `__final_norm__`.

## Nothing about convergence changes

| | |
|---|---|
| junction scorecard | 1708 / 2073, unchanged |
| random sweep, overall | 92.0%, unchanged |
| random sweep, inside the documented Mach range | 98.5%, unchanged |

That is the point: this corrects the answer that comes back, not the decision about success. It also means the residual norms that harness recorded until now carry no information. Nothing in the provenance record leaned on them, because the norm was never used to decide anything.

## Falsified (policy sec 0, item 9)

| reverted | result |
|---|---|
| best-iterate guard removed | 3 tests red |
| harness key reverted | 1 red |
| retry comparison removed | 1 red |

All restore green. The retry pair is driven through `_solve_impl` rather than a particular stiff network, so the comparison is what is tested rather than one network's luck.

**Left alone deliberately:** a solution demoted by the junction consistency checks is still returned with the success flag false. That is consistent with returning a best iterate, but a caller ignoring the flag receives a state the solver has just identified as physically inadmissible. Recorded rather than changed.

Suite 2173 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RNDxZouiHoJdaLpnnPjHq
