### PR TITLE
fix(junction): derive the soft-barrier weight from the network's scales (#272)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **The junction soft-barrier weight is derived from the network's scales
+  instead of being a fixed constant.** `soft_penalty_alpha` multiplies a
+  squared mass flow to produce a pressure, so it carries `Pa/(kg/s)^2` and is
+  only meaningful against a particular network's scales; the barrier's fixed
+  point sits at `slack* = sqrt(dP/alpha)`, and what matters is that as a
+  fraction of the flow. Measured on one junction scaled over five decades with
+  every dimensionless group held fixed, the weight needed to converge follows
+  `1/m_ref^2` exactly -- two decades of weight per decade of size -- and the
+  previous fixed value failed on the same junction at a hundredth of its size.
+  `NetworkSolver` now derives `alpha = P_ref / (f*m_ref)^2` from the reference
+  state it already computes for seeding and hands it to each element that owns
+  a barrier, frozen for the solve so the residual and Jacobian are unchanged in
+  form. A degenerate reference state falls back to the fixed default rather
+  than producing a weaker barrier, and an explicitly set `soft_penalty_alpha`
+  always wins. Measured: the junction validation scorecard is identical to the
+  digit (2108 of 2546 converged, every source's mean error unchanged) because
+  that set already sat on the saturation plateau, while the same junction now
+  converges across seven decades of size instead of five.
 - **The junction soft barrier no longer has a fixed point that solves park
   in.** `MPCEv2Element` replaces the physics with a "soft barrier" when a port
   flows against its declared direction, meant to pull Newton back toward

--- a/docs/API_PYTHON.md
+++ b/docs/API_PYTHON.md
@@ -621,6 +621,49 @@ Changing any of these values is a retune and needs a before/after table
 before it lands, not a silent edit -- `python/tests/test_junction_tuned_constants.py`
 pins the documented values.
 
+### The Junction Soft-Barrier Weight
+
+Distinct from the tuned constants above: this is a **numerical** parameter, not
+physics, and it is derived rather than declared.
+
+When `strict=False` and a port flows against its declared direction,
+`MPCEv2Element` replaces the physics with a continuity residual plus a
+one-sided quadratic penalty, `alpha * max(0, -e_i * mdot_i)^2`. The penalty
+shares its row with the continuity relation, so it balances against a pressure
+error rather than driving the offending flow to zero, and has a fixed point at
+`slack* = sqrt(dP / alpha)`. A solve that reaches it parks there.
+
+`alpha` therefore carries `Pa/(kg/s)^2` and cannot be a constant: the weight
+needed scales as `1/m_ref^2`, two decades per decade of network size.
+`NetworkSolver` derives it before each solve from the reference state it
+already computes for seeding:
+
+```python
+alpha = P_ref / (BARRIER_SLACK_FRACTION * m_ref) ** 2   # f = 0.005
+```
+
+placing the fixed point at 0.5% of the reference mass flow whatever the
+network's size. It is frozen for the solve, so the residual and Jacobian are
+unchanged in form.
+
+| name | where | meaning |
+|---|---|---|
+| `BARRIER_SLACK_FRACTION` | `combaero.network.mpce_v2_element` | where the fixed point is placed, as a fraction of `m_ref` |
+| `DEFAULT_SOFT_PENALTY_ALPHA` | same | fallback when no solver has supplied a weight, or the reference state is degenerate |
+| `scaled_penalty_alpha(P_ref, m_ref)` | same | the derivation, exposed for testing |
+| `MPCEv2Element.effective_penalty_alpha()` | element | the weight actually used, after precedence |
+
+Precedence: an explicitly set `soft_penalty_alpha` always wins, then the
+solver-supplied scale-aware weight, then the fallback. So the tuning knob keeps
+working:
+
+```python
+element.soft_penalty_alpha = 5.0e7   # explicit: overrides the derived weight
+```
+
+Raising `alpha` shrinks the fixed point and never destabilises the solve --
+the response is monotone and saturates -- so when in doubt, larger.
+
 ### Combustion Integration
 ```python
 from combaero.network.combustion import (

--- a/python/combaero/network/mpce_v2_element.py
+++ b/python/combaero/network/mpce_v2_element.py
@@ -51,6 +51,47 @@ from combaero.network.components import (
 FlowDirection = Literal["merge", "branch"]
 
 
+#: Fallback soft-barrier weight, in Pa/(kg/s)^2. Only used when the solver has
+#: not supplied a scale-aware value (see ``scaled_penalty_alpha``).
+DEFAULT_SOFT_PENALTY_ALPHA: float = 1.0e11
+
+#: Where the soft barrier's fixed point is placed, as a fraction of the
+#: network's reference mass flow.
+#:
+#: The barrier's penalty shares a residual row with the continuity relation, so
+#: it balances against a pressure error rather than driving the slack to zero,
+#: giving a fixed point at ``slack* = sqrt(dP / alpha)``. Solving that for alpha
+#: at ``slack* = f * m_ref`` and taking the reference pressure as the largest
+#: error the network could absorb gives
+#:
+#:     alpha = P_ref / (f * m_ref)^2
+#:
+#: which is dimensionally consistent and therefore size-independent, unlike a
+#: fixed alpha. 0.5% is not a fitted value: measured on the random boundary
+#: harness the response is monotone in alpha and flat well below this, so the
+#: choice is a margin above the point where solves stop parking in the barrier
+#: (measured at roughly 14% of the reference flow for the traced case, and
+#: case-dependent). Using ``P_ref`` in place of the pressure error the network
+#: can really absorb overestimates it, which errs toward a larger alpha and a
+#: smaller fixed point -- the safe direction (issue #272).
+BARRIER_SLACK_FRACTION: float = 0.005
+
+
+def scaled_penalty_alpha(ref_pressure: float, ref_mdot: float) -> float:
+    """Soft-barrier weight for a network of the given pressure and flow scale.
+
+    Returns ``DEFAULT_SOFT_PENALTY_ALPHA`` when either scale is unusable, so a
+    degenerate reference state can never produce a weaker barrier than the
+    fallback.
+    """
+    if not (math.isfinite(ref_pressure) and math.isfinite(ref_mdot)):
+        return DEFAULT_SOFT_PENALTY_ALPHA
+    if ref_pressure <= 0.0 or ref_mdot <= 0.0:
+        return DEFAULT_SOFT_PENALTY_ALPHA
+    slack = BARRIER_SLACK_FRACTION * ref_mdot
+    return float(ref_pressure / (slack * slack))
+
+
 class MPCEv2Element(MultiPortChamberElement):
     """Mynard Unified0D residual on MPCE-v1's topology framework.
 
@@ -107,14 +148,22 @@ class MPCEv2Element(MultiPortChamberElement):
     # mass flow. At 1e11 it is 0.45%, small enough that the sign flip that
     # restores the declared regime happens instead.
     #
-    # NOT dimensionless: alpha carries Pa/(kg/s)^2, so this value is tied to
-    # the scales of the validation set (mdot ~ 1e-1 kg/s, Pt ~ 1e5-1e6 Pa).
-    # A network far outside them wants the same slack*/mdot_ref ratio, i.e.
-    # a scale-aware alpha; that is a residual-form change and is not made
-    # here. Measured across the random boundary harness the response is
-    # monotone in alpha and flat from 1e9 up, so this is a saturation point
-    # rather than a tuned optimum (issue #272).
-    soft_penalty_alpha: float = 1.0e11
+    # NOT dimensionless: alpha carries Pa/(kg/s)^2, so a fixed value is tied
+    # to one network size. Measured on a single junction scaled over five
+    # decades with every dimensionless group held fixed, the alpha needed to
+    # converge follows 1/m_ref^2 exactly -- two decades of alpha per decade of
+    # size -- and this constant fails on the same junction at a hundredth of
+    # its size. It is therefore only the FALLBACK. ``NetworkSolver`` derives a
+    # scale-aware value from the network's own reference pressure and mass
+    # flow and hands it over (see ``BARRIER_SLACK_FRACTION`` and
+    # ``scaled_penalty_alpha``); this value is used when no solver has supplied
+    # one, or when a caller has set ``soft_penalty_alpha`` explicitly, which
+    # always wins.
+    soft_penalty_alpha: float = DEFAULT_SOFT_PENALTY_ALPHA
+
+    #: Scale-aware weight supplied by ``NetworkSolver`` before a solve. ``None``
+    #: when no solver has run, in which case ``soft_penalty_alpha`` is used.
+    _barrier_alpha_scaled: float | None = None
 
     #: TUNED CONSTANT -- combaero's joining-side etransfer correction, an
     #: extension to Mynard 2015 (not in the paper). Vanishes at psi = 1 by
@@ -431,6 +480,21 @@ class MPCEv2Element(MultiPortChamberElement):
         diag["Pt_jct"] = float(Pt_jct)
         return diag
 
+    def effective_penalty_alpha(self) -> float:
+        """The soft-barrier weight this element will actually use.
+
+        An explicitly set ``soft_penalty_alpha`` always wins -- that is the
+        tuning knob, and a caller who has reached for it means it. Otherwise
+        the scale-aware value the solver derived from the network's own
+        pressure and mass scales is used, falling back to the fixed default
+        when no solver has supplied one.
+        """
+        if self.soft_penalty_alpha != DEFAULT_SOFT_PENALTY_ALPHA:
+            return float(self.soft_penalty_alpha)
+        if self._barrier_alpha_scaled is None:
+            return float(self.soft_penalty_alpha)
+        return float(self._barrier_alpha_scaled)
+
     def _soft_barrier_residual(
         self,
         states: list[NetworkMixtureState],
@@ -449,7 +513,7 @@ class MPCEv2Element(MultiPortChamberElement):
         next iteration.
         """
         N = self.N
-        alpha = float(self.soft_penalty_alpha)
+        alpha = float(self.effective_penalty_alpha())
         residuals: list[float] = []
         jac: dict[int, dict[str, float]] = {}
         for i in range(N):

--- a/python/combaero/network/solver.py
+++ b/python/combaero/network/solver.py
@@ -22,6 +22,7 @@ from .components import (
     WallNode,
 )
 from .graph import FlowNetwork
+from .mpce_v2_element import scaled_penalty_alpha
 
 
 class SolverTimeoutError(Exception):
@@ -647,6 +648,41 @@ class NetworkSolver:
             if port_elems[i]:
                 out[f"{port_elems[i]}.m_dot"] = share * scale
         return out
+
+    def _apply_barrier_scale(self) -> None:
+        """Give every chamber element a soft-barrier weight matched to this
+        network's scales.
+
+        The barrier's penalty shares a residual row with the continuity
+        relation, so it balances against a pressure error instead of driving
+        the offending mass flow to zero, and its fixed point sits at
+        ``slack* = sqrt(dP / alpha)``. ``alpha`` therefore carries
+        Pa/(kg/s)^2 and a fixed value only holds the fixed point at a sensible
+        fraction of the flow for ONE network size. Measured on a single
+        junction scaled over five decades with every dimensionless group held
+        fixed, the alpha needed to converge follows ``1/m_ref^2`` exactly, and
+        the shipped fallback fails on that junction at a hundredth of its size
+        (issue #272).
+
+        The weight is frozen for the solve rather than recomputed per
+        iterate, so it stays a constant in the residual and the Jacobian is
+        unchanged. A caller who sets ``soft_penalty_alpha`` explicitly keeps
+        it; see ``MPCEv2Element.effective_penalty_alpha``.
+        """
+        # Only elements that actually own a soft barrier. The chamber base is
+        # shared with EjectorElement and ConstantKTeeElement, and reaching for
+        # every subclass is how the junction seed broke the GUI ejector.
+        elements = [
+            e
+            for e in self.network.elements.values()
+            if isinstance(e, MultiPortChamberElement) and hasattr(e, "effective_penalty_alpha")
+        ]
+        if not elements:
+            return
+        ref = self._infer_reference_state()
+        alpha = scaled_penalty_alpha(float(ref["P"]), float(ref["m_dot"]))
+        for element in elements:
+            element._barrier_alpha_scaled = alpha
 
     def _build_x0(self) -> np.ndarray:
         """
@@ -1666,6 +1702,7 @@ class NetworkSolver:
         topologies, 11/16 on merge -- prefer 'default' /
         'analytical_pt_prop' for merge networks.
         """
+        self._apply_barrier_scale()
         retry_applicable = (
             auto_retry
             and x0 is None

--- a/python/combaero/network/solver.py
+++ b/python/combaero/network/solver.py
@@ -22,7 +22,6 @@ from .components import (
     WallNode,
 )
 from .graph import FlowNetwork
-from .mpce_v2_element import scaled_penalty_alpha
 
 
 class SolverTimeoutError(Exception):
@@ -679,6 +678,11 @@ class NetworkSolver:
         ]
         if not elements:
             return
+        # Imported here, not at module scope: mpce_v2_element pulls in the
+        # sympy-derived Jacobian, and sympy is not installed in the minimal
+        # build environments that only import combaero (Windows/MSVC CI).
+        from .mpce_v2_element import scaled_penalty_alpha
+
         ref = self._infer_reference_state()
         alpha = scaled_penalty_alpha(float(ref["P"]), float(ref["m_dot"]))
         for element in elements:

--- a/python/tests/test_barrier_scale_awareness.py
+++ b/python/tests/test_barrier_scale_awareness.py
@@ -1,0 +1,200 @@
+"""The soft-barrier weight has units, so it cannot be a constant.
+
+#302 fixed the barrier's fixed point by raising `soft_penalty_alpha` from 1e7
+to 1e11. That was the right direction and the wrong kind of answer. The weight
+multiplies a squared mass flow to produce a pressure::
+
+    R_i = (Pt_i - Pt_jct) + alpha * max(0, -e_i * mdot_i)^2
+
+so it carries Pa/(kg/s)^2 and is only meaningful against a particular
+network's scales. The barrier's fixed point sits at `slack* = sqrt(dP/alpha)`,
+and what matters is that as a FRACTION of the flow, `slack*/m_ref`, which a
+fixed alpha holds constant for exactly one network size.
+
+Measured on one junction scaled over five decades with every dimensionless
+group held fixed -- same pressure, Mach, angle, area ratio, split and loss
+coefficients, only bigger or smaller -- the alpha needed to converge follows
+`1/m_ref^2` exactly: 1e14, 1e12, 1e10, 1e8, 1e6, 1e4 for size factors 1e-3
+through 1e2. Two decades of alpha per decade of size, with the prediction
+`alpha_ref * (m_ref/m)^2` landing on the measured value every time. The 1e11
+fallback fails on that junction at a hundredth of its size.
+
+`NetworkSolver` now derives the weight from the network's own reference
+pressure and mass flow, `alpha = P_ref / (f * m_ref)^2` with `f` =
+`BARRIER_SLACK_FRACTION`, and freezes it for the solve -- so it is a constant
+in the residual and the Jacobian is unchanged.
+
+Issue #272. Record in `validation/junction/MPCE_CPP_PORT_DESIGN.md` section 7e.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import math
+import random
+import warnings
+
+import pytest
+
+from combaero.network import NetworkSolver
+from combaero.network.mpce_v2_element import (
+    BARRIER_SLACK_FRACTION,
+    DEFAULT_SOFT_PENALTY_ALPHA,
+    MPCEv2Element,
+    scaled_penalty_alpha,
+)
+from validation.junction import random_robustness as rr
+
+
+@pytest.fixture(scope="module")
+def base_case():
+    rng = random.Random(20260906)
+    for _ in range(400):
+        case = rr.sample(rng)
+        if rr.has_root(case) is not True:
+            continue
+        if (
+            case.joining
+            and case.drive == "flow_and_pressures"
+            and 156.0 < case.theta_deg < 156.5
+            and 2.5 < case.psi < 2.6
+        ):
+            return case
+    pytest.skip("the traced case is no longer produced by this seed")
+
+
+def _converges(case) -> bool:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return rr.classify(rr.build(case)) == "converged"
+
+
+# ---------------------------------------------------------------------------
+# The weight itself
+# ---------------------------------------------------------------------------
+
+
+def test_the_weight_places_the_fixed_point_at_the_intended_fraction():
+    """alpha = P_ref / (f*m_ref)^2 must invert to slack* = f*m_ref, taking
+    dP = P_ref. Checked by going back through sqrt(dP/alpha) rather than by
+    restating the formula."""
+    for pressure, mdot in ((1.0e5, 0.1), (6.245e5, 9.2576e-2), (2.0e6, 30.0)):
+        alpha = scaled_penalty_alpha(pressure, mdot)
+        slack_star = math.sqrt(pressure / alpha)
+        assert slack_star == pytest.approx(BARRIER_SLACK_FRACTION * mdot, rel=1e-12)
+
+
+def test_the_weight_scales_as_one_over_mdot_squared():
+    """The measured law: two decades of alpha per decade of size."""
+    a1 = scaled_penalty_alpha(1.0e5, 1.0)
+    a2 = scaled_penalty_alpha(1.0e5, 0.1)
+    a3 = scaled_penalty_alpha(1.0e5, 0.01)
+
+    assert a2 / a1 == pytest.approx(100.0, rel=1e-12)
+    assert a3 / a2 == pytest.approx(100.0, rel=1e-12)
+
+
+@pytest.mark.parametrize(
+    ("pressure", "mdot"),
+    [(0.0, 1.0), (1.0e5, 0.0), (-1.0e5, 1.0), (1.0e5, -1.0), (float("nan"), 1.0)],
+)
+def test_a_degenerate_reference_state_falls_back(pressure, mdot):
+    """A bad reference must never produce a WEAKER barrier than the fallback,
+    which is what a naive divide would do at m_ref -> large or P_ref -> 0."""
+    assert scaled_penalty_alpha(pressure, mdot) == DEFAULT_SOFT_PENALTY_ALPHA
+
+
+# ---------------------------------------------------------------------------
+# Which weight an element actually uses
+# ---------------------------------------------------------------------------
+
+
+def _element() -> MPCEv2Element:
+    return MPCEv2Element(
+        id="jct",
+        inlet_nodes=["a", "b"],
+        outlet_nodes=["c"],
+        inlet_angles_deg=[0.0, 90.0],
+        outlet_angles_deg=[0.0],
+        port_areas=[0.01, 0.01, 0.01],
+        flow_direction="merge",
+        strict=False,
+    )
+
+
+def test_without_a_solver_the_element_uses_the_fallback():
+    assert _element().effective_penalty_alpha() == DEFAULT_SOFT_PENALTY_ALPHA
+
+
+def test_the_solver_supplied_weight_is_used():
+    element = _element()
+    element._barrier_alpha_scaled = 1.234e13
+
+    assert element.effective_penalty_alpha() == 1.234e13
+
+
+def test_an_explicit_setting_always_wins():
+    """The tuning knob has to keep working: a caller who sets the weight means
+    it, and must not have it silently overridden by the network's scales."""
+    element = _element()
+    element._barrier_alpha_scaled = 1.234e13
+    element.soft_penalty_alpha = 5.0e7
+
+    assert element.effective_penalty_alpha() == 5.0e7
+
+
+def test_the_solver_hands_the_scale_to_every_chamber_element(base_case):
+    solver = NetworkSolver(rr.build(base_case))
+    elements = [e for e in solver.network.elements.values() if isinstance(e, MPCEv2Element)]
+    assert elements
+    assert all(e._barrier_alpha_scaled is None for e in elements)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        solver.solve(timeout=30.0)
+
+    for element in elements:
+        assert element._barrier_alpha_scaled is not None
+        assert element.effective_penalty_alpha() == element._barrier_alpha_scaled
+
+
+def test_the_weight_is_frozen_for_the_solve_not_recomputed_per_iterate(base_case):
+    """If it tracked the state it would enter the Jacobian, which is the one
+    thing that would make this a residual-form change."""
+    solver = NetworkSolver(rr.build(base_case))
+    element = next(e for e in solver.network.elements.values() if isinstance(e, MPCEv2Element))
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        solver.solve(timeout=30.0)
+    first = element._barrier_alpha_scaled
+
+    import numpy as np
+
+    solver._residuals(np.array(solver._last_x) * 1.5)
+    assert element._barrier_alpha_scaled == first
+
+
+# ---------------------------------------------------------------------------
+# The measurement that motivated it
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("factor", [1.0e-4, 1.0e-3, 1.0e-2, 1.0e-1, 1.0, 1.0e1, 1.0e2, 1.0e3])
+def test_the_same_junction_converges_at_every_size(base_case, factor):
+    """Seven decades of size. Scaling the port area at fixed pressure, Mach,
+    angle, area ratio, split and loss coefficients leaves every dimensionless
+    group untouched: it is the same junction, so it must still solve."""
+    assert _converges(dataclasses.replace(base_case, area=base_case.area * factor))
+
+
+@pytest.mark.parametrize("factor", [1.0e-4, 1.0e-3, 1.0e-2])
+def test_the_fixed_fallback_would_have_failed_at_those_sizes(base_case, factor, monkeypatch):
+    """The control. Without the hand-off the element falls back to the fixed
+    weight, and these are the sizes it cannot solve -- which is the whole
+    reason the weight is derived rather than declared. If this ever goes green
+    the motivating measurement has changed and the constant should be
+    re-derived, not the test relaxed."""
+    monkeypatch.setattr(NetworkSolver, "_apply_barrier_scale", lambda self: None)
+
+    assert not _converges(dataclasses.replace(base_case, area=base_case.area * factor))

--- a/validation/junction/MPCE_CPP_PORT_DESIGN.md
+++ b/validation/junction/MPCE_CPP_PORT_DESIGN.md
@@ -685,11 +685,12 @@ choice, because that is precisely the condition that places the fixed point at
 that mdot. The criterion is the fixed point's location, not the penalty's
 size.
 
-**Declared limitation.** `alpha` carries Pa/(kg/s)^2, so 1e11 is tied to the
-scales of the validation set (mdot ~ 1e-1 kg/s, Pt ~ 1e5-1e6 Pa). A network
-far outside them needs the same `slack*/mdot_ref` ratio, which means a
-scale-aware alpha built from the network's own pressure and mass scales. That
-is a residual-form change and is not made here.
+**Declared limitation -- since measured and removed, see section 7e.**
+`alpha` carries Pa/(kg/s)^2, so 1e11 is tied to the scales of the validation
+set. Measured on one junction scaled over five decades, the alpha needed
+follows 1/m_ref^2 exactly and 1e11 fails at a hundredth of the size. The
+weight is now derived from the network's own scales. Calling it a
+residual-form change was also wrong: frozen for the solve it is not one.
 
 **What this means for the port.** Less than section 7c claimed. There is no
 branch-on-primal defect in the closure to resolve first: the supplier and
@@ -698,6 +699,89 @@ construction, the common-port selection and the K sign were all measured
 identical on both sides of the traced seam. What the port must carry across is
 the barrier and its weight, since a C++ transcription with the old constant
 would reproduce the fixed point exactly.
+
+## 7e. The barrier weight has units, so it cannot be a constant (2026-09-07)
+
+Section 7d fixed the barrier's fixed point by raising `soft_penalty_alpha`
+from 1e7 to 1e11, and closed with the scale-dependence as a declared
+limitation. It was declared but not measured. Measuring it overturned the
+"1e11 is fine" reading.
+
+**The controlled experiment.** Take one junction and change only its SIZE.
+Scaling the port area at fixed pressure, Mach, angle, area ratio, split and
+loss coefficients leaves every dimensionless group untouched -- it is the same
+junction, bigger or smaller -- so anything that changes is a scale artefact.
+For each size, the smallest `alpha` (swept by decades) that converges:
+
+| size factor | m_ref (kg/s) | alpha needed | predicted `alpha_ref (m_ref/m)^2` |
+|---|---|---|---|
+| 1e-3 | 9.26e-5 | 1e14 | |
+| 1e-2 | 9.26e-4 | 1e12 | |
+| 1e-1 | 9.26e-3 | 1e10 | |
+| 1e0 | 9.26e-2 | 1e8 | 1e8 |
+| 1e1 | 9.26e-1 | 1e6 | 1e6 |
+| 1e2 | 9.26 | 1e4 | 1e4 |
+
+Two decades of `alpha` per decade of size, exactly, over five decades. The
+prediction column is not fitted -- it is `alpha_ref * (m_ref/m)^2` -- and it
+lands on the measured value every time. **The shipped 1e11 fails on the
+identical junction at a hundredth of its size** (measured: sizes 1e-2, 1e-3
+and 1e-4 do not converge with the hand-off disabled).
+
+**Why, dimensionally.** The row is a pressure balance in Pa, so `alpha`
+carries Pa/(kg/s)^2. It is not a tolerance or a dimensionless weight but a
+conversion factor between a mass-flow error and a pressure, meaningful only
+against a network's own scales. The governing group is
+
+    Pi = alpha m_ref^2 / dP        and        slack*/m_ref = 1 / sqrt(Pi)
+
+so a fixed `alpha` holds the fixed point at a sensible fraction of the flow
+for exactly one network size.
+
+**One correction to 7d.** It called this a residual-form change. It only is if
+`alpha` is recomputed from the state each iterate, because then it enters the
+Jacobian. **Frozen for the solve it is not a form change at all** -- the
+residual is character-for-character unchanged and only the constant is
+computed instead of declared. That is the version implemented.
+
+**What was built.** `NetworkSolver._apply_barrier_scale` derives
+
+    alpha = P_ref / (f m_ref)^2,   f = BARRIER_SLACK_FRACTION = 0.005
+
+from the reference state `_infer_reference_state` already computes for
+seeding, and hands it to each element that owns a barrier before the solve.
+The 0.5% is a margin, not a fit: solves stop parking in the barrier at roughly
+14% of the reference flow for the traced case (case-dependent), and the
+response saturates far below 0.5%. Taking `P_ref` as the pressure error the
+network can absorb overestimates it, which errs toward a larger `alpha` and a
+smaller fixed point -- the safe direction. A degenerate reference state falls
+back to the fixed default rather than producing a weaker barrier. An
+explicitly set `soft_penalty_alpha` always wins, so the tuning knob the
+earlier sweeps used still works.
+
+The hand-off is restricted to elements that actually own a barrier rather than
+to every `MultiPortChamberElement`: the chamber base is shared with
+`EjectorElement` and `ConstantKTeeElement`, and reaching for every subclass is
+how the junction seed broke the GUI ejector in step 5a.
+
+**Measured.**
+
+| | fixed 1e11 | scale-aware |
+|---|---|---|
+| scorecard converged | 2108 / 2546 | 2108 / 2546 |
+| scorecard scored | 2081 | 2081 |
+| Bassett / Hager / Idelchik / Wang mean err | 0.1538 / 0.0787 / 0.8880 / 0.1184 | identical |
+| random: within Mach 0.3 | 99.3% | 99.3% |
+| random: root exists | 92.9% | 92.7% |
+| same junction, sizes 1e-4 to 1e3 | 5 of 8 converge | **8 of 8** |
+
+The scorecard is identical to the digit, and that is the point: the validation
+set sits in the range where 1e11 was already on the saturation plateau, so the
+derived weight must reproduce it exactly. It is not a no-op -- across 982
+scorecard solves the barrier is evaluated 4809 times and the derived weight is
+used every one of them, spanning 1.8e10 to 6.4e12. The `root exists` cell
+moves by one draw of 395, which is noise. The gain is entirely in the size
+range the validation set does not cover.
 
 ## 8. The port, sequenced by provenance
 


### PR DESCRIPTION
Follow-up to #302, which fixed the soft barrier's fixed point by raising `soft_penalty_alpha` 1e7 → 1e11 and closed with the scale-dependence as a *declared limitation*. It was declared but not measured. Measuring it overturns the "1e11 is fine" reading.

## The controlled measurement

One junction, only its **size** changed. Scaling the port area at fixed pressure, Mach, angle, area ratio, split and loss coefficients leaves every dimensionless group untouched — it is the same junction, bigger or smaller — so anything that moves is a scale artefact. The smallest `alpha` (swept by decades) that converges:

| size factor | m_ref (kg/s) | alpha needed | predicted `alpha_ref·(m_ref/m)²` |
|---|---|---|---|
| 1e-3 | 9.26e-5 | 1e14 | |
| 1e-2 | 9.26e-4 | 1e12 | |
| 1e-1 | 9.26e-3 | 1e10 | |
| 1e0 | 9.26e-2 | 1e8 | 1e8 |
| 1e1 | 9.26e-1 | 1e6 | 1e6 |
| 1e2 | 9.26 | 1e4 | 1e4 |

**Two decades of `alpha` per decade of size, exactly, over five decades.** The prediction column is not fitted — it is `alpha_ref·(m_ref/m)²` — and it lands on the measured value every time. **The shipped 1e11 fails on the identical junction at a hundredth of its size** (sizes 1e-2, 1e-3, 1e-4 do not converge with the hand-off disabled).

## Why

The row is a pressure balance in Pa, so `alpha` carries `Pa/(kg/s)²`. It is not a tolerance or a dimensionless weight but a conversion factor between a mass-flow error and a pressure, meaningful only against a network's own scales. The governing group is `Pi = alpha·m_ref²/dP`, with `slack*/m_ref = 1/sqrt(Pi)` — so a fixed `alpha` holds the fixed point at a sensible fraction of the flow for exactly one network size.

## What was built

`NetworkSolver._apply_barrier_scale` derives, from the reference state `_infer_reference_state` already computes for seeding:

```
alpha = P_ref / (BARRIER_SLACK_FRACTION * m_ref)**2      # f = 0.005
```

and hands it to each element that owns a barrier before the solve. **Frozen for the solve**, so the residual is character-for-character unchanged and the Jacobian is untouched — which also corrects #302's claim that this would be a residual-form change. It only would be if recomputed per iterate.

- A degenerate reference state falls back to the fixed default rather than producing a *weaker* barrier.
- An explicitly set `soft_penalty_alpha` always wins, so the tuning knob the earlier sweeps used still works.
- The hand-off is restricted to elements that actually own a barrier rather than every `MultiPortChamberElement` — the chamber base is shared with `EjectorElement` and `ConstantKTeeElement`, and reaching for every subclass is how the junction seed broke the GUI ejector in step 5a.

The 0.5% is a margin, not a fit: solves stop parking in the barrier around 14% of the reference flow for the traced case (case-dependent), and the response saturates far below 0.5%. Taking `P_ref` as the absorbable pressure error overestimates it, which errs toward a larger `alpha` and a smaller fixed point — the safe direction.

## Measured

| | fixed 1e11 | scale-aware |
|---|---|---|
| scorecard converged | 2108 / 2546 | 2108 / 2546 |
| scorecard scored | 2081 | 2081 |
| Bassett / Hager / Idelchik / Wang mean err | 0.1538 / 0.0787 / 0.8880 / 0.1184 | identical |
| random: within Mach 0.3 | 99.3% | 99.3% |
| random: root exists | 92.9% | 92.7% |
| same junction, sizes 1e-4 to 1e3 | 5 of 8 | **8 of 8** |

The scorecard being identical to the digit is the point: that set already sat on the saturation plateau, so the derived weight must reproduce it exactly. **It is not a no-op** — across 982 scorecard solves the barrier is evaluated 4809 times and the derived weight is used on every one, spanning 1.8e10 to 6.4e12. The `root exists` cell moves by one draw of 395, which is noise. The gain is entirely in the size range the validation set does not cover.

Full suite green (2218 passed). Falsified: with the hand-off removed, 4 tests go red — the hand-off test and exactly the three sizes the fixed weight cannot solve.

Refs #271, #272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RNDxZouiHoJdaLpnnPjHq
