### PR TITLE
feat(validation): score Bassett joining type 4, and fix two swapped leg labels (#271, #272)

### DIFF
--- a/docs/archive/JUNCTION_OPERATING_POINT_271.md
+++ b/docs/archive/JUNCTION_OPERATING_POINT_271.md
@@ -1093,6 +1093,76 @@ Still not digitised: Perez-Garcia 2010, 90 degree compressible tees, metadata
 and README only. Torregrosa 2017 and Stigler 2010 are on disk and referenced
 nowhere.
 
+## Finding 15: the crossover corroborated, and two labels found to be swapped
+
+The crossover in Finding 13 -- the pseudodatum form better below an area ratio
+of about 2.6, Bassett's two-supplier form better above -- rested almost entirely
+on Idelchik above the crossover. Before digitising anything new, the cheapest
+independent test was already on disk.
+
+**Bassett flow type 4**, joining, 75 measured points at area ratios 1, 2 and 4,
+unscored because K7 and K8 were never mapped to a leg. Wiring them needed two
+things settled from the paper rather than from our own docstrings.
+
+### The labels were the wrong way round
+
+Table 1, flow type 4:
+
+    K7 = [(p_B + rho u_B^2/2) - (p_A + rho u_A^2/2)] / (rho u_A^2/2),  q = m_B/m_A
+    K8 = [(p_C + rho u_C^2/2) - (p_A + rho u_A^2/2)] / (rho u_A^2/2),  q = m_C/m_A
+
+Every ratio and the denominator sit on A, so **A is the common branch**, B is
+the lateral and C the other straight leg. K7 is the LATERAL-to-common
+coefficient and K8 the STRAIGHT one. `bassett2001.py` said the opposite, and
+nothing caught it because neither coefficient was ever scored. Corrected, and
+the measurements confirm it: read as written the closure sits at 0.20 and 0.31,
+with the legs swapped it is 0.56 and 1.02.
+
+### It is the same network with the lateral mirrored
+
+Type 6 has the common at C, so in type 4 the lateral joins pointing the other
+way along the main duct. That is the same three-port network with the lateral
+at `pi - theta`, which the data confirms:
+
+| lateral angle | K7 error | K8 error |
+|---|---|---|
+| theta | 0.562 | 1.017 |
+| **pi - theta** | **0.201** | **0.313** |
+
+My first attempt at this was wrong, and instructively so: I predicted the
+mirror correctly but paired K7 with K11 and K8 with K12, because I trusted our
+docstrings over the paper's Table 1. Nothing fitted under any of the four
+mappings, which is what sent me back to the source.
+
+### The corroboration
+
+| area ratio | model | with the patch | Bassett's form |
+|---|---|---|---|
+| 1 | 0.153 | 0.153 | **0.081** |
+| 2 | 0.505 | 0.466 | **0.191** |
+| 4 | 0.700 | 0.549 | **0.267** |
+
+**The degradation with area ratio reproduces on an independent flow type**, and
+the tuned correction again helps without closing the gap. The trend is now
+carried by two distinct datasets rather than by Idelchik alone.
+
+The exact crossover location is *not* corroborated: on type 4 Bassett's form is
+ahead even at equal areas, where on type 6 the closure was clearly better. That
+comparison is his own analytical form against his own measurements, so some of
+the margin is circular. What survives independently is the shape of the
+degradation, not the point at which the two curves cross.
+
+Per-cell, once wired through the network:
+
+| coefficient | psi=1 | psi=2 | psi=4 |
+|---|---|---|---|
+| K7, lateral | 0.065 | 0.257 | 0.177 |
+| K8, straight | 0.159 | 0.551 | 0.766 |
+
+The bias is negative throughout at the larger area ratios, so the model
+under-predicts the joining loss into a small branch -- the same direction
+Idelchik and Wang both show.
+
 ## What this changes
 
 - The 26 unrescued solves are no longer a mystery: most are infeasible, and

--- a/python/tests/test_bassett_type4_joining.py
+++ b/python/tests/test_bassett_type4_joining.py
@@ -1,0 +1,207 @@
+"""Bassett joining flow type 4, and the leg labels that were the wrong way round.
+
+75 measured points at area ratios 1, 2 and 4 sat unscored because K7 and K8
+were never mapped to a leg. Wiring them needed two things settled from the
+paper rather than from our own docstrings.
+
+**Which leg each coefficient belongs to.** Table 1, flow type 4:
+
+    K7 = [(p_B + rho u_B^2/2) - (p_A + rho u_A^2/2)] / (rho u_A^2/2),  q = m_B/m_A
+    K8 = [(p_C + rho u_C^2/2) - (p_A + rho u_A^2/2)] / (rho u_A^2/2),  q = m_C/m_A
+
+Every ratio and the denominator are on A, so **A is the common branch**, B is
+the lateral and C the other straight leg. K7 is therefore the LATERAL-to-common
+coefficient on the lateral fraction and K8 the STRAIGHT one on the straight
+fraction. `bassett2001.py` documented them the other way round, and nothing
+caught it because neither was ever scored.
+
+**Which network it is.** Type 6 has the common at C instead, so in type 4 the
+lateral joins pointing the other way along the main duct: the same three-port
+network with the lateral mirrored to `pi - theta`. Measured over the 75 points,
+that mapping gives mean errors of 0.20 and 0.31 against 0.56 and 1.02
+unmirrored.
+"""
+
+from __future__ import annotations
+
+import math
+import warnings
+
+import numpy as np
+import pytest
+
+from combaero.network._mynard2010 import junction_loss_coefficient
+from validation.junction.models import bassett2001
+from validation.junction.models.mpce_v2_network import MPCEv2Network
+from validation.junction.network_runner import (
+    _LATERAL_K_IDS,
+    _STRAIGHT_K_IDS,
+    iter_network_records,
+)
+from validation.junction.runner import _read_xy_csv
+from validation.junction.schema import load_dataset
+
+_A = 0.01
+
+
+@pytest.fixture(scope="module")
+def model():
+    return MPCEv2Network(strict=False)
+
+
+@pytest.fixture(scope="module")
+def measured():
+    pts = []
+    for f in load_dataset().files:
+        kid = f.K_id or f.coefficient or ""
+        if kid in {"K7", "K8"} and f.kind == "measured":
+            for x, y in _read_xy_csv(f.path):
+                if 0.02 < x < 0.98:
+                    pts.append((kid, x, f.psi or 1.0, f.theta_deg or 45.0, y))
+    assert pts, "the type-4 measured files have gone missing"
+    return pts
+
+
+def _closure(q_lat: float, psi: float, theta_rad: float) -> tuple[float, float]:
+    """(straight, lateral) from the raw closure in joining flow."""
+    U = np.array([(1.0 - q_lat) * 10.0, q_lat * 10.0 * psi, -10.0])
+    A = np.array([_A, _A / psi, _A])
+    ang = np.array([0.0, theta_rad, math.pi])
+    r = junction_loss_coefficient(U, A, ang)
+    return float(r.K[0]), float(r.K[1])
+
+
+# ---------------------------------------------------------------------------
+# Which leg is which
+# ---------------------------------------------------------------------------
+
+
+def test_K7_is_the_lateral_coefficient_and_K8_the_straight_one():
+    assert "K7" in _LATERAL_K_IDS and "K7" not in _STRAIGHT_K_IDS
+    assert "K8" in _STRAIGHT_K_IDS and "K8" not in _LATERAL_K_IDS
+
+
+def test_the_docstrings_say_so_too():
+    """They said the opposite until this was scored, so pin the words."""
+    assert "LATERAL" in bassett2001.K7_raw.__doc__
+    assert "STRAIGHT" in bassett2001.K8_raw.__doc__
+
+
+def test_the_leg_assignment_is_what_the_measurements_prefer(measured):
+    """Decided by the data, not by reading: score both assignments."""
+    errs = {"as read": [], "swapped": []}
+    for kid, q_file, psi, th, meas in measured:
+        tm = math.pi - math.radians(th)
+        q_lat = (1.0 - q_file) if kid == "K8" else q_file
+        k_str, k_lat = _closure(q_lat, psi, tm)
+        errs["as read"].append(abs((k_lat if kid == "K7" else k_str) - meas))
+        errs["swapped"].append(abs((k_str if kid == "K7" else k_lat) - meas))
+
+    assert np.mean(errs["as read"]) < np.mean(errs["swapped"]), (
+        "the measurements prefer the other leg assignment, so Table 1 has been read wrongly again"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Which network
+# ---------------------------------------------------------------------------
+
+
+def test_type_4_is_type_6_with_the_lateral_mirrored(measured):
+    """Both mappings scored against the measurements; the mirror must win."""
+    direct, mirrored = [], []
+    for kid, q_file, psi, th, meas in measured:
+        t = math.radians(th)
+        q_lat = (1.0 - q_file) if kid == "K8" else q_file
+        for angle, bucket in ((t, direct), (math.pi - t, mirrored)):
+            k_str, k_lat = _closure(q_lat, psi, angle)
+            bucket.append(abs((k_lat if kid == "K7" else k_str) - meas))
+
+    assert np.mean(mirrored) < 0.6 * np.mean(direct), (
+        f"mirrored {np.mean(mirrored):.4f} vs direct {np.mean(direct):.4f}"
+    )
+
+
+def test_the_analytical_forms_agree_with_the_mirror_reading():
+    """Bassett's own type-4 pair should sit close to his type-6 pair evaluated
+    at the mirrored angle with the legs swapped. Not identical -- the two
+    derivations use different control volumes -- but close enough that the
+    correspondence is not a coincidence."""
+    for psi in (1.0, 2.0, 4.0):
+        for q in (0.2, 0.5, 0.8):
+            t = math.radians(45.0)
+            tm = math.pi - t
+            assert bassett2001.K7_corr(q, psi, t) == pytest.approx(
+                bassett2001.K12_corr(q, psi, tm), abs=0.25
+            )
+            assert bassett2001.K8_corr(q, psi, t) == pytest.approx(
+                bassett2001.K11_corr(q, psi, tm), abs=0.25
+            )
+
+
+# ---------------------------------------------------------------------------
+# The axis, the trap this arc keeps returning to
+# ---------------------------------------------------------------------------
+
+
+def test_K8_is_on_the_straight_fraction_and_K7_is_not(model):
+    """K8 at q and K7 at 1-q must build the SAME network, exactly as
+    Bassett's K11 pairs with K12."""
+    straight = model.evaluate_network("bassett2001", "K8", 0.3, 2.0, math.radians(45.0))
+    lateral = model.evaluate_network("bassett2001", "K7", 0.7, 2.0, math.radians(45.0))
+
+    assert straight.converged and lateral.converged
+    assert straight.K_straight == pytest.approx(lateral.K_straight, rel=1e-9)
+    assert straight.K_lateral == pytest.approx(lateral.K_lateral, rel=1e-9)
+
+
+def test_the_achieved_split_comes_back_on_the_file_axis(model):
+    q = 0.3
+    r = model.evaluate_network("bassett2001", "K8", q, 2.0, math.radians(45.0))
+
+    assert r.converged, r.message
+    assert r.q_converged == pytest.approx(q, abs=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# It is actually scored
+# ---------------------------------------------------------------------------
+
+
+def test_type_4_reaches_the_scorecard(model):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        records = [
+            r
+            for r in iter_network_records(model, load_dataset(), topologies=("imposed_q",))
+            if r.K_id in {"K7", "K8"}
+        ]
+
+    assert len(records) > 70, f"only {len(records)} type-4 records reach the runner"
+    assert {r.psi for r in records} == {1.0, 2.0, 4.0}, "the area-ratio sweep is incomplete"
+    scored = [r for r in records if r.error is not None]
+    assert len(scored) > 60
+
+
+def test_the_model_degrades_with_area_ratio_here_too(model):
+    """The finding this data was wired to corroborate. It was previously
+    resting almost entirely on Idelchik above an area ratio of about 2.6, and
+    this is an independent flow type from a different figure of the paper.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        records = [
+            r
+            for r in iter_network_records(model, load_dataset(), topologies=("imposed_q",))
+            if r.K_id in {"K7", "K8"} and r.error is not None
+        ]
+
+    by_psi = {}
+    for psi in (1.0, 2.0, 4.0):
+        errs = [abs(r.error) for r in records if r.psi == psi]
+        assert errs, f"no scored points at psi={psi}"
+        by_psi[psi] = float(np.mean(errs))
+
+    assert by_psi[1.0] < by_psi[2.0] < by_psi[4.0], (
+        f"the degradation with area ratio has changed shape: {by_psi}"
+    )

--- a/validation/junction/README.md
+++ b/validation/junction/README.md
@@ -33,6 +33,18 @@ dataset:
   reflection coefficients), not steady K. Could be a separate
   acoustic-tier dataset later if needed.
 
+## Joining flow types
+
+Bassett defines six flow types. Types 4 and 6 are both joining tees with one
+lateral inlet, one straight inlet and one straight outlet; they differ in WHICH
+straight leg is the outlet, so the lateral joins pointing the other way along
+the main duct. Type 4 is therefore scored on the same network with the lateral
+mirrored to `pi - theta`.
+
+Each coefficient is indexed on the fraction in its own leg, and which leg that
+is comes from Table 1, not from the coefficient's name: for type 4 the common
+branch is A, so K7 is the lateral coefficient and K8 the straight one.
+
 ## Mach-indexed sources
 
 Most files are a coefficient against the flow split. Wang 2014 is a Mach sweep

--- a/validation/junction/models/bassett2001.py
+++ b/validation/junction/models/bassett2001.py
@@ -82,13 +82,21 @@ def K6(q: float, psi: float, theta: float) -> float:
 
 
 def K7_raw(q: float, psi: float, theta: float) -> float:
-    """Joining type 4, straight path (Table 2, no angle correction)."""
+    """Joining type 4, LATERAL path (Table 2, no angle correction).
+
+    Table 1: K7 = [(p_B + rho u_B^2/2) - (p_A + rho u_A^2/2)] / (rho u_A^2/2)
+    with q = m_B/m_A. In flow type 4 the common branch is A, B is the lateral
+    and C the other straight leg, so this is the LATERAL-to-common coefficient
+    indexed on the lateral fraction -- K8 is the straight one. The docstrings
+    here said the opposite until 2026-09-06, and nothing caught it because
+    neither coefficient was scored.
+    """
     c = math.cos(theta)
     return 4.0 * q - 1.0 + q * q * (psi * psi - 2.0 + 2.0 * psi * c)
 
 
 def K7_corr(q: float, psi: float, theta: float) -> float:
-    """Joining type 4, straight path with Eq 34 correction:
+    """Joining type 4, LATERAL path with Eq 34 correction:
     theta' = pi - (3/4)*(pi - theta) substituted everywhere theta appears."""
     tc = math.pi - 0.75 * (math.pi - theta)
     c = math.cos(tc)
@@ -96,13 +104,19 @@ def K7_corr(q: float, psi: float, theta: float) -> float:
 
 
 def K8_raw(q: float, psi: float, theta: float) -> float:
-    """Joining type 4, lateral path (Table 2, no angle correction).
-    K8 = 1 - q^2 + 2 * (1-q)^2 * psi * cos(theta)."""
+    """Joining type 4, STRAIGHT path (Table 2, no angle correction).
+
+    Table 1: K8 = [(p_C + rho u_C^2/2) - (p_A + rho u_A^2/2)] / (rho u_A^2/2)
+    with q = m_C/m_A, so it is the straight-inlet coefficient on the straight
+    fraction. See K7 for the naming correction.
+
+    K8 = 1 - q^2 + 2 * (1-q)^2 * psi * cos(theta).
+    """
     return 1.0 - q * q + 2.0 * (1.0 - q) * (1.0 - q) * psi * math.cos(theta)
 
 
 def K8_corr(q: float, psi: float, theta: float) -> float:
-    """Joining type 4, lateral path with Eq 34 correction."""
+    """Joining type 4, STRAIGHT path with Eq 34 correction."""
     tc = math.pi - 0.75 * (math.pi - theta)
     return 1.0 - q * q + 2.0 * (1.0 - q) * (1.0 - q) * psi * math.cos(tc)
 

--- a/validation/junction/models/mpce_v2_network.py
+++ b/validation/junction/models/mpce_v2_network.py
@@ -147,6 +147,22 @@ class MPCEv2Network:
                 q_lateral, psi or 1.0, theta_rad or math.pi / 2.0, topology
             )
             return _to_file_axis(result, flip=K_id in {"K5", "K2"})
+        if K_id in {"K7", "K8"}:
+            # Joining flow TYPE 4. Bassett Table 1 puts the common branch at A
+            # rather than C, so the lateral joins pointing the other way along
+            # the main duct than in type 6: the same three-port network with
+            # the lateral mirrored to pi - theta. Measured over his 75 type-4
+            # points, that mapping gives mean errors of 0.20 and 0.31 against
+            # 0.56 and 1.02 unmirrored.
+            #
+            # And K7 is the LATERAL-to-common coefficient on the lateral
+            # fraction, K8 the straight one on the straight fraction -- the
+            # reverse of what bassett2001.py's docstrings said until this was
+            # scored. Only K8 takes the 1 - q.
+            q_lateral = 1.0 - q if K_id == "K8" else q
+            theta_used = math.pi - (theta_rad if theta_rad is not None else math.pi / 2.0)
+            result = self._joining(q_lateral, psi or 1.0, theta_used, topology)
+            return _to_file_axis(result, flip=K_id == "K8")
         if K_id in {"K11", "K12"}:
             # Bassett Table 1 indexes each joining coefficient by the fraction
             # in ITS OWN inlet leg: K11's q is mdot_A/mdot_C (the STRAIGHT

--- a/validation/junction/network_runner.py
+++ b/validation/junction/network_runner.py
@@ -120,8 +120,11 @@ class NetworkRecord:
 # Wang 2014 names his joining pair K_13 (lateral inlet to common outlet) and
 # K_23 (straight inlet to common outlet), which are the lateral and straight
 # coefficients under different labels.
-_LATERAL_K_IDS = {"K1", "K6", "K12", "xi_l", "K_13"}
-_STRAIGHT_K_IDS = {"K2", "K5", "K11", "xi_t", "K_23"}
+# Bassett flow type 4 is joining with the common branch at A rather than C,
+# so K7 is the lateral-to-common coefficient and K8 the straight one -- the
+# reverse of what this module's docstrings claimed before 2026-09-06.
+_LATERAL_K_IDS = {"K1", "K6", "K12", "xi_l", "K_13", "K7"}
+_STRAIGHT_K_IDS = {"K2", "K5", "K11", "xi_t", "K_23", "K8"}
 
 # Ground truth for network scoring: digitised measurements, and handbook
 # tabulations (Idelchik) which are reference data in their own right. Not a


### PR DESCRIPTION
The crossover found in the joining derivation -- pseudodatum form better below an area ratio of about 2.6, Bassett's two-supplier form better above -- rested almost entirely on Idelchik above the crossover. Before digitising anything new, the cheapest independent test was already on disk: **75 measured type-4 points at area ratios 1, 2 and 4**, unscored because K7 and K8 were never mapped to a leg.

## The labels were the wrong way round

Table 1, flow type 4:

```
K7 = [(p_B + rho u_B^2/2) - (p_A + rho u_A^2/2)] / (rho u_A^2/2),  q = m_B/m_A
K8 = [(p_C + rho u_C^2/2) - (p_A + rho u_A^2/2)] / (rho u_A^2/2),  q = m_C/m_A
```

Every ratio and the denominator sit on **A**, so A is the common branch, B the lateral and C the other straight leg. **K7 is the lateral-to-common coefficient and K8 the straight one.** `bassett2001.py` documented the reverse, and nothing caught it because neither was ever scored. The measurements settle it: read as Table 1 says the closure sits at 0.20 and 0.31; with the legs swapped, 0.56 and 1.02.

## It is the same network with the lateral mirrored

Type 6 has the common at C, so in type 4 the lateral joins pointing the other way along the main duct.

| lateral angle | K7 error | K8 error |
|---|---|---|
| theta | 0.562 | 1.017 |
| **pi - theta** | **0.201** | **0.313** |

My first attempt was wrong and instructively so: I predicted the mirror correctly but paired K7 with K11 and K8 with K12, trusting our docstrings over the paper's Table 1. Nothing fitted under any of the four mappings, which is what sent me back to the source.

## The corroboration

| area ratio | model | with the patch | Bassett's form |
|---|---|---|---|
| 1 | 0.153 | 0.153 | **0.081** |
| 2 | 0.505 | 0.466 | **0.191** |
| 4 | 0.700 | 0.549 | **0.267** |

**The degradation with area ratio reproduces on an independent flow type**, and the tuned correction again helps without closing the gap. That trend is now carried by two distinct datasets rather than by Idelchik alone.

**The exact crossover location is not corroborated.** On type 4 Bassett's form is ahead even at equal areas, where on type 6 the closure was clearly better, and that comparison is his own analytical form against his own measurements, so some of the margin is circular. What survives independently is the shape of the degradation, not the point at which the curves cross.

Through the network, per cell:

| coefficient | psi=1 | psi=2 | psi=4 |
|---|---|---|---|
| K7, lateral | 0.065 | 0.257 | 0.177 |
| K8, straight | 0.159 | 0.551 | 0.766 |

Bias is negative throughout at the larger ratios, so the model under-predicts the joining loss into a small branch, the same direction Idelchik and Wang both show.

## Falsified (policy sec 0, item 9)

| reverted | result |
|---|---|
| leg labels swapped back | the label test red |
| lateral no longer mirrored | the degradation test red |
| K8's axis transform removed | three tests red |

All restore green. 87 of the 91 type-4 points now converge and score. Suite 2184 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RNDxZouiHoJdaLpnnPjHq
