### PR TITLE
feat(solver): report why a solve ended, not just whether it succeeded (#272)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`NetworkSolver.solve` now reports why a solve ended, separately from
+  whether it succeeded.** Five new keys: `__converged__` (the root finder's own
+  verdict), `__consistent__` (the elements' physical-consistency verdict, with
+  **`None` meaning not checked** -- never `True`), `__inconsistent_elements__`,
+  `__outcome__` (a `SolveOutcome` `StrEnum`, always set) and
+  `__worst_residuals__` (the rows carrying the residual, largest first).
+  `__success__` keeps its exact meaning, converged **and** consistent, so
+  existing callers are unaffected. The motivation: `__success__` is False both
+  when Newton never got there and when it found a root a junction then rejected
+  as unphysical -- the latter reporting a tiny `__final_norm__` next to
+  `success=False` -- and everything else about the failure was only available
+  by matching substrings of `__message__`, part of which comes from SciPy.
+  `SolveOutcome` is exported from `combaero.network`. The GUI's `NetworkResult`
+  surfaces the same fields, and its docstring no longer describes `success` as
+  "converged within the residual tolerance", which it has not been since the
+  consistency checks landed.
+
 ### Fixed
 - **The junction soft-barrier weight is derived from the network's scales
   instead of being a fixed constant.** `soft_penalty_alpha` multiplies a

--- a/docs/API_PYTHON.md
+++ b/docs/API_PYTHON.md
@@ -381,6 +381,49 @@ print(f"System Mass Flow: {results.elements['feed'].m_dot} kg/s")
 
 ## Network Solver
 
+### What a solve reports
+
+`NetworkSolver.solve` returns the solved unknowns plus a set of `__dunder__`
+bookkeeping keys. Five of them say what happened:
+
+| key | type | meaning |
+|---|---|---|
+| `__success__` | `bool` | converged **and** consistent. Unchanged; keep using it for "can I trust this result". |
+| `__converged__` | `bool` | the root finder reached the residual tolerance, whatever the consistency checks then said |
+| `__consistent__` | `bool \| None` | the elements' own physical-consistency verdict. **`None` means not checked** -- either the solve never converged, or no element in this network has a verifier. It is not a pass. |
+| `__inconsistent_elements__` | `list[str]` | ids of the elements that rejected the solution |
+| `__outcome__` | `SolveOutcome` | why it ended, in one machine-readable value |
+| `__worst_residuals__` | `list[dict]` | the rows carrying the residual, largest first |
+
+`__success__` is False in two quite different situations, and reading it alone
+cannot tell them apart: Newton never got there, or Newton got there and a
+junction rejected the root as unphysical. The second reports a *small*
+`__final_norm__` next to `success=False`, which looks like a contradiction
+until `__converged__` and `__consistent__` are read separately.
+
+```python
+from combaero.network import SolveOutcome
+
+result = solver.solve()
+if result["__outcome__"] == SolveOutcome.INCONSISTENT:
+    print("converged, then rejected by", result["__inconsistent_elements__"])
+elif not result["__success__"]:
+    worst = result["__worst_residuals__"][0]
+    print(f"{result['__outcome__']}: {worst['name']} carries {worst['residual']:.3e}")
+```
+
+`SolveOutcome` is a `StrEnum`, so it compares and serialises as a plain
+string: `CONVERGED`, `INCONSISTENT`, `NO_PROGRESS`, `RESIDUAL_TOO_LARGE`,
+`TIMEOUT`, `ERROR`, `NOT_CONVERGED`, `NO_UNKNOWNS`.
+
+> [!TIP]
+> Prefer `__outcome__` over matching on `__message__`. Part of that text comes
+> from SciPy and can be reworded without notice; `__outcome__` is classified
+> once, by the code that knows the answer.
+
+Note there is no `__residual_norm__`; the norm is `__final_norm__`.
+
+
 ### Basic Usage
 ```python
 from combaero.network import FlowNetwork, NetworkSolver, OrificeElement

--- a/gui/backend/runner.py
+++ b/gui/backend/runner.py
@@ -154,9 +154,25 @@ class NetworkResult:
     and use as a warm start for follow-on operations such as boundary swaps.
 
     Attributes:
-        success: True when the solver converged within the residual tolerance.
+        success: True when the solve both converged AND passed every element's
+            physical-consistency check. It is NOT "converged within the
+            residual tolerance" -- a root that a junction rejects as
+            unphysical reports ``success=False`` with a small ``final_norm``,
+            which read as a contradiction until ``converged`` and
+            ``consistent`` were reported separately.
+        converged: True when the root finder reached the residual tolerance,
+            regardless of what the consistency checks then said.
+        consistent: True/False from the elements' own physical-consistency
+            checks, or None when nothing checked -- either because the solve
+            never converged, or because no element in this network has a
+            verifier. None is NOT a pass.
+        inconsistent_elements: ids of the elements that rejected the solution.
+        outcome: machine-readable reason the solve ended
+            (``combaero.network.SolveOutcome``). Prefer this over matching on
+            ``message``, whose wording comes partly from SciPy.
         message: Human-readable solver status string.
         final_norm: Euclidean norm of the residual vector at convergence.
+        worst_residuals: the rows carrying the residual, largest first.
     """
 
     def __init__(
@@ -172,8 +188,13 @@ class NetworkResult:
         id_to_method: dict[str, str],
     ) -> None:
         self.success: bool = bool(raw.get("__success__", False))
+        self.converged: bool = bool(raw.get("__converged__", False))
+        self.consistent: bool | None = raw.get("__consistent__")
+        self.inconsistent_elements: list[str] = list(raw.get("__inconsistent_elements__") or [])
+        self.outcome: str = str(raw.get("__outcome__", "not_converged"))
         self.message: str = str(raw.get("__message__", ""))
         self.final_norm: float | None = raw.get("__final_norm__")
+        self.worst_residuals: list[dict] = list(raw.get("__worst_residuals__") or [])
         self._x_solution: Any = raw.get("__x_solution__")
         unk_names: list[str] = raw.get("__unknown_names__", [])
         x_sol: list[float] = raw.get("__x_solution__") or []

--- a/python/combaero/network/__init__.py
+++ b/python/combaero/network/__init__.py
@@ -45,7 +45,7 @@ from .pressure_loss import (
     LinearThetaLoss,
 )
 from .schema import DiagnosticSpec, spec_for, validate_diagnostics, ALL_KNOWN_FIELDS
-from .solver import NetworkSolver
+from .solver import NetworkSolver, SolveOutcome
 
 __all__: list[str] = [
     "PlenumNode",
@@ -73,6 +73,7 @@ __all__: list[str] = [
     "mix_streams",
     "FlowNetwork",
     "NetworkSolver",
+    "SolveOutcome",
     "NetworkNode",
     "NetworkElement",
     "DiagnosticSpec",

--- a/python/combaero/network/solver.py
+++ b/python/combaero/network/solver.py
@@ -1,6 +1,7 @@
 import math
 import time
 import warnings
+from enum import StrEnum
 from typing import Any, Literal
 
 import numpy as np
@@ -26,6 +27,47 @@ from .graph import FlowNetwork
 
 class SolverTimeoutError(Exception):
     """Raised when the solver exceeds the specified wall-clock timeout."""
+
+
+class SolveOutcome(StrEnum):
+    """Why a solve ended, in one machine-readable value.
+
+    A ``StrEnum``, so it compares and serialises as a plain string and an
+    existing ``== "converged"`` keeps working.
+
+    ``NetworkSolver`` used to report only ``__success__`` and a free-text
+    ``__message__``, so every consumer that needed to know WHY a solve failed
+    matched on substrings of that message -- and the messages come partly from
+    SciPy, which is free to reword them. This does that classification once, at
+    the point that knows the answer.
+    """
+
+    #: A root was found, and it passed every element's consistency check (or
+    #: no element had one).
+    CONVERGED = "converged"
+    #: A root was found and then rejected by an element's own physical
+    #: consistency check. ``__inconsistent_elements__`` names them.
+    INCONSISTENT = "inconsistent"
+    #: The minimiser stopped improving before reaching tolerance.
+    NO_PROGRESS = "no_progress"
+    #: The method reported success at a non-zero local minimum of ||F||.
+    RESIDUAL_TOO_LARGE = "residual_too_large"
+    #: The wall-clock budget ran out.
+    TIMEOUT = "timeout"
+    #: An exception was raised while evaluating residuals.
+    ERROR = "error"
+    #: Did not converge, with no more specific reason available.
+    NOT_CONVERGED = "not_converged"
+    #: Nothing to solve: the network is empty or fully constrained.
+    NO_UNKNOWNS = "no_unknowns"
+
+
+def _classify_solver_message(message: str) -> SolveOutcome:
+    """The one place SciPy's free-text failure message is interpreted."""
+    text = (message or "").lower()
+    if "not making good progress" in text:
+        return SolveOutcome.NO_PROGRESS
+    return SolveOutcome.NOT_CONVERGED
 
     pass
 
@@ -2058,6 +2100,11 @@ class NetworkSolver:
                 "__success__": True,
                 "__message__": "Network is empty or fully constrained (no unknowns).",
                 "__iterations__": 0,
+                "__converged__": True,
+                "__consistent__": None,
+                "__inconsistent_elements__": [],
+                "__outcome__": SolveOutcome.NO_UNKNOWNS,
+                "__worst_residuals__": [],
             }
 
         # Set default iteration limit based on problem size (matches hybr's own default
@@ -2422,6 +2469,7 @@ class NetworkSolver:
         # Solve with timing
         _RESIDUAL_TOL = 1e-3
         solve_start_time = time.time()
+        outcome: SolveOutcome = SolveOutcome.NOT_CONVERGED
         try:
             sol = root(residuals_wrapper, x0_scaled, method=method, options=options, jac=use_jac)
             solve_end_time = time.time()
@@ -2429,12 +2477,14 @@ class NetworkSolver:
             final_x = best_x
             success = sol.success
             message = sol.message
+            outcome = SolveOutcome.CONVERGED if success else _classify_solver_message(message)
             # Efficiently use tracked norm instead of re-evaluating
             final_norm = float(best_res_norm)
             # Guard against methods (e.g. lm) that report success at a
             # non-zero local minimum of ||F||^2.
             if success and final_norm > _RESIDUAL_TOL:
                 success = False
+                outcome = SolveOutcome.RESIDUAL_TOO_LARGE
                 message = (
                     f"Solver reported success but |F|={final_norm:.3e} "
                     f"exceeds residual tolerance ({_RESIDUAL_TOL})."
@@ -2444,12 +2494,14 @@ class NetworkSolver:
         except SolverTimeoutError as e:
             final_x = best_x
             success = False
+            outcome = SolveOutcome.TIMEOUT
             message = str(e)
             final_norm = float(best_res_norm)
         except Exception as e:
             # Fallback for unexpected errors during residuals evaluation
             final_x = best_x
             success = False
+            outcome = SolveOutcome.ERROR
             message = f"Unexpected error during residual evaluation: {e}"
             final_norm = float(best_res_norm)
 
@@ -2464,6 +2516,7 @@ class NetworkSolver:
                 if sol2.success and fallback_norm < _RESIDUAL_TOL:
                     final_x = fallback_x
                     success = True
+                    outcome = SolveOutcome.CONVERGED
                     message = f"Converged after fallback to hybr (original {method} failed)."
                     final_norm = fallback_norm
             except Exception:
@@ -2501,6 +2554,7 @@ class NetworkSolver:
                     if _lm_norm < _RESIDUAL_TOL:
                         final_x = best_x
                         success = True
+                        outcome = SolveOutcome.CONVERGED
                         _hybr_end = "stalled at" if _stall_fired[0] else "|F|="
                         message = (
                             f"Converged with LM fallback "
@@ -2552,6 +2606,22 @@ class NetworkSolver:
         # higher-Pt port (a passive junction manufacturing flow work).
         # Each element's verify_solution_consistent encodes its own
         # criterion; demote failures to honest non-convergence.
+        #
+        # The verdict is REPORTED as well as applied. "Not checked" is not the
+        # same as "fine": a network whose elements carry no verifier gets
+        # ``__consistent__ = None``, never True, so a caller cannot read a
+        # silent absence of checking as a clean bill of health.
+        # The root finder's own verdict, before the consistency check can
+        # demote it. ``__success__`` folds the two together and must keep
+        # doing so; this is the half that says whether Newton got there.
+        converged = bool(success)
+        _bad_junctions: list[str] = []
+        _checkable = [
+            element
+            for element in self.network.elements.values()
+            if hasattr(element, "verify_solution_consistent")
+        ]
+        consistent: bool | None = None
         if success:
             _sol_names = dict(zip(self.unknown_names, final_x, strict=False))
             _bad_junctions = [
@@ -2560,8 +2630,11 @@ class NetworkSolver:
                 if hasattr(element, "verify_solution_consistent")
                 and not element.verify_solution_consistent(_sol_names)
             ]
+            if _checkable:
+                consistent = not _bad_junctions
             if _bad_junctions:
                 success = False
+                outcome = SolveOutcome.INCONSISTENT
                 message = (
                     "Converged to an unphysical artifact root at "
                     f"junction(s) {_bad_junctions}: the solution failed "
@@ -2772,6 +2845,17 @@ class NetworkSolver:
         sol_dict["__success__"] = success
         sol_dict["__message__"] = message
         sol_dict["__final_norm__"] = final_norm
+        # Why the solve ended, split into the two questions ``__success__``
+        # conflates: did the root finder get there, and is what it found
+        # physically admissible. ``__success__`` keeps its meaning -- both.
+        sol_dict["__converged__"] = bool(converged)
+        sol_dict["__consistent__"] = consistent
+        sol_dict["__inconsistent_elements__"] = list(_bad_junctions)
+        sol_dict["__outcome__"] = outcome
+        # The rows carrying the residual, largest first. Already computed for
+        # the diagnostic payload; a failed solve is far easier to read with
+        # them than with a single norm.
+        sol_dict["__worst_residuals__"] = [{"name": n, "residual": v} for n, v in _worst]
         sol_dict["__unknown_names__"] = list(self.unknown_names)
         sol_dict["__x_solution__"] = list(final_x)
         # Convergence history: per-eval (eval_idx, t_elapsed_s, residual_norm)

--- a/python/tests/test_solver_reporting_fields.py
+++ b/python/tests/test_solver_reporting_fields.py
@@ -1,0 +1,285 @@
+"""What a solve reports about itself.
+
+`NetworkSolver.solve` used to answer only two questions: a boolean
+`__success__` and a free-text `__message__`. That conflates things a caller
+has to tell apart, and forces string matching for the rest:
+
+- `__success__` is False both when Newton never got there AND when it found a
+  root that a junction then rejected as unphysical. The second case reports a
+  tiny `__final_norm__` alongside `success=False`, which reads as a
+  contradiction until the two are reported separately.
+- "why did it fail" was only available by matching substrings of
+  `__message__` -- and part of that text comes from SciPy, which is free to
+  reword it. `validation/junction/random_robustness.classify` did exactly
+  that.
+- "the elements were checked and passed" and "nothing checked anything" both
+  came back as silence.
+
+So: `__converged__` (the root finder's own verdict), `__consistent__`
+(True/False/**None for not checked**), `__inconsistent_elements__`,
+`__outcome__` (a `SolveOutcome`, always set) and `__worst_residuals__`.
+`__success__` keeps its meaning exactly -- converged AND consistent -- because
+callers depend on it.
+
+Issue #272, follow-up to #299.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+import warnings
+
+import numpy as np
+import pytest
+
+import combaero as cb
+from combaero.network import (
+    ChannelElement,
+    FlowNetwork,
+    NetworkSolver,
+    PressureBoundary,
+    SolveOutcome,
+)
+from validation.junction import random_robustness as rr
+
+
+def _solve(net, **kw):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return NetworkSolver(net).solve(timeout=30.0, **kw)
+
+
+@pytest.fixture(scope="module")
+def outcomes():
+    """A spread of real solves, so the fields are exercised on both verdicts."""
+    rng = random.Random(20260906)
+    out = []
+    for _ in range(60):
+        out.append(_solve(rr.build(rr.sample(rng))))
+    assert any(s["__success__"] for s in out)
+    assert any(not s["__success__"] for s in out)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Always present, always set
+# ---------------------------------------------------------------------------
+
+
+def test_every_solve_reports_every_field(outcomes):
+    for sol in outcomes:
+        for key in (
+            "__converged__",
+            "__consistent__",
+            "__inconsistent_elements__",
+            "__outcome__",
+            "__worst_residuals__",
+        ):
+            assert key in sol, f"{key} missing"
+        assert isinstance(sol["__outcome__"], SolveOutcome)
+
+
+def test_the_outcome_is_a_plain_string_too():
+    """A StrEnum, so an existing `== "converged"` and any JSON encoder keep
+    working. Pinned because switching to a bare Enum would break both
+    silently."""
+    assert SolveOutcome.CONVERGED == "converged"
+    assert str(SolveOutcome.NO_PROGRESS) == "no_progress"
+    assert f"{SolveOutcome.TIMEOUT}" == "timeout"
+
+
+def test_a_network_with_no_unknowns_still_reports_an_outcome(monkeypatch):
+    """The early return for a fully-constrained network used to hand back a
+    three-key dict, so a caller reading `__outcome__` got a KeyError on the
+    one case that never fails. Driven by emptying the unknown list rather
+    than by an empty network, which the graph validator rejects outright."""
+    Y = list(cb.mole_to_mass(cb.species.dry_air()))
+    net = FlowNetwork()
+    net.add_node(PressureBoundary("inlet", Pt=2.0e5, Tt=300.0, Y=Y))
+    net.add_node(PressureBoundary("outlet", Pt=1.9e5, Tt=300.0, Y=Y))
+    net.add_element(ChannelElement("ch", "inlet", "outlet", length=0.3, diameter=0.05))
+
+    solver = NetworkSolver(net)
+    real = solver._build_x0
+
+    def no_unknowns():
+        real()
+        solver.unknown_names = []
+        return np.array([])
+
+    monkeypatch.setattr(solver, "_build_x0", no_unknowns)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        sol = solver.solve(timeout=30.0)
+
+    assert sol["__success__"] is True
+    assert sol["__outcome__"] == SolveOutcome.NO_UNKNOWNS
+    assert sol["__consistent__"] is None
+    assert sol["__worst_residuals__"] == []
+
+
+# ---------------------------------------------------------------------------
+# success = converged AND consistent
+# ---------------------------------------------------------------------------
+
+
+def test_success_still_means_both(outcomes):
+    for sol in outcomes:
+        expected = bool(sol["__converged__"]) and sol["__consistent__"] is not False
+        assert bool(sol["__success__"]) is expected
+
+
+def test_a_converged_solve_reports_converged_and_the_converged_outcome(outcomes):
+    for sol in outcomes:
+        if not sol["__success__"]:
+            continue
+        assert sol["__converged__"] is True
+        assert sol["__outcome__"] == SolveOutcome.CONVERGED
+        assert sol["__inconsistent_elements__"] == []
+
+
+def test_a_failed_solve_names_a_reason_other_than_converged(outcomes):
+    for sol in outcomes:
+        if sol["__success__"]:
+            continue
+        assert sol["__outcome__"] != SolveOutcome.CONVERGED
+
+
+# ---------------------------------------------------------------------------
+# "not checked" is not "fine"
+# ---------------------------------------------------------------------------
+
+
+def test_not_checked_reports_none_not_true():
+    """A network with no element that owns a consistency check must report
+    None. Reporting True would let a caller read the absence of any checking
+    as a clean bill of health."""
+    Y = list(cb.mole_to_mass(cb.species.dry_air()))
+    net = FlowNetwork()
+    net.add_node(PressureBoundary("inlet", Pt=2.0e5, Tt=300.0, Y=Y))
+    net.add_node(PressureBoundary("outlet", Pt=1.9e5, Tt=300.0, Y=Y))
+    net.add_element(ChannelElement("ch", "inlet", "outlet", length=0.3, diameter=0.05))
+
+    sol = _solve(net)
+
+    assert sol["__success__"] is True
+    assert sol["__converged__"] is True
+    assert sol["__consistent__"] is None, "nothing checked, so this cannot be True"
+
+
+def test_a_non_converged_solve_does_not_claim_consistency(outcomes):
+    """The checks only run on a converged solve, so an unconverged one has no
+    verdict to report -- not a negative one."""
+    for sol in outcomes:
+        if sol["__converged__"]:
+            continue
+        assert sol["__consistent__"] is None
+
+
+def test_a_checked_and_passing_solve_reports_true(outcomes):
+    """The other side: where a junction DID verify the root, the field must be
+    True rather than None, or it carries no information."""
+    assert any(sol["__consistent__"] is True for sol in outcomes)
+
+
+# ---------------------------------------------------------------------------
+# The residual rows
+# ---------------------------------------------------------------------------
+
+
+def test_worst_residuals_are_named_sorted_and_real(outcomes):
+    for sol in outcomes:
+        worst = sol["__worst_residuals__"]
+        if not worst:
+            continue
+        names = set(sol["__unknown_names__"])
+        values = [row["residual"] for row in worst]
+        assert all(row["name"] in names for row in worst)
+        assert values == sorted(values, reverse=True)
+        assert all(v >= 0.0 for v in values)
+
+
+def test_the_worst_row_is_consistent_with_the_norm(outcomes):
+    """The largest row cannot exceed the norm, nor be a vanishing fraction of
+    it -- that would mean the two describe different states."""
+    for sol in outcomes:
+        worst = sol["__worst_residuals__"]
+        norm = sol["__final_norm__"]
+        if not worst or not math.isfinite(norm) or norm <= 0.0:
+            continue
+        assert worst[0]["residual"] <= norm * (1.0 + 1e-6)
+        assert worst[0]["residual"] >= norm / math.sqrt(len(sol["__unknown_names__"])) * 0.99
+
+
+# ---------------------------------------------------------------------------
+# The consumer that used to string-match
+# ---------------------------------------------------------------------------
+
+
+def test_the_random_harness_classifies_from_the_outcome_not_the_message():
+    """The proof that the string matching is gone: rewriting `__message__` to
+    something unrecognisable must not change a single bucket."""
+    rng = random.Random(4242)
+    cases = [rr.sample(rng) for _ in range(25)]
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        before = [rr.classify(rr.build(c)) for c in cases]
+
+    original = NetworkSolver.solve
+
+    def scrambled(self, *args, **kwargs):
+        sol = original(self, *args, **kwargs)
+        sol["__message__"] = "lorem ipsum dolor sit amet"
+        return sol
+
+    NetworkSolver.solve = scrambled
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            after = [rr.classify(rr.build(c)) for c in cases]
+    finally:
+        NetworkSolver.solve = original
+
+    assert before == after, "the buckets still depend on the message text"
+    assert set(before) != {"converged"}, "the sample must contain failures to be worth anything"
+
+
+# ---------------------------------------------------------------------------
+# The case the split exists for
+# ---------------------------------------------------------------------------
+
+
+def test_a_rejected_root_reports_converged_true_and_consistent_false():
+    """The whole reason these are two fields. A root the junction rejects
+    reports `success=False` with a SMALL residual norm, which is unreadable
+    from `__success__` alone. Forced rather than sampled: the random harness
+    produces no rejection in 80 draws, so this branch would otherwise be
+    exercised by nothing.
+    """
+    rng = random.Random(20260906)
+    for _ in range(40):
+        net = rr.build(rr.sample(rng))
+        solver = NetworkSolver(net)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            clean = solver.solve(timeout=30.0)
+        if not clean["__success__"]:
+            continue
+
+        element = next(e for e in net.elements.values() if hasattr(e, "verify_solution_consistent"))
+        element.verify_solution_consistent = lambda *a, **k: False
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            sol = NetworkSolver(net).solve(timeout=30.0)
+
+        assert sol["__converged__"] is True, "the root finder still got there"
+        assert sol["__consistent__"] is False
+        assert sol["__success__"] is False
+        assert sol["__outcome__"] == SolveOutcome.INCONSISTENT
+        assert element.id in sol["__inconsistent_elements__"]
+        # The point: a tiny norm alongside success=False.
+        assert sol["__final_norm__"] < 1e-3
+        return
+    pytest.skip("no converging draw available to reject")

--- a/validation/junction/random_robustness.py
+++ b/validation/junction/random_robustness.py
@@ -56,6 +56,7 @@ from combaero.network import (
     MassFlowBoundary,
     MomentumChamberNode,
     NetworkSolver,
+    SolveOutcome,
     PressureBoundary,
 )
 from combaero.network._mynard2010 import junction_loss_coefficient
@@ -345,6 +346,14 @@ def max_port_mach(case: Case) -> float | None:
     )
 
 
+_BUCKET_BY_OUTCOME = {
+    SolveOutcome.CONVERGED: "converged",
+    SolveOutcome.INCONSISTENT: "rejected",
+    SolveOutcome.NO_PROGRESS: "no progress",
+    SolveOutcome.RESIDUAL_TOO_LARGE: "residual too large",
+}
+
+
 def classify(net: FlowNetwork, timeout: float = 20.0) -> str:
     """Solve and bucket the outcome. Never raises."""
     solver = NetworkSolver(net)
@@ -354,16 +363,12 @@ def classify(net: FlowNetwork, timeout: float = 20.0) -> str:
             sol = solver.solve(timeout=timeout)
         except Exception:  # noqa: BLE001 -- the bucket IS the report
             return "raised"
-    if sol.get("__success__"):
-        return "converged"
-    message = (sol.get("__message__") or "").lower()
-    if "unphysical" in message or "dissipative" in message:
-        return "rejected"
-    if "not making good progress" in message:
-        return "no progress"
-    if "exceeds" in message:
-        return "residual too large"
-    return "other"
+    # Read the solver's own verdict. This used to match substrings of
+    # ``__message__`` -- including SciPy's wording, which SciPy is free to
+    # change -- so the buckets silently depended on prose. ``__outcome__``
+    # is the solver's single machine-readable answer; the bucket names are
+    # kept as they were so the summary tables stay comparable.
+    return _BUCKET_BY_OUTCOME.get(sol.get("__outcome__"), "other")
 
 
 @dataclass


### PR DESCRIPTION
The small one from the #272 follow-up list. Motivated directly by the barrier investigation, which spent several rounds establishing by hand what the solver could have said outright.

## The problem

`NetworkSolver.solve` answered two questions: a boolean `__success__` and a free-text `__message__`.

- `__success__` is False both when Newton never got there **and** when it found a root that a junction then rejected as unphysical. The second reports a *tiny* `__final_norm__` next to `success=False`, which reads as a contradiction.
- Everything else about a failure was only reachable by matching substrings of `__message__` — part of which comes from SciPy, which is free to reword it. `validation/junction/random_robustness.classify` did exactly that.
- "checked and passed" and "nothing checked anything" both came back as silence.

## What it adds

| key | type | meaning |
|---|---|---|
| `__converged__` | `bool` | the root finder's own verdict |
| `__consistent__` | `bool \| None` | the elements' verdict — **`None` means not checked**, never `True` |
| `__inconsistent_elements__` | `list[str]` | which elements rejected the solution |
| `__outcome__` | `SolveOutcome` | why it ended, machine-readable, always set |
| `__worst_residuals__` | `list[dict]` | the rows carrying the residual, largest first |

**`__success__` keeps its exact meaning** — converged AND consistent — so existing callers are unaffected. A test pins that identity across a spread of real solves.

`__consistent__` is `None` whenever nothing checked: either the solve did not converge, or no element in the network owns a verifier. "Not checked" must not be readable as a clean bill of health.

`SolveOutcome` is a `StrEnum` (`CONVERGED`, `INCONSISTENT`, `NO_PROGRESS`, `RESIDUAL_TOO_LARGE`, `TIMEOUT`, `ERROR`, `NOT_CONVERGED`, `NO_UNKNOWNS`), so it compares and serialises as a plain string. Exported from `combaero.network`.

## The consumer that used to string-match

`random_robustness.classify` now reads `__outcome__`. The proof is a test that scrambles `__message__` to lorem ipsum and asserts not one bucket moves — it fails if the string matching comes back.

## GUI

`NetworkResult` surfaces the same fields, and its docstring no longer describes `success` as *"converged within the residual tolerance"*, which it has not been since the consistency checks landed.

## Verification

Full suite green (2231 passed). Falsified both new behaviours:

- reverting the None-when-unchecked rule reds `test_not_checked_reports_none_not_true`
- putting `classify` back on string matching reds the scramble test

The `INCONSISTENT` branch is not reachable from random draws (no rejection in 80), so it is tested by forcing a verifier to fail rather than left to chance.

Refs #271, #272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RNDxZouiHoJdaLpnnPjHq
