### PR TITLE
fix(junction): move the soft barrier's fixed point out of the flow range (#272)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **The junction soft barrier no longer has a fixed point that solves park
+  in.** `MPCEv2Element` replaces the physics with a "soft barrier" when a port
+  flows against its declared direction, meant to pull Newton back toward
+  `mdot = 0` so a sign flip can restore the declared regime. It could not: the
+  penalty is added into the same residual row as the continuity relation,
+  `R_i = (Pt_i - Pt_jct) + alpha*max(0, -e_i*mdot_i)^2`, and the element has no
+  spare row to give it, so the solver could zero that row by carrying a
+  pressure error equal and opposite to the penalty instead of by driving the
+  slack to zero. The barrier therefore behaved as a fabricated pressure loss
+  with a fixed point at `slack* = sqrt(dP/alpha)`. At the previous
+  `soft_penalty_alpha` of 1e7 that put it at 45% of the common mass flow, and
+  affected solves plateaued on a residual floor with an ordinary in-regime root
+  available. `soft_penalty_alpha` is now 1e11, which moves the fixed point to
+  0.45%. Measured: the junction validation scorecard goes from 2080 to 2108
+  converged of 2546 with every source's mean error equal or better (Bassett
+  0.1548 -> 0.1538, Idelchik 0.8902 -> 0.8880, Hager and Wang unchanged), and
+  the random boundary-condition sweep from 98.3% to 99.3% inside the closure's
+  documented Mach range. The response is monotone in `alpha` and flat above
+  1e9, so this is a saturation point rather than a fitted value. Note that
+  `alpha` carries Pa/(kg/s)^2 and is therefore tied to the scales it was
+  measured on; a network far outside them wants a scale-aware weight.
 - **A failed solve now really does return its best iterate.**
   `NetworkSolver.solve` warns "Returning best iterate" on non-convergence, but
   the returned state and its residual norm were captured immediately after the

--- a/docs/archive/JUNCTION_OPERATING_POINT_271.md
+++ b/docs/archive/JUNCTION_OPERATING_POINT_271.md
@@ -1163,6 +1163,30 @@ The bias is negative throughout at the larger area ratios, so the model
 under-predicts the joining loss into a small branch -- the same direction
 Idelchik and Wang both show.
 
+## Finding 16: a plateau above zero is a mode seam, not a blocked root
+
+Finding 12 concluded that the failures sit outside the model. That holds for
+the q-endpoint cases it examined, but it is not the whole picture: some
+non-converged solves have a smooth residual history that flattens onto a floor
+well above zero, and a minimum that is not a root means something is blocking
+the root.
+
+One such case was taken apart in full. Two candidate mechanisms were falsified
+by measurement -- the soft barrier (the floor does not scale with
+`soft_penalty_alpha`, and is *higher* with the barrier off) and choking (the
+branch runs at Mach 0.72 against a critical ratio of 1.892). The floor is
+carried by two equal and opposite rows, and equals the total-pressure jump a
+*lossless* connection cannot close. The Jacobian is rank 11 of 12 there, but
+none of the residual lies in the directions it cannot reach, so the root is
+reachable and Newton merely has no step.
+
+The mechanism is that the straight inlet has reversed: an element declared as
+a merge is physically dividing, the closure reads supplier and collector from
+the signed flows at runtime, and the residual formula changes across that
+reversal. The full numbers, the alpha sweep, the SVD and the sweep of the
+straight port's flow through zero are in [MPCE_CPP_PORT_DESIGN.md] section 7c,
+along with the limits of the evidence and what it means for the port.
+
 ## What this changes
 
 - The 26 unrescued solves are no longer a mystery: most are infeasible, and

--- a/docs/archive/JUNCTION_OPERATING_POINT_271.md
+++ b/docs/archive/JUNCTION_OPERATING_POINT_271.md
@@ -1163,29 +1163,47 @@ The bias is negative throughout at the larger area ratios, so the model
 under-predicts the joining loss into a small branch -- the same direction
 Idelchik and Wang both show.
 
-## Finding 16: a plateau above zero is a mode seam, not a blocked root
+## Finding 16: a plateau above zero is the soft barrier's fixed point
 
 Finding 12 concluded that the failures sit outside the model. That holds for
-the q-endpoint cases it examined, but it is not the whole picture: some
+the q-endpoint cases it examined, but not for the whole set: some
 non-converged solves have a smooth residual history that flattens onto a floor
 well above zero, and a minimum that is not a root means something is blocking
 the root.
 
-One such case was taken apart in full. Two candidate mechanisms were falsified
-by measurement -- the soft barrier (the floor does not scale with
-`soft_penalty_alpha`, and is *higher* with the barrier off) and choking (the
-branch runs at Mach 0.72 against a critical ratio of 1.892). The floor is
-carried by two equal and opposite rows, and equals the total-pressure jump a
-*lossless* connection cannot close. The Jacobian is rank 11 of 12 there, but
-none of the residual lies in the directions it cannot reach, so the root is
-reachable and Newton merely has no step.
+One such case was taken apart in full. The blocker is the element's own
+soft barrier, and the two hypotheses that looked like better candidates were
+both wrong.
 
-The mechanism is that the straight inlet has reversed: an element declared as
-a merge is physically dividing, the closure reads supplier and collector from
-the signed flows at runtime, and the residual formula changes across that
-reversal. The full numbers, the alpha sweep, the SVD and the sweep of the
-straight port's flow through zero are in [MPCE_CPP_PORT_DESIGN.md] section 7c,
-along with the limits of the evidence and what it means for the port.
+**The barrier, not the physics.** At the floor, 95.7% of residual evaluations
+took the soft-barrier path rather than the Mynard closure: the straight port
+was flowing against its declared direction, and `MPCEv2Element.residuals`
+routes any such state to `_soft_barrier_residual`. Every anomaly first
+attributed to the junction model -- two equal and opposite rows, a rank-11
+Jacobian, a residual that jumps across the port's reversal -- belongs to the
+barrier.
+
+**Why it has a fixed point.** The penalty is added into the same residual row
+as the continuity relation, and the element has no spare row to give it. The
+solver can therefore zero that row by carrying a pressure error equal and
+opposite to the penalty rather than by driving the slack to zero, which puts a
+fixed point at `slack* = sqrt(dP / alpha)`. Confirmed to six digits: the case
+parked at 0.041338 kg/s carrying a fabricated 17088.3 Pa, against a predicted
+0.041338. At the old alpha of 1e7 that is 45% of the common mass flow.
+
+**Two wrong turns worth recording.** Sweeping alpha *downward* to zero made
+the floor higher, which read as a falsification of the penalty hypothesis. It
+is not: alpha = 0 does not remove the barrier, it turns the element into a
+lossless junction. And removing the barrier outright -- letting the closure
+solve whichever regime the flows present -- fixed the traced case but made
+both aggregates worse, and was reverted.
+
+**The fix is the weight**, 1e7 -> 1e11, which moves the fixed point to 0.45%
+of the common flow. Scorecard 2080 -> 2108 converged, random harness 98.3% ->
+99.3% in range, every source's mean error equal or better. The response is
+monotone in alpha and flat above 1e9, so this is a saturation point and not a
+tuned optimum. Full tables, the instrumented before/after and the declared
+scale-dependence are in [MPCE_CPP_PORT_DESIGN.md] sections 7c and 7d.
 
 ## What this changes
 

--- a/python/combaero/network/mpce_v2_element.py
+++ b/python/combaero/network/mpce_v2_element.py
@@ -85,9 +85,36 @@ class MPCEv2Element(MultiPortChamberElement):
     # Soft-barrier penalty scale used when ``strict=False`` and the observed
     # flow direction disagrees with the declared one. Wraps the
     # one-sided quadratic ``alpha * max(0, -expected_sign * mdot)^2``.
-    # Calibrated so that a wrong-sign mdot of 0.1 kg/s contributes roughly
-    # 1e5 Pa to the residual -- the natural Pt scale. Tunable via attribute.
-    soft_penalty_alpha: float = 1.0e7
+    #
+    # Sized by where the barrier's FIXED POINT lands, not by the size of the
+    # penalty. The penalty is added into the same residual row as the
+    # continuity relation, ``R_i = (Pt_i - Pt_jct) + alpha*slack^2``, so the
+    # solver can zero that row by carrying a pressure error equal and
+    # opposite to the penalty rather than by driving the slack to zero. The
+    # barrier therefore has a fixed point at
+    #
+    #     slack* = sqrt(dP / alpha)
+    #
+    # where dP is the pressure error the surrounding network can absorb, and
+    # a solve that reaches it parks there instead of returning to the
+    # declared regime. Confirmed on a traced case to six digits: dP = 17088.3
+    # Pa gave slack* = 0.041338 kg/s against a measured 0.041338.
+    #
+    # The old value of 1e7 came from sizing the penalty to reach the Pt scale
+    # (1e5 Pa) at a representative wrong-sign mdot of 0.1 kg/s -- which is the
+    # worst possible choice, because it places the fixed point AT that
+    # representative mdot. On the traced case slack* was 45% of the common
+    # mass flow. At 1e11 it is 0.45%, small enough that the sign flip that
+    # restores the declared regime happens instead.
+    #
+    # NOT dimensionless: alpha carries Pa/(kg/s)^2, so this value is tied to
+    # the scales of the validation set (mdot ~ 1e-1 kg/s, Pt ~ 1e5-1e6 Pa).
+    # A network far outside them wants the same slack*/mdot_ref ratio, i.e.
+    # a scale-aware alpha; that is a residual-form change and is not made
+    # here. Measured across the random boundary harness the response is
+    # monotone in alpha and flat from 1e9 up, so this is a saturation point
+    # rather than a tuned optimum (issue #272).
+    soft_penalty_alpha: float = 1.0e11
 
     #: TUNED CONSTANT -- combaero's joining-side etransfer correction, an
     #: extension to Mynard 2015 (not in the paper). Vanishes at psi = 1 by

--- a/python/tests/test_mpce_soft_barrier_fixed_point.py
+++ b/python/tests/test_mpce_soft_barrier_fixed_point.py
@@ -1,0 +1,216 @@
+"""The soft barrier had a fixed point, and solves parked in it.
+
+`MPCEv2Element` refuses a port flowing against its declared direction. In
+non-strict mode it replaces the physics with a "soft barrier" whose docstring
+promises it "pulls Newton back toward mdot_i = 0, from which a sign flip
+restores the strict-physics residual on the next iteration". Measured, it did
+the opposite.
+
+The penalty is added INTO the continuity row rather than occupying one of its
+own::
+
+    R_i = (Pt_i - Pt_jct) + alpha * max(0, -e_i * mdot_i)^2
+
+so the solver can zero that row by carrying a pressure error equal and
+opposite to the penalty instead of by driving the slack to zero. The barrier
+is then not a barrier: it is a fabricated pressure loss the network happily
+accommodates, with a fixed point at
+
+    slack* = sqrt(dP / alpha)
+
+where dP is the pressure error the surrounding network can absorb. At the old
+alpha of 1e7 that put slack* at 45% of the common mass flow -- nowhere near
+the mdot = 0 the sign flip needs -- and a traced case sat there at a residual
+floor of 1.6e4 Pa while an in-regime root existed and converged to |F| = 1e-5
+when seeded at it.
+
+The fix is the weight, not the form: alpha = 1e11 moves the fixed point to
+0.45% of the common flow. Across the random boundary harness the response is
+monotone in alpha and flat from 1e9 up, so this is a saturation point and not
+a tuned optimum.
+
+Issue #272. Full record in `validation/junction/MPCE_CPP_PORT_DESIGN.md`
+section 7c.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+import warnings
+
+import numpy as np
+import pytest
+
+from combaero.network import NetworkSolver
+from combaero.network.mpce_v2_element import MPCEv2Element
+from validation.junction import random_robustness as rr
+
+_TRACED_SEED = 20260906
+
+
+@pytest.fixture(scope="module")
+def traced_case():
+    """The plateau case the investigation took apart: joining flow, branch at
+    156.3 deg, area ratio 2.565, driven by a flow and two pressures."""
+    rng = random.Random(_TRACED_SEED)
+    for _ in range(400):
+        case = rr.sample(rng)
+        if rr.has_root(case) is not True:
+            continue
+        if (
+            case.joining
+            and case.drive == "flow_and_pressures"
+            and 156.0 < case.theta_deg < 156.5
+            and 2.5 < case.psi < 2.6
+        ):
+            return case
+    pytest.skip("the traced case is no longer produced by this seed")
+
+
+def _solve(case, alpha: float):
+    original = MPCEv2Element.soft_penalty_alpha
+    MPCEv2Element.soft_penalty_alpha = alpha
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            return NetworkSolver(rr.build(case)).solve(timeout=30.0)
+    finally:
+        MPCEv2Element.soft_penalty_alpha = original
+
+
+# ---------------------------------------------------------------------------
+# The mechanism
+# ---------------------------------------------------------------------------
+
+
+def test_the_penalty_shares_a_row_with_the_continuity_relation():
+    """The structural cause. If the penalty ever gets a row of its own this
+    test should be the one that fails, because the fixed point goes with it."""
+    element = MPCEv2Element(
+        id="jct",
+        inlet_nodes=["a", "b"],
+        outlet_nodes=["c"],
+        inlet_angles_deg=[0.0, 90.0],
+        outlet_angles_deg=[0.0],
+        port_areas=[0.01, 0.01, 0.01],
+        flow_direction="merge",
+        strict=False,
+    )
+    assert element.N == 3
+    # N ports + one mass row: no spare row for a penalty to live in.
+    assert len(element.port_nodes) + 1 == 4
+
+
+def test_the_barrier_fixed_point_follows_the_closed_form(traced_case):
+    """slack* = sqrt(dP / alpha). Measured against the formula rather than
+    against a recorded number, so it pins the mechanism and not an output."""
+    sol = _solve(traced_case, 1.0e7)
+
+    assert not sol["__success__"], "the old weight is expected to fail here"
+    names = list(sol["__unknown_names__"])
+    x = np.array(sol["__x_solution__"])
+
+    # Two quantities measured independently of each other: the slack comes
+    # from a mass-flow unknown, dP from two pressure unknowns. The claim is
+    # that the barrier balances one against the other.
+    slack = abs(float(x[names.index("lc_str.m_dot")]))
+    dP = abs(float(x[names.index("port_str.Pt")]) - float(x[names.index("jct.P_jct")]))
+    assert slack > 0.0 and dP > 0.0
+
+    predicted = math.sqrt(dP / 1.0e7)
+    assert predicted == pytest.approx(slack, rel=0.25), (
+        f"slack {slack:.6f} kg/s against sqrt(dP/alpha) = {predicted:.6f} "
+        f"for dP = {dP:.1f} Pa: the barrier is not balancing the pressure error"
+    )
+
+    # And the balance point is a large fraction of the flow, which is why the
+    # sign flip the barrier is supposed to enable never happens.
+    m_com = abs(float(x[names.index("lc_com.m_dot")]))
+    assert slack / m_com > 0.3, (
+        f"the fixed point sat at {100.0 * slack / m_com:.1f}% of the common flow"
+    )
+
+
+def test_an_in_regime_root_existed_all_along(traced_case):
+    """The floor was not the model running out of solutions. Seeded at the
+    operating point the reduced system predicts, the same network converges."""
+    m_com, q = rr.operating_point(traced_case)
+    solver = NetworkSolver(rr.build(traced_case))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        seed = solver.solve(timeout=30.0)
+    names = list(seed["__unknown_names__"])
+    x0 = np.array(seed["__x_solution__"])
+    for name, value in (
+        ("lc_com.m_dot", m_com),
+        ("lc_str.m_dot", m_com * (1.0 - q)),
+        ("lc_bra.m_dot", m_com * q),
+    ):
+        x0[names.index(name)] = value
+
+    original = MPCEv2Element.soft_penalty_alpha
+    MPCEv2Element.soft_penalty_alpha = 1.0e7
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            sol = solver.solve(timeout=30.0, x0=x0)
+    finally:
+        MPCEv2Element.soft_penalty_alpha = original
+
+    assert sol["__success__"], "the in-regime root is not reachable even when seeded"
+    assert sol["__final_norm__"] < 1e-3
+
+
+# ---------------------------------------------------------------------------
+# The fix
+# ---------------------------------------------------------------------------
+
+
+def test_the_traced_case_converges_at_the_shipped_weight(traced_case):
+    sol = _solve(traced_case, MPCEv2Element.soft_penalty_alpha)
+
+    assert sol["__success__"], f"|F| = {sol['__final_norm__']:.4e}"
+    assert sol["__final_norm__"] < 1e-3
+
+
+def test_it_converges_into_the_declared_regime(traced_case):
+    """Not merely to something. The element is declared a merge, and the
+    solution must have both inlets flowing in -- otherwise the barrier has
+    been traded for a reversed root, which is a different answer."""
+    sol = _solve(traced_case, MPCEv2Element.soft_penalty_alpha)
+    names = list(sol["__unknown_names__"])
+    x = np.array(sol["__x_solution__"])
+
+    assert sol["__success__"]
+    assert float(x[names.index("lc_str.m_dot")]) > 0.0
+    assert float(x[names.index("lc_bra.m_dot")]) > 0.0
+
+
+def test_the_weight_is_on_the_saturation_plateau():
+    """Guards against the constant being a tuned optimum: the response must be
+    flat above it, so neighbouring decades do as well."""
+    assert MPCEv2Element.soft_penalty_alpha >= 1.0e9
+
+
+@pytest.mark.parametrize("alpha", [1.0e9, 1.0e10, 1.0e11, 1.0e12])
+def test_neighbouring_decades_all_solve_the_traced_case(traced_case, alpha):
+    assert _solve(traced_case, alpha)["__success__"]
+
+
+# ---------------------------------------------------------------------------
+# No regression in aggregate
+# ---------------------------------------------------------------------------
+
+
+def test_the_random_harness_does_not_regress():
+    """Banded, because it is a convergence rate over random draws and not a
+    deterministic invariant. Baseline at alpha = 1e7 was 98.3%."""
+    summary = rr.run(n=150, seed=_TRACED_SEED)
+    text = rr.format_summary(summary)
+
+    import re
+
+    match = re.search(r"within Mach 0\.3\s+\d+\s+([\d.]+)%", text)
+    assert match, "the harness no longer reports the in-range convergence rate"
+    assert float(match.group(1)) >= 97.0, text

--- a/validation/junction/MPCE_CPP_PORT_DESIGN.md
+++ b/validation/junction/MPCE_CPP_PORT_DESIGN.md
@@ -533,6 +533,77 @@ must preserve; it does not buy convergence here.
 and then reverting with `git checkout` reverted the fix as well. Commit
 first, then instrument.
 
+## 7c. Step 2 follow-up: the residual plateau is a mode seam (2026-09-07)
+
+Some non-converged solves have a well-behaved residual history that flattens
+onto a floor well above zero. A minimum that is not a root says an equation,
+a coefficient or a penalty is blocking the real root. One such case was taken
+apart to find which.
+
+**The case,** from the random-boundary sweep: joining flow, `flow_and_pressures`
+drive, branch at 156.3 deg (nearly head-on to the straight inlet), area ratio
+2.565, `k_straight` +0.710, `k_branch` +4.285. Floor `|F|` = 1.598e4 with the
+soft barrier on, 2.44e4 with it off.
+
+**The soft barrier is not the cause.** It was the first hypothesis and it is
+plausible from the magnitudes alone: `soft_penalty_alpha` is 1e7 and the
+reversed port sits at 0.04 kg/s, whose product is the right order. Falsified
+by sweeping alpha 1e7 -> 0: floors 1.598e4, 2.367e4, 2.435e4, 2.443e4,
+2.443e4, 2.443e4. The floor does not scale with alpha, and removing the
+barrier makes it **higher**.
+
+**Choking is not the cause.** With the barrier off the port Machs are 0.171,
+0.050 and 0.722 against a critical `Pt/P` of 1.892.
+
+**Two rows carry the floor, equal and opposite.** With the barrier off,
+`port_bra.Pt` at -1.2213e4 and `b_com.P` at +1.2213e4, 31.5% of `|F|` each.
+That 12213 Pa is exactly `b_bra.Pt - port_bra.Pt`: the total-pressure equality
+across a *lossless* connection cannot be closed.
+
+**The Jacobian is singular there, but that is not what blocks it.** SVD of the
+12x12 at the floor: rank 11, singular values 2.35e-1 down to 1.25e-7,
+condition 2.6e13. The null direction is almost purely `port_bra.P` (0.9987);
+the left null space pairs the `port_bra.P` and `jct.P_jct` rows at
+-0.707/+0.707, i.e. two rows have become linearly dependent. **But 0.0% of
+`|F|^2` lies in the unreachable directions.** So the residual is reducible in
+principle. Newton simply has no well-defined step.
+
+**The mechanism is a mode seam.** The element is declared `flow_direction="merge"`
+with the straight and branch ports as inlets. At the floor the straight port
+carries **-0.0268 kg/s**: physically the junction has become a *dividing* one.
+The closure reads supplier and collector from the signed flows at runtime, so
+it does switch. Sweeping the straight port's flow through zero with the other
+unknowns held at the floor:
+
+| `lc_str.m_dot` | `\|F\|` | sigma_min | cond | mode |
+|---|---|---|---|---|
+| -1e-4 | 2.596e4 | 1.251e-7 | 2.65e13 | dividing |
+| 0 | 1.840e5 | 3.06e-17 | 1.09e23 | on the seam |
+| +1e-4 | 3.278e5 | 6.585e-7 | 9.11e12 | merging |
+
+The residual jumps by an order of magnitude across a flow change of 2e-4 kg/s,
+and the system is near-singular on **both** sides, not only at the seam. At
+exactly zero the third behaviour is the step-2(b) fix: the excluded port is
+snapped to its *declared* direction, which is why `|F|` there sits near the
+merging value rather than between the two. The solve parks on this surface.
+
+**Limits of the evidence.** The sweep varies one unknown while holding the
+others at the dividing-side solution, so part of that jump is the far side
+being an inconsistent state rather than the residual being discontinuous in
+the full state. And the near-singularity is present on both sides, so the seam
+alone does not create it. What is established is that the plateau is neither a
+penalty artefact nor a blocked root, and that a port reversal changes which
+residual formula is evaluated.
+
+**What this means for the port.** The supplier/collector classification is a
+branch on a primal quantity that changes the residual formula, and the
+analytic Jacobian does not see it -- it differentiates whichever branch is
+active as though the classification were constant. Step 4's branch-on-primal
+note covers the pseudosupplier reorientation but not this one. A C++ port that
+transcribes the Python faithfully inherits the seam, so this is a defect to
+resolve before the port, not after. It is the one open item behind the
+"implementation correct first, then port" decision in section 9.
+
 ## 8. The port, sequenced by provenance
 
 Each step has a gate that is a table against digitised data, not a green suite.

--- a/validation/junction/MPCE_CPP_PORT_DESIGN.md
+++ b/validation/junction/MPCE_CPP_PORT_DESIGN.md
@@ -545,12 +545,17 @@ drive, branch at 156.3 deg (nearly head-on to the straight inlet), area ratio
 2.565, `k_straight` +0.710, `k_branch` +4.285. Floor `|F|` = 1.598e4 with the
 soft barrier on, 2.44e4 with it off.
 
-**The soft barrier is not the cause.** It was the first hypothesis and it is
-plausible from the magnitudes alone: `soft_penalty_alpha` is 1e7 and the
-reversed port sits at 0.04 kg/s, whose product is the right order. Falsified
-by sweeping alpha 1e7 -> 0: floors 1.598e4, 2.367e4, 2.435e4, 2.443e4,
-2.443e4, 2.443e4. The floor does not scale with alpha, and removing the
-barrier makes it **higher**.
+**The soft barrier IS the cause -- the first sweep tested the wrong thing.**
+The magnitudes make it the obvious suspect: `soft_penalty_alpha` is 1e7 and
+the reversed port sits at 0.04 kg/s, whose product is the right order.
+Sweeping alpha 1e7 -> 0 gave floors 1.598e4, 2.367e4, 2.435e4, 2.443e4,
+2.443e4, 2.443e4, which looked like a falsification: the floor does not scale
+with alpha and is *higher* with the barrier off. It is not. Setting alpha to
+zero does not remove the barrier, it turns the element into a **lossless
+junction** (`Pt_i = Pt_jct`), which is a different wrong model that happens to
+sit further from the boundary conditions. The sweep tested the penalty's
+WEIGHT while the barrier's PATH was what mattered, and only the downward
+direction was tried. See section 7d.
 
 **Choking is not the cause.** With the barrier off the port Machs are 0.171,
 0.050 and 0.722 against a critical `Pt/P` of 1.892.
@@ -568,8 +573,8 @@ the left null space pairs the `port_bra.P` and `jct.P_jct` rows at
 `|F|^2` lies in the unreachable directions.** So the residual is reducible in
 principle. Newton simply has no well-defined step.
 
-**The mechanism is a mode seam.** The element is declared `flow_direction="merge"`
-with the straight and branch ports as inlets. At the floor the straight port
+**It is not a mode seam either.** The element is declared
+`flow_direction="merge"` with the straight and branch ports as inlets. At the floor the straight port
 carries **-0.0268 kg/s**: physically the junction has become a *dividing* one.
 The closure reads supplier and collector from the signed flows at runtime, so
 it does switch. Sweeping the straight port's flow through zero with the other
@@ -603,6 +608,96 @@ note covers the pseudosupplier reorientation but not this one. A C++ port that
 transcribes the Python faithfully inherits the seam, so this is a defect to
 resolve before the port, not after. It is the one open item behind the
 "implementation correct first, then port" decision in section 9.
+
+## 7d. The plateau, fixed: the barrier's fixed point (2026-09-07)
+
+Section 7c identified the plateau's shape but named the wrong cause twice.
+Instrumenting the element settled it.
+
+**What the element was actually doing.** At the floor, 95.7% of residual
+evaluations took the **soft-barrier path**, not the closure. The straight
+port's declared direction is "in"; the iterate had it flowing out by 0.0413
+kg/s, and `residuals` routes any wrong-direction port to
+`_soft_barrier_residual`. Everything section 7c measured -- the two equal and
+opposite rows, the rank deficiency, the residual jump across the port's
+reversal -- was a property of the barrier, not of the junction physics. The
+"mode seam" was the boundary between the barrier path and the closure path.
+
+**Why the barrier had a fixed point.** Its docstring promises it "pulls Newton
+back toward mdot_i = 0, from which a sign flip restores the strict-physics
+residual on the next iteration". It cannot, because the penalty is added into
+the same residual row as the continuity relation:
+
+    R_i = (Pt_i - Pt_jct) + alpha * max(0, -e_i * mdot_i)^2
+
+The element has exactly N+1 rows for N+1 unknowns, so the penalty has no row
+of its own. The solver can therefore zero that row by carrying a pressure
+error equal and opposite to the penalty, instead of by driving the slack to
+zero. The penalty is not a barrier at all: it is a fabricated pressure loss
+the network accommodates, with a fixed point at
+
+    slack* = sqrt(dP / alpha)
+
+**Confirmed to six digits.** The traced case parked at slack = 0.041338 kg/s
+carrying a fabricated 17088.3 Pa, against a predicted
+`sqrt(17088.3 / 1e7)` = 0.041338. That is 45% of the common mass flow -- the
+sign flip the barrier exists to enable was never remotely close.
+
+**There was an in-regime root the whole time.** Seeded at the operating point
+the reduced incompressible system predicts, the same network converges to
+`|F|` = 1.0e-5 with every port in its declared direction. The floor was never
+the model running out of solutions.
+
+**The dead end: removing the barrier.** The first fix let the closure solve
+whatever regime the flows actually present, on the argument that a reversed
+port is a regime and not a wrong basin -- Mynard classifies from the signed
+flows at every call, and the element's own regime branches are already written
+from those masks rather than from the declaration. It fixed the traced case
+and made both aggregates **worse**: scorecard 2080 -> 1895 converged, random
+harness 98.3% -> 97.6% in range. Reverted. The barrier is doing real work
+pulling transient wrong-direction iterates back; the defect was where it
+parks, not that it exists.
+
+**The fix is the weight.** `soft_penalty_alpha` 1e7 -> 1e11 moves the fixed
+point from 45% of the common flow to 0.45%.
+
+| | alpha 1e7 | drop the barrier | alpha 1e9 | **alpha 1e11** |
+|---|---|---|---|---|
+| scorecard converged | 2080 / 2546 | 1895 | 2101 | **2108** |
+| scorecard scored | 2062 | 1873 | 2076 | **2081** |
+| Bassett mean err | 0.1548 | 0.1515 | 0.1541 | **0.1538** |
+| Idelchik mean err | 0.8902 | 0.9430 | 0.8898 | **0.8880** |
+| all sources mean err | 0.5017 | 0.4966 | 0.4995 | **0.4984** |
+| random: root exists | 91.4% | 90.4% | 92.9% | **92.9%** |
+| random: within Mach 0.3 | 98.3% | 97.6% | 99.3% | **99.3%** |
+
+Hager and Wang are unchanged to four decimals throughout.
+
+**Not a tuned optimum.** Swept across the whole random harness the response is
+monotone in alpha and flat from 1e9 upward, so 1e11 sits on a saturation
+plateau rather than at a peak. That is what makes it safe against fitting to
+the validation set: there is no peak to find.
+
+**Where the old value came from.** 1e7 was chosen so that a wrong-sign mdot of
+0.1 kg/s contributes about 1e5 Pa, "the natural Pt scale". Sizing a penalty to
+*equal* the pressure scale at a representative mdot is the worst available
+choice, because that is precisely the condition that places the fixed point at
+that mdot. The criterion is the fixed point's location, not the penalty's
+size.
+
+**Declared limitation.** `alpha` carries Pa/(kg/s)^2, so 1e11 is tied to the
+scales of the validation set (mdot ~ 1e-1 kg/s, Pt ~ 1e5-1e6 Pa). A network
+far outside them needs the same `slack*/mdot_ref` ratio, which means a
+scale-aware alpha built from the network's own pressure and mass scales. That
+is a residual-form change and is not made here.
+
+**What this means for the port.** Less than section 7c claimed. There is no
+branch-on-primal defect in the closure to resolve first: the supplier and
+collector classification is continuous through the crossing, and the angle
+construction, the common-port selection and the K sign were all measured
+identical on both sides of the traced seam. What the port must carry across is
+the barrier and its weight, since a C++ transcription with the old constant
+would reproduce the fixed point exactly.
 
 ## 8. The port, sequenced by provenance
 


### PR DESCRIPTION
Fixes the residual plateau reported in #272, and corrects the two wrong causes I named on the way there.

## The mechanism

`MPCEv2Element` replaces the physics with a "soft barrier" when a port flows against its declared direction. Its docstring promises it *"pulls Newton back toward `mdot_i = 0`, from which a sign flip restores the strict-physics residual on the next iteration"*. Instrumented, it does the opposite.

The penalty is added into the **same residual row** as the continuity relation, and the element has exactly N+1 rows for N+1 unknowns, so it has no row of its own:

```
R_i = (Pt_i - Pt_jct) + alpha * max(0, -e_i * mdot_i)^2
```

The solver can therefore zero that row by carrying a pressure error equal and opposite to the penalty, instead of by driving the slack to zero. The barrier is not a barrier — it is a fabricated pressure loss the network accommodates, with a fixed point at `slack* = sqrt(dP / alpha)`.

**Confirmed to six digits.** The traced case parked at `slack = 0.041338 kg/s` carrying a fabricated `17088.3 Pa`, against a predicted `sqrt(17088.3 / 1e7) = 0.041338`. That is **45% of the common mass flow** — the sign flip the barrier exists to enable was never close. 95.7% of residual evaluations there took the barrier path rather than the closure.

**There was an in-regime root the whole time.** Seeded at the operating point the reduced incompressible system predicts, the same network converges to `|F| = 1.0e-5` with every port in its declared direction.

## The fix

`soft_penalty_alpha` 1e7 → 1e11, which moves the fixed point to 0.45% of the common flow.

| | alpha 1e7 | drop the barrier | alpha 1e9 | **alpha 1e11** |
|---|---|---|---|---|
| scorecard converged | 2080 / 2546 | 1895 | 2101 | **2108** |
| scorecard scored | 2062 | 1873 | 2076 | **2081** |
| Bassett mean err | 0.1548 | 0.1515 | 0.1541 | **0.1538** |
| Idelchik mean err | 0.8902 | 0.9430 | 0.8898 | **0.8880** |
| all sources mean err | 0.5017 | 0.4966 | 0.4995 | **0.4984** |
| random: within Mach 0.3 | 98.3% | 97.6% | 99.3% | **99.3%** |

Hager and Wang are unchanged to four decimals throughout. Full suite green (2195 passed).

**Not a tuned optimum.** Swept across the whole random harness the response is monotone in alpha and flat from 1e9 upward — a saturation plateau, not a peak, so there is nothing here to fit to the validation set.

**Where 1e7 came from.** It was sized so a wrong-sign mdot of 0.1 kg/s contributes about 1e5 Pa, "the natural Pt scale". Sizing a penalty to *equal* the pressure scale at a representative mdot is the worst available choice: that is precisely the condition that places the fixed point at that mdot.

## Dead end, recorded

The first fix let the closure solve whichever regime the flows actually present, on the argument that a reversed port is a regime and not a wrong basin. It fixed the traced case and made **both aggregates worse** (1895 converged, 97.6%). Reverted. The barrier does real work on transient iterates; the defect was where it parks.

## Corrections to the first commit on this branch

The docs commit concluded a mode seam and cleared the penalty. Both are corrected in place:

- The downward alpha sweep that appeared to clear the penalty tested its **weight**, not its **path**. `alpha = 0` does not remove the barrier — it turns the element into a lossless junction, a different wrong model that happens to sit further from the boundary conditions.
- There is no mode seam. The supplier/collector classification, the angle construction, the common-port selection and the K sign were all measured **identical** on both sides of the crossing. What jumps is the barrier path.

That also softens what this means for the C++ port: there is no branch-on-primal defect in the closure to resolve first, but a transcription carrying the old constant would reproduce the fixed point exactly.

## Declared limitation

`alpha` carries `Pa/(kg/s)^2`, so 1e11 is tied to the scales it was measured on (mdot ~ 1e-1 kg/s, Pt ~ 1e5-1e6 Pa). A network far outside them needs the same `slack*/mdot_ref` ratio, i.e. a scale-aware weight built from the network's own scales. That is a residual-form change and is not made here.

Refs #271, #272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RNDxZouiHoJdaLpnnPjHq
