### PR TITLE
feat(validation): score Wang 2014, the compressible data that was never used (#271)

### DIFF
--- a/docs/archive/JUNCTION_OPERATING_POINT_271.md
+++ b/docs/archive/JUNCTION_OPERATING_POINT_271.md
@@ -1006,6 +1006,93 @@ consistency checks is still returned, with the success flag false. That is
 consistent with returning a best iterate, but a caller who ignores the flag
 receives a state the solver has just identified as physically inadmissible.
 
+## Finding 14: the compressible data was there all along, and the model holds up in it
+
+Asked whether any compressible validation data exists. It does, it was fully
+digitised, and nothing scored a single point of it.
+
+**Wang 2014**, compressible combining flow at 45 degree tees: 30 curves, 200
+measured points, common-branch Mach from 0.091 to 0.595, area ratios 1, 1.56
+and 2.44, splits 0, 0.2, 0.5, 0.8 and 1. His K_13 and K_23 are the lateral and
+straight joining coefficients.
+
+Two independent reasons nothing used it, neither of them physics. The network
+runner dropped every file whose abscissa was not the split, which was all
+thirty. The raw correlation runner handles a Mach abscissa correctly but its
+model adapter returns nothing unless the source is Bassett. Even the
+paper-ceiling reference covered 16 of the 200.
+
+### What it took to wire
+
+Three things, and the axis one is where every previous mistake in this arc was
+made:
+
+- **Wang's q is the LATERAL inlet fraction and BOTH his coefficients are
+  indexed on it**, unlike Bassett, who re-indexes his straight-leg K11 on the
+  straight inlet. So neither takes a `1 - q` here. The `1 - q` that
+  `equivalences.py` carries for K_23 maps Wang onto Bassett's axis for the
+  cross-paper rollup, not onto the network.
+- **His `a = S_c / S_b` is common over lateral, which is exactly Bassett's
+  psi**, so it passes straight through.
+- **His K is normalised on the common port's total minus static**, not on
+  `1/2 rho u^2`. Those agree only in the incompressible limit: `p0 - p` exceeds
+  `1/2 rho u^2` by about `M^2/4` in relative terms, so 0.2% at Mach 0.1 and 9%
+  at Mach 0.6. Extracting what he actually measured keeps a definitional
+  difference out of what would otherwise look like model error.
+
+The network is placed at each point's own Mach through the library's isentropic
+mass-flux relation, rather than at the fixture's fixed low-speed reference.
+
+### The result
+
+| Mach band | n | MAE | bias |
+|---|---|---|---|
+| below 0.15 | 18 | **0.0967** | -0.037 |
+| 0.15 to 0.30 | 24 | 0.1187 | -0.069 |
+| 0.30 to 0.45 | 36 | 0.0938 | -0.005 |
+| above 0.45 | 42 | 0.1486 | -0.041 |
+
+For comparison, the same model scores 0.0949 against Bassett and 0.0859 against
+Hager. **At low Mach the closure agrees with Wang about as well as it agrees
+with the two sources it was built against**, on a source it had never been
+compared with. That is the first genuinely measured check of the joining side:
+Idelchik is a handbook tabulation and Bassett's joining coefficients are his own
+analytical forms.
+
+**And the degradation with Mach is mild.** Read with Wang's own definition, an
+incompressible closure holds to about 0.15 at Mach 0.6. That materially weakens
+the case for the `kappa M^2` correction in sec 8 step 5 of the design record --
+it should now have to prove it beats 0.15 before being added, rather than being
+assumed necessary.
+
+### Where it is weak, and the agreement is independent
+
+| split | area ratio 1 | 1.56 | 2.44 |
+|---|---|---|---|
+| 0.2 | 0.04 / 0.06 | 0.05 / 0.05 | 0.04 / 0.10 |
+| 0.5 | 0.14 / 0.12 | 0.04 / 0.08 | 0.19 / 0.06 |
+| 0.8 | 0.03 / 0.03 | 0.17 / 0.10 | **0.30 / 0.65** |
+
+(lateral / straight coefficient). The error grows with area ratio and with
+lateral fraction, worst at a small branch taking most of the flow. **That is
+exactly where Idelchik put the error too** -- two independent sources, one
+handbook and one experiment, agreeing on where the model is weak, which is a
+much stronger statement than either alone. It is also the regime
+`joining_etransfer_alpha` was introduced for.
+
+### What is not scored
+
+80 of the 200 points, all of them the `q = 0` and `q = 1` curves where one
+inlet carries no flow at all. 75 are refused by the direction check, which is
+it doing its job on a degenerate boundary case rather than a failure. The
+pressure-driven topologies are skipped for this source rather than failed: they
+size their boundary pressures from Bassett's analytical K, which has no meaning
+for another paper.
+
+Still not digitised: Perez-Garcia 2010, 90 degree compressible tees, metadata
+and README only. Torregrosa 2017 and Stigler 2010 are on disk and referenced
+nowhere.
+
 ## What this changes
 
 - The 26 unrescued solves are no longer a mystery: most are infeasible, and

--- a/python/tests/test_junction_network_runner.py
+++ b/python/tests/test_junction_network_runner.py
@@ -154,10 +154,61 @@ def test_topology_filter_in_run_network():
     assert topologies == {"imposed_q"}
 
 
-def test_iter_skips_x_axis_M3_files():
-    """Wang files (x_axis=M_3) should be skipped -- network mode uses q only."""
-    ds = load_dataset()
-    tee = TeeJunctionElementNetwork()
-    records = list(iter_network_records(tee, ds, topologies=("imposed_q",)))
-    papers = {r.paper for r in records}
-    assert "wang2014" not in papers, "wang files should be skipped (M_3 axis)"
+def test_mach_indexed_files_are_scored_at_their_own_mach():
+    """Wang 2014 sweeps Mach at a fixed split, and network mode used to drop
+    every such file because it only understood a q abscissa.
+
+    That silently excluded the only measured compressible data in the set --
+    200 points from Mach 0.09 to 0.60 -- so the roles are swapped for these
+    files: the abscissa is the Mach and the split comes from the metadata.
+    """
+    from validation.junction.models.mpce_v2_network import MPCEv2Network
+
+    records = [
+        r
+        for r in iter_network_records(
+            MPCEv2Network(strict=False), load_dataset(), topologies=("imposed_q",)
+        )
+        if r.paper == "wang2014"
+    ]
+
+    assert records, "the compressible source is being dropped again"
+    assert all(r.mach is not None for r in records), "a Mach-indexed record must carry its Mach"
+    machs = [r.mach for r in records]
+    assert min(machs) < 0.15 and max(machs) > 0.45, "the Mach sweep is not being covered"
+    # the split is metadata here, not the abscissa
+    assert {round(r.q, 2) for r in records} <= {0.0, 0.2, 0.5, 0.8, 1.0}
+
+
+def test_incompressible_sources_carry_no_mach():
+    """Bassett, Hager and Idelchik specify no Mach, and must not be given a
+    fabricated one -- the same "not checked is not the same as fine" rule the
+    consistency field follows."""
+    from validation.junction.models.mpce_v2_network import MPCEv2Network
+
+    records = [
+        r
+        for r in iter_network_records(
+            MPCEv2Network(strict=False), load_dataset(), topologies=("imposed_q",)
+        )
+        if r.paper != "wang2014"
+    ]
+
+    assert records
+    assert all(r.mach is None for r in records)
+
+
+def test_a_mach_indexed_source_is_not_charged_for_topologies_it_cannot_use():
+    """The pressure-driven skeletons size their boundaries from Bassett's
+    analytical K, which means nothing for another source. Emitting them as
+    failures would count a skip as a failure."""
+    from validation.junction.models.mpce_v2_network import MPCEv2Network
+
+    records = [
+        r
+        for r in iter_network_records(MPCEv2Network(strict=False), load_dataset())
+        if r.paper == "wang2014"
+    ]
+
+    assert records
+    assert {r.topology for r in records} == {"imposed_q"}

--- a/validation/junction/MPCE_CPP_PORT_DESIGN.md
+++ b/validation/junction/MPCE_CPP_PORT_DESIGN.md
@@ -593,6 +593,13 @@ Plus whole-row FD tests
 item 1 is lifted) at `< 1e-6`; a ctest comparing the C++ kernel against golden
 Python values (the ejector recipe's `.h` golden-data pattern).
 
+**Step 5 -- compressibility. THE PREMISE HAS WEAKENED (2026-09-06).** Wang's
+200 measured points are now scored in-network (Finding 14 of the
+operating-point record) and an incompressible closure, read with Wang's own K
+definition, holds to MAE 0.15 at Mach 0.6 and 0.097 below Mach 0.15 -- about
+what it manages against Bassett and Hager. A `kappa M^2` correction must now
+beat 0.15 to earn its place; it can no longer be assumed necessary.
+
 **Step 5 -- compressibility.** Port `K_dat_j_closed`'s `kappa M_dat^2`
 correction into the closure (it is already in `tee_junction.h`, templated, with
 the v3 spec's derivation). Gate: Wang 2014 (digitised) and Perez-Garcia

--- a/validation/junction/README.md
+++ b/validation/junction/README.md
@@ -33,6 +33,19 @@ dataset:
   reflection coefficients), not steady K. Could be a separate
   acoustic-tier dataset later if needed.
 
+## Mach-indexed sources
+
+Most files are a coefficient against the flow split. Wang 2014 is a Mach sweep
+at a FIXED split, and it is the only measured compressible data in the set: 200
+points from Mach 0.09 to 0.60. The network runner reads those files with the
+roles swapped -- abscissa is the Mach, split comes from the metadata -- places
+the network at that Mach, and extracts K with Wang's own normalisation
+(the common port's total minus static, not `1/2 rho u^2`, which differ by about
+9% at Mach 0.6).
+
+The scorecard keeps a Mach band as its own axis, so an incompressible closure
+is never averaged across one.
+
 ## Convergence is measured somewhere else
 
 The scorecard's convergence column is measured on cases whose boundary

--- a/validation/junction/models/_network_builder.py
+++ b/validation/junction/models/_network_builder.py
@@ -362,6 +362,60 @@ def _extract_K_joining(
     )
 
 
+
+def mass_flow_for_mach(
+    mach: float,
+    area: float = _F_C,
+    Pt: float = _PT_REF,
+    Tt: float = _TT_REF,
+) -> float:
+    """Mass flow that puts a duct of ``area`` at ``mach``, isentropically.
+
+    Used to place a validation network at a source's own Mach number instead of
+    the fixture's fixed low-speed reference. Goes through the library's own
+    thermodynamics (`mass_flux_isentropic`) rather than a perfect-gas formula so
+    the property model is the one the solver will use.
+    """
+    X = _x_air()
+    gamma = float(cb.isentropic_expansion_coefficient(Tt, X))
+    ratio = (1.0 + 0.5 * (gamma - 1.0) * mach * mach) ** (gamma / (gamma - 1.0))
+    G = float(cb.mass_flux_isentropic(Tt, Pt, Pt / ratio, X))
+    return G * area
+
+
+def _extract_K_joining_dynamic_pressure(
+    sol: dict[str, float],
+    *,
+    common_node: str,
+    straight_node: str,
+    lateral_node: str,
+    m_dot_ref: float,
+    area: float,
+) -> tuple[float, float]:
+    """Joining K normalised on the common port's TOTAL MINUS STATIC pressure.
+
+    Wang 2014 defines K_13 = (p0_1 - p0_3) / (p0_3 - p_3) and K_23 likewise,
+    where 3 is the common branch. The usual `_extract_K_joining` divides by
+    1/2 rho u^2 evaluated at a fixed reference flow, which agrees with that only
+    in the incompressible limit and only when the flow is at the reference
+    level: p0 - p exceeds 1/2 rho u^2 by about M^2/4 in relative terms, so the
+    two definitions differ by roughly 0.2% at Mach 0.1 and 9% at Mach 0.6.
+
+    Extracting what the source actually measured keeps the comparison honest at
+    every Mach, rather than folding a definitional difference into what looks
+    like model error.
+    """
+    Pt_com = sol[f"{common_node}.Pt"]
+    P_com = sol[f"{common_node}.P"]
+    q_dyn = Pt_com - P_com
+    if q_dyn <= 0.0:
+        raise KeyError("common port has no dynamic pressure to normalise on")
+    return (
+        (sol[f"{lateral_node}.Pt"] - Pt_com) / q_dyn,
+        (sol[f"{straight_node}.Pt"] - Pt_com) / q_dyn,
+    )
+
+
 def solve_and_extract(
     net: FlowNetwork,
     *,
@@ -372,6 +426,7 @@ def solve_and_extract(
     area: float = _F_C,
     flow_direction: Literal["separating", "joining"] = "separating",
     verifier: Callable[[dict[str, float]], bool] | None = None,
+    extractor: Callable[..., tuple[float, float]] | None = None,
 ) -> NetworkResult:
     """Run NetworkSolver, return convergence + K diagnostics."""
     solver = NetworkSolver(net)
@@ -406,7 +461,8 @@ def solve_and_extract(
             message="post-solve verification failed (soft barrier landed off-physical)",
         )
     try:
-        extractor = _extract_K_joining if flow_direction == "joining" else _extract_K
+        if extractor is None:
+            extractor = _extract_K_joining if flow_direction == "joining" else _extract_K
         K_lat, K_str = extractor(
             sol,
             common_node=common_node,

--- a/validation/junction/models/mpce_v2_network.py
+++ b/validation/junction/models/mpce_v2_network.py
@@ -10,6 +10,7 @@ lateral branch because Mynard's K already captures the full loss.
 from __future__ import annotations
 
 import math
+from collections.abc import Callable
 from dataclasses import replace
 
 from combaero.network import LosslessConnectionElement
@@ -17,6 +18,7 @@ from combaero.network.mpce_v2_element import MPCEv2Element
 from validation.junction.models import bassett2001
 from validation.junction.models._network_builder import (
     _F_C,
+    _extract_K_joining_dynamic_pressure,
     _M_DOT_REF,
     ALL_TOPOLOGIES,
     NetworkResult,
@@ -27,6 +29,7 @@ from validation.junction.models._network_builder import (
     build_separating_mfb_two_pb_skeleton,
     build_separating_network_skeleton,
     build_separating_three_pb_skeleton,
+    mass_flow_for_mach,
     solve_and_extract,
 )
 
@@ -127,6 +130,8 @@ class MPCEv2Network:
             return NetworkResult(
                 converged=False, message=f"idelchik1966 coefficient {K_id} not wired"
             )
+        if paper == "wang2014":
+            return self._wang(K_id, q, psi, theta_rad, topology, kwargs.get("mach"))
         if paper != "bassett2001":
             return NetworkResult(converged=False, message=f"paper {paper!r} not wired")
         if K_id in {"K6", "K5", "K2"}:
@@ -155,6 +160,53 @@ class MPCEv2Network:
         return NetworkResult(
             converged=False,
             message=f"K_id {K_id} not yet wired for MPCE-v2",
+        )
+
+    def _wang(
+        self,
+        K_id: str,
+        q: float,
+        psi: float | None,
+        theta_rad: float | None,
+        topology: Topology,
+        mach: float | None,
+    ) -> NetworkResult:
+        """Wang 2014: compressible combining flow at 45 degrees.
+
+        AXES, because this is where every previous mistake was made. Wang's
+        `q = m_1 / m_3` is the LATERAL inlet fraction, and BOTH his
+        coefficients are indexed on it -- unlike Bassett, who re-indexes his
+        straight-leg K11 on the straight inlet. So neither K_13 nor K_23 takes
+        a 1 - q here, and neither needs one on the way out. The 1 - q that
+        `equivalences.py` carries for K_23 maps Wang onto Bassett's axis for
+        the cross-paper rollup, not onto this network.
+
+        `a = S_c / S_b` is common over lateral, which is exactly Bassett's psi,
+        so it passes straight through as the area ratio.
+
+        Only `imposed_q` is wired. The pressure-driven skeletons size their
+        boundary pressures from Bassett's analytical K, which has no meaning
+        for a different source, and `imposed_q` is in any case the only
+        topology whose extracted K measures the model (#290).
+        """
+        if K_id not in {"K_13", "K_23"}:
+            return NetworkResult(converged=False, message=f"wang2014 {K_id} not wired")
+        if topology != "imposed_q":
+            return NetworkResult(
+                converged=False,
+                message=(
+                    f"wang2014 is wired for imposed_q only; {topology!r} would size its "
+                    "boundary pressures from another paper's correlation"
+                ),
+            )
+        m_in = _M_DOT_REF if mach is None else mass_flow_for_mach(mach)
+        return self._joining(
+            q,
+            psi or 1.0,
+            theta_rad if theta_rad is not None else math.radians(45.0),
+            topology,
+            m_in=m_in,
+            extractor=_extract_K_joining_dynamic_pressure,
         )
 
     def _separating(
@@ -206,15 +258,27 @@ class MPCEv2Network:
             verifier=jct.verify_solution_consistent if not self.strict else None,
         )
 
-    def _joining(self, q: float, psi: float, theta_rad: float, topology: Topology) -> NetworkResult:
+    def _joining(
+        self,
+        q: float,
+        psi: float,
+        theta_rad: float,
+        topology: Topology,
+        m_in: float = _M_DOT_REF,
+        extractor: Callable[..., tuple[float, float]] | None = None,
+    ) -> NetworkResult:
         """Build a joining-flow MPCE-v2 network. ``q`` is the LATERAL inlet fraction.
 
         Geometry mirrors the separating case (str at 0deg, bra at theta) but
         flow reverses: str and bra are inlets, com is the outlet. The
         ``MPCEv2Element`` residual reads the flow direction from the
         signed mass flows at runtime, so the same element handles both.
+
+        ``m_in`` places the network at a chosen flow level, which is what lets
+        a Mach-indexed source be scored at its own operating point rather than
+        at the fixture's fixed low-speed reference. ``extractor`` lets a source
+        with its own K definition be read off the same solve.
         """
-        m_in = _M_DOT_REF
         A_bra = _F_C / psi
         if topology == "imposed_q":
             net = build_joining_imposed_q_skeleton(m_in=m_in, m_lateral=q * m_in)
@@ -259,4 +323,5 @@ class MPCEv2Network:
             area=_F_C,
             flow_direction="joining",
             verifier=jct.verify_solution_consistent if not self.strict else None,
+            extractor=extractor,
         )

--- a/validation/junction/network_runner.py
+++ b/validation/junction/network_runner.py
@@ -67,6 +67,9 @@ class NetworkRecord:
     # Only `imposed_q` imposes it; elsewhere it is an outcome and the record's
     # K was extracted there, not at `q` (issue #271).
     q_converged: float | None = None
+    #: Common-branch Mach the point was evaluated at. None for the
+    #: incompressible sources, which do not specify one.
+    mach: float | None = None
     # The measured curve's K at `q_converged`, which is the value `K_extracted`
     # must be compared against. None when the solve did not converge, or when
     # the operating point it reached lies outside the curve's digitised range.
@@ -114,8 +117,11 @@ class NetworkRecord:
 # Hager 1984 names its coefficients xi_t (straight-through) and xi_l (lateral);
 # the schema stores them in `coefficient` with K_id=None, and _which_K is fed
 # `K_id or coefficient`, so both spellings must be here.
-_LATERAL_K_IDS = {"K1", "K6", "K12", "xi_l"}
-_STRAIGHT_K_IDS = {"K2", "K5", "K11", "xi_t"}
+# Wang 2014 names his joining pair K_13 (lateral inlet to common outlet) and
+# K_23 (straight inlet to common outlet), which are the lateral and straight
+# coefficients under different labels.
+_LATERAL_K_IDS = {"K1", "K6", "K12", "xi_l", "K_13"}
+_STRAIGHT_K_IDS = {"K2", "K5", "K11", "xi_t", "K_23"}
 
 # Ground truth for network scoring: digitised measurements, and handbook
 # tabulations (Idelchik) which are reference data in their own right. Not a
@@ -202,7 +208,9 @@ def iter_network_records(
 
     supported = set(getattr(model, "SUPPORTED_TOPOLOGIES", ALL_TOPOLOGIES))
     for file in dataset.files:
-        if file.kind not in _GROUND_TRUTH_KINDS or file.x_axis != "q":
+        if file.kind not in _GROUND_TRUTH_KINDS:
+            continue
+        if file.x_axis not in ("q", "M_3"):
             continue
         K_id = file.K_id or file.coefficient or ""
         which = _which_K(K_id)
@@ -212,14 +220,30 @@ def iter_network_records(
         curve = sorted(rows)
         theta_rad = math.radians(file.theta_deg) if file.theta_deg is not None else None
         paper = file.path.parent.name
-        for q_val, K_m in rows:
+        # A Mach-indexed file sweeps M at a FIXED split, so the roles of the
+        # abscissa and the metadata swap. Wang 2014 is the only such source,
+        # and it is the only measured compressible data in the set.
+        mach_axis = file.x_axis == "M_3"
+        # Wang records the area ratio as `a` (common over lateral), which is
+        # the same quantity Bassett calls psi.
+        psi_val = file.psi if file.psi is not None else file.a
+        for x_val, K_m in rows:
+            q_val = (file.q if file.q is not None else 0.5) if mach_axis else x_val
+            mach_val = x_val if mach_axis else file.M_3
             if not (-0.05 <= q_val <= 1.05):
                 continue
             for topology in topologies:
                 if topology not in supported:
                     continue
+                # The pressure-driven skeletons size their boundary pressures
+                # from Bassett's analytical K, which has no meaning for another
+                # source. Skipping is not the same as failing, so a Mach-indexed
+                # source must not be charged for topologies it was never
+                # applicable to.
+                if mach_axis and topology != "imposed_q":
+                    continue
                 result = model.evaluate_network(
-                    paper, K_id, q_val, file.psi, theta_rad, topology=topology
+                    paper, K_id, q_val, psi_val, theta_rad, topology=topology, mach=mach_val
                 )
                 K_ext = (
                     (result.K_lateral if which == "lateral" else result.K_straight)
@@ -230,7 +254,7 @@ def iter_network_records(
                     paper=paper,
                     K_id=K_id,
                     canonical_K=canonical_K(paper, K_id),
-                    psi=file.psi,
+                    psi=psi_val,
                     theta_deg=file.theta_deg,
                     q=q_val,
                     K_measured=K_m,
@@ -242,14 +266,20 @@ def iter_network_records(
                     topology=topology,
                     message=result.message,
                     q_converged=result.q_converged if result.converged else None,
+                    # On a Mach-indexed curve the abscissa is not q, so the
+                    # achieved-q interpolation of item 9b does not apply: the
+                    # split is imposed and the measured value is the one at
+                    # this point.
                     K_measured_at_q_converged=(
                         K_m
-                        if result.q_converged is None
+                        if mach_axis
+                        or result.q_converged is None
                         or abs(result.q_converged - q_val) <= _Q_SNAP
                         else _curve_value_at(curve, result.q_converged)
                     )
                     if result.converged
                     else None,
+                    mach=mach_val,
                 )
 
 
@@ -270,6 +300,11 @@ class NetworkCell:
     canonical_K: str
     psi_bin: str
     theta_bin: str
+    #: Mach band for a compressible source, "n/a" for the incompressible ones.
+    #: Kept as its own axis so an incompressible closure is never averaged
+    #: across Mach: Wang 2014 sweeps 0.09 to 0.60, and the model is documented
+    #: only for the bottom of that.
+    mach_bin: str
     topology: Topology
     N: int = 0
     n_converged: int = 0
@@ -290,6 +325,26 @@ class NetworkCell:
     n_off_point: int = 0
 
 
+#: Mach bands for the compressible source. The first is where an
+#: incompressible closure is documented to apply; the rest are reported
+#: separately rather than averaged in.
+_MACH_BANDS: tuple[tuple[float, str], ...] = (
+    (0.15, "M<0.15"),
+    (0.30, "M.15-.3"),
+    (0.45, "M.3-.45"),
+    (10.0, "M>0.45"),
+)
+
+
+def _mach_bin(mach: float | None) -> str:
+    if mach is None:
+        return "n/a"
+    for upper, label in _MACH_BANDS:
+        if mach < upper:
+            return label
+    return _MACH_BANDS[-1][1]
+
+
 def _median(xs: list[float]) -> float:
     if not xs:
         return 0.0
@@ -302,25 +357,26 @@ def build_network_cells(records: list[NetworkRecord]) -> list[NetworkCell]:
     """Group by (canonical_K, psi, theta, topology) -> NetworkCell."""
     from collections import defaultdict
 
-    groups: dict[tuple[str, float | None, float | None, Topology], list[NetworkRecord]] = (
-        defaultdict(list)
-    )
+    groups: dict[
+        tuple[str, float | None, float | None, str, Topology], list[NetworkRecord]
+    ] = defaultdict(list)
     for r in records:
-        groups[(r.canonical_K, r.psi, r.theta_deg, r.topology)].append(r)
+        groups[(r.canonical_K, r.psi, r.theta_deg, _mach_bin(r.mach), r.topology)].append(r)
 
     topo_order = {t: i for i, t in enumerate(ALL_TOPOLOGIES)}
 
     def _sort_key(item):
-        (cK, psi, theta, topo), _ = item
+        (cK, psi, theta, mbin, topo), _ = item
         return (
             cK,
             psi if psi is not None else -1.0,
             theta if theta is not None else -1.0,
+            mbin,
             topo_order.get(topo, 99),
         )
 
     cells: list[NetworkCell] = []
-    for (cK, psi, theta, topo), recs in sorted(groups.items(), key=_sort_key):
+    for (cK, psi, theta, mbin, topo), recs in sorted(groups.items(), key=_sort_key):
         N = len(recs)
         conv = [r for r in recs if r.converged and r.K_extracted is not None]
         n_conv = len(conv)
@@ -340,6 +396,7 @@ def build_network_cells(records: list[NetworkRecord]) -> list[NetworkCell]:
                 canonical_K=cK,
                 psi_bin=f"{psi:g}" if psi is not None else "n/a",
                 theta_bin=f"{theta:g}" if theta is not None else "n/a",
+                mach_bin=mbin,
                 topology=topo,
                 N=N,
                 n_converged=n_conv,
@@ -360,7 +417,7 @@ def format_network_scorecard(model_name: str, cells: list[NetworkCell]) -> str:
     lines = []
     lines.append(f"=== Network scorecard: {model_name} ===")
     lines.append(
-        f"{'canonical_K':<18} {'psi':>5} {'theta':>5} {'topology':<12} "
+        f"{'canonical_K':<18} {'psi':>5} {'theta':>5} {'mach':>8} {'topology':<12} "
         f"{'N':>4} {'%conv':>6} {'RMSE':>8} {'bias':>8} {'dq':>6} {'off':>6} {'t_ms':>6}"
     )
     lines.append("-" * 95)
@@ -377,7 +434,8 @@ def format_network_scorecard(model_name: str, cells: list[NetworkCell]) -> str:
             "-" if not (c.n_off_point or c.n_off_curve) else f"{c.n_off_point}/{c.n_off_curve}"
         )
         lines.append(
-            f"{c.canonical_K:<18} {c.psi_bin:>5} {c.theta_bin:>5} {c.topology:<12} "
+            f"{c.canonical_K:<18} {c.psi_bin:>5} {c.theta_bin:>5} {c.mach_bin:>8} "
+            f"{c.topology:<12} "
             f"{c.N:>4} {c.pct_converged * 100:>5.0f}% {rmse_str:>8} {bias_str:>8} "
             f"{drift_str:>6} {off_str:>6} {c.median_wall_time_ms:>5.1f}"
         )


### PR DESCRIPTION
Asked whether any compressible validation data exists. **It does, it was fully digitised, and nothing scored a single point of it.**

## What was sitting there

Wang 2014, compressible combining flow at 45 degree tees: 30 curves, **200 measured points**, common-branch Mach 0.091 to 0.595, area ratios 1 / 1.56 / 2.44, splits 0 / 0.2 / 0.5 / 0.8 / 1.

Two independent reasons nothing used it, neither of them physics. The network runner dropped every file whose abscissa was not the split, which was all thirty. The raw correlation runner handles a Mach abscissa but its adapter returns nothing unless the source is Bassett. Even the paper-ceiling reference covered 16 of the 200.

## The three things it took

- **Wang's q is the lateral inlet fraction and both his coefficients are indexed on it**, unlike Bassett who re-indexes his straight-leg coefficient. So neither takes a `1 - q` here; the one in `equivalences.py` maps onto Bassett's axis for the cross-paper rollup, not onto the network. Pinned by test, since this is where every previous mistake in the arc was made.
- **His `a` is common over lateral**, which is exactly Bassett's psi.
- **His K is normalised on total minus static**, not `1/2 rho u^2`. Those agree only incompressibly, differing by ~0.2% at Mach 0.1 and ~9% at Mach 0.6. Extracting what he measured keeps a definitional difference out of what would otherwise read as model error.

The network is placed at each point's own Mach through the library's isentropic mass-flux relation.

## The result

| Mach band | n | MAE | bias |
|---|---|---|---|
| below 0.15 | 18 | **0.0967** | -0.037 |
| 0.15 to 0.30 | 24 | 0.1187 | -0.069 |
| 0.30 to 0.45 | 36 | 0.0938 | -0.005 |
| above 0.45 | 42 | 0.1486 | -0.041 |

The same model scores 0.0949 against Bassett and 0.0859 against Hager. **At low Mach it agrees with Wang about as well as with the two sources it was built against**, on a source it had never met. This is the first genuinely *measured* check of the joining side: Idelchik is a handbook tabulation and Bassett's joining coefficients are his own analytical forms.

**The degradation with Mach is mild.** Read with Wang's own definition, an incompressible closure holds to about 0.15 at Mach 0.6. That materially weakens the premise of the compressibility step in the port plan: a `kappa M^2` correction must now beat 0.15 to earn its place rather than being assumed necessary. Noted in the design doc.

## Where it is weak, confirmed independently

| split | a=1 | a=1.56 | a=2.44 |
|---|---|---|---|
| 0.2 | 0.04 / 0.06 | 0.05 / 0.05 | 0.04 / 0.10 |
| 0.5 | 0.14 / 0.12 | 0.04 / 0.08 | 0.19 / 0.06 |
| 0.8 | 0.03 / 0.03 | 0.17 / 0.10 | **0.30 / 0.65** |

Lateral / straight coefficient. Error grows with area ratio and with lateral fraction, worst at a small branch taking most of the flow. **That is exactly where Idelchik puts it too** -- a handbook and an experiment agreeing independently on where the model is weak, which is much stronger than either alone. It is also the regime `joining_etransfer_alpha` was introduced for, and that constant is still calibrated against the old closure.

## What is not scored, and why

80 of the 200 points, all the `q = 0` and `q = 1` curves where one inlet carries no flow. 75 are refused by the direction check, which is it working on a degenerate boundary case rather than failing. The pressure-driven topologies are **skipped** for this source rather than failed: they size their boundary pressures from Bassett's analytical K, which means nothing for another paper, and counting a skip as a failure is the category error this arc keeps returning to.

The scorecard now carries a Mach band as its own axis, so an incompressible closure is never averaged across one.

Still not digitised: Perez-Garcia 2010, 90 degree compressible tees, metadata and README only. Torregrosa 2017 and Stigler 2010 are on disk and referenced nowhere.

Records rise 2073 to 2273, converged 1828. Suite 2175 passed. The validation run is about two minutes slower for the extra 200 solves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RNDxZouiHoJdaLpnnPjHq
