### PR TITLE
feat(junction): compute the momentum-CV junction in C++, Python becomes a shim (#271)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **The momentum-CV junction's residual and Jacobian are now computed in C++.**
+  `MPCEv2Element` becomes a shim: it applies the guards -- the degenerate-state
+  fallbacks and the wrong-direction soft barrier, which are solver policy
+  rather than junction physics -- and then calls
+  `_core.mpce_v2_residuals_and_jacobian`, which seeds the whole element over
+  `(P_i, Pt_i, outer_mdot_i, Pt_jct)` and returns exact partials for every one.
+  This replaces a Python closure evaluation, a sympy-lambdified Jacobian block
+  for the canonical separating tee, an N+1-call finite-difference fallback for
+  every other topology, and a hand-derived `dR/dP` column.
+  **The Jacobian is now more complete, not merely faster.** The hand-derived
+  column covered the common port only, but `K` depends on every port's velocity
+  and every velocity on its own density; measured against central differences of
+  the assembled network Jacobian, the worst relative error falls from 4.4e-3 to
+  1.4e-6. Accuracy is unchanged to four decimals on every validation source
+  (Bassett 0.1538, Hager 0.0787, Idelchik 0.8880, Wang 0.1184) and convergence
+  is slightly better: the scorecard goes from 2108 to 2109 of 2546, and the
+  random boundary sweep from 92.9% to 93.7% of draws that admit a root.
+  `MPCEv2Element.jacobian_method` is retired and now selects nothing; it is kept
+  so existing callers do not break. The sympy derivation remains in
+  `_mpce_v2_jacobian.py` as an offline cross-check rather than a runtime path.
+
 ### Added
 - **`NetworkSolver.solve` now reports why a solve ended, separately from
   whether it succeeded.** Five new keys: `__converged__` (the root finder's own

--- a/docs/API_CPP.md
+++ b/docs/API_CPP.md
@@ -789,6 +789,57 @@ Port convention: MAIN_INLET=A, BRANCH=B, MAIN_OUTLET=C; `m_dot_com` = common-por
 mass flow, `m_dot_branch` = branch mass flow, `F_C` = cross-sectional area [m^2] at
 the common port, `psi` = A_branch / A_com, `theta` = branch angle [rad].
 
+### Momentum-CV Junction: whole-element (f, J)
+
+Backs `MPCEv2Element`. Unlike the tee functions above, this returns the whole
+element's residual vector and its full Jacobian from one seeded evaluation --
+forward-mode dual numbers over every unknown, so there is no separate
+derivation to keep in sync (`include/mpce_junction.h`).
+
+```cpp
+struct MpceGeometry {
+    std::array<double, 3> area, theta_rad, port_sign;
+    double joining_etransfer_alpha, eta_scale;
+};
+
+struct MpceResidualJacobian {
+    std::array<double, 4> residual;                    // 3 port rows + mass
+    std::array<std::array<double, 10>, 4> jacobian;    // [row][seed]
+    bool valid;                                        // false: not a junction
+    int common_port;
+    double k_term_sign;
+    std::array<double, 3> k_per_port;
+};
+
+MpceResidualJacobian mpce_v2_residuals_and_jacobian(
+    const std::array<double, 3>& p_static, const std::array<double, 3>& p_total,
+    const std::array<double, 3>& rho,      const std::array<double, 3>& drho_dp,
+    const std::array<double, 3>& outer_mdot, double pt_jct,
+    const MpceGeometry& geom);
+```
+
+Seed order, matching the Jacobian's columns:
+
+| columns | unknown |
+|---|---|
+| 0-2 | `p_static[i]` |
+| 3-5 | `p_total[i]` |
+| 6-8 | `outer_mdot[i]` |
+| 9 | `pt_jct` |
+
+`outer_mdot` is the CONNECTING element's mass flow, not the junction-convention
+one; `geom.port_sign` maps between them, so the Jacobian arrives already
+expressed in the solver's own unknowns.
+
+**Physics only.** The kernel does not own the degenerate-state guards or the
+wrong-direction soft barrier -- those are solver policy and live in
+`MPCEv2Element`. It reports `valid = false` for a flow pattern that is not a
+junction in any regime rather than guessing.
+
+**Thermodynamics stays at the call site**: pass `rho` and `drho/dP` per port.
+A Jacobian is first order, so seeding `rho + (drho/dP)(P - P_val)` is exact.
+For combaero's mixtures `drho/dP = rho/P` holds to 1e-11.
+
 Residual sign convention: `R_straight = dP0_straight + K_straight * q_dyn`,
 `R_branch = dP0_branch + K_branch * q_dyn`.
 

--- a/python/combaero/_core.cpp
+++ b/python/combaero/_core.cpp
@@ -19,6 +19,7 @@
 #include "heat_transfer.h"
 #include "humidair.h"
 #include "incompressible.h"
+#include "mpce_junction.h"
 #include "materials.h"
 #include "orifice.h"
 #include "registry.h"
@@ -296,6 +297,44 @@ PYBIND11_MODULE(_core, m) {
         "Momentum chamber residual: P_total = P + 0.5*rho*v^2");
 
   // Multi-port chamber (momentum-CV junction)
+  // --- Momentum-CV junction: whole-element (f, J) -------------------------
+  py::class_<solver::MpceGeometry>(
+      m, "MpceGeometry",
+      "Fixed geometry and tuning for the momentum-CV junction kernel")
+      .def(py::init<>())
+      .def_readwrite("area", &solver::MpceGeometry::area)
+      .def_readwrite("theta_rad", &solver::MpceGeometry::theta_rad)
+      .def_readwrite("port_sign", &solver::MpceGeometry::port_sign)
+      .def_readwrite("joining_etransfer_alpha",
+                     &solver::MpceGeometry::joining_etransfer_alpha)
+      .def_readwrite("eta_scale", &solver::MpceGeometry::eta_scale);
+
+  py::class_<solver::MpceResidualJacobian>(
+      m, "MpceResidualJacobian",
+      "Whole-element residuals and Jacobian for the momentum-CV junction")
+      .def_readonly("residual", &solver::MpceResidualJacobian::residual)
+      .def_readonly("jacobian", &solver::MpceResidualJacobian::jacobian)
+      .def_readonly("valid", &solver::MpceResidualJacobian::valid)
+      .def_readonly("common_port", &solver::MpceResidualJacobian::common_port)
+      .def_readonly("k_term_sign", &solver::MpceResidualJacobian::k_term_sign)
+      .def_readonly("k_per_port", &solver::MpceResidualJacobian::k_per_port);
+
+  m.def("mpce_v2_residuals_and_jacobian",
+        &solver::mpce_v2_residuals_and_jacobian, py::arg("p_static"),
+        py::arg("p_total"), py::arg("rho"), py::arg("drho_dp"),
+        py::arg("outer_mdot"), py::arg("pt_jct"), py::arg("geom"),
+        "Momentum-CV junction whole-element (f, J), three ports.\n\n"
+        "Physics only: the caller owns the degenerate-state guards and the\n"
+        "wrong-direction soft barrier (see include/mpce_junction.h).\n\n"
+        "Jacobian seed order, matching the returned rows:\n"
+        "  0..2  p_static[i]     3..5  p_total[i]\n"
+        "  6..8  outer_mdot[i]   9     pt_jct\n\n"
+        "``outer_mdot`` is the CONNECTING element's mass flow, not the\n"
+        "junction-convention one; ``geom.port_sign`` maps between them, so\n"
+        "the Jacobian comes back already in the solver's own unknowns.\n\n"
+        "Returns: MpceResidualJacobian (valid=False when the flow pattern\n"
+        "is not a junction at all).");
+
   py::class_<solver::PortImpulseJacobian>(
       m, "PortImpulseJacobian",
       "Per-port impulse-residual Jacobian for MultiPortChamberResult")

--- a/python/combaero/network/mpce_v2_element.py
+++ b/python/combaero/network/mpce_v2_element.py
@@ -41,7 +41,7 @@ from typing import Literal
 
 import numpy as np
 
-from combaero.network._mpce_v2_jacobian import dKQ_dmdot_separating_T
+from combaero import _core
 from combaero.network._mynard2010 import junction_loss_coefficient
 from combaero.network.components import (
     MultiPortChamberElement,
@@ -95,22 +95,21 @@ def scaled_penalty_alpha(ref_pressure: float, ref_mdot: float) -> float:
 class MPCEv2Element(MultiPortChamberElement):
     """Mynard Unified0D residual on MPCE-v1's topology framework.
 
-    The ``jacobian_method`` attribute controls how the K*q_dyn term's
-    Jacobian is computed:
-      - ``"sympy"`` (default): analytical sympy-derived Jacobian for the
-        canonical 3-port separating T (1 supplier on port 0, straight at
-        0 deg, branch at theta_branch). Uses 1 Mynard evaluation per
-        residual call. Non-canonical topologies (joining, theta != 0 on
-        the straight arm, N != 3) auto-fall-back to FD because the
-        sympy derivation is specific to the canonical case. Validated on
-        the separating K6 / K5 audit: identical convergence + accuracy
-        vs FD with ~1.14x wall-time speedup.
-      - ``"fd"``: numerical finite-difference on Mynard. Costs N+1
-        Mynard evaluations per residual call. Always available across
-        all topologies. The previous default; flipped to sympy in PR
-        adding GUI solver tweaks once the empirical "fd is more robust
-        on mfb_two_pb low-q" concern was found to no longer apply at
-        the post-soft-barrier audit point.
+    The residual and its Jacobian come from
+    ``_core.mpce_v2_residuals_and_jacobian``, which seeds the whole element
+    over ``(P_i, Pt_i, outer_mdot_i, Pt_jct)`` and returns exact partials for
+    every one. What stays here is the GUARDS -- the degenerate-state
+    fallbacks and the wrong-direction soft barrier -- which are solver policy
+    rather than junction physics (issue #271, step 4.4).
+
+    ``jacobian_method`` is RETIRED and selects nothing. It chose between a
+    sympy derivation for the canonical 3-port separating T and an N+1-call
+    finite-difference fallback for every other topology; both are gone. The
+    sympy derivation survives in ``_mpce_v2_jacobian.py`` as an offline
+    cross-check (``test_mpce_v2_jacobian.py``), not as a runtime path. The
+    attribute is kept so existing callers that set it do not break, and is
+    documented here rather than removed silently -- a knob that quietly does
+    nothing is worse than one that says so.
 
     ``flow_direction`` constrains which physical flow regime this element
     represents:
@@ -644,182 +643,89 @@ class MPCEv2Element(MultiPortChamberElement):
             sup_mask = U_mynard > 0.0
             col_mask = U_mynard < 0.0
 
-        try:
-            mynard = junction_loss_coefficient(
-                U_mynard,
-                A,
-                theta_rad,
-                joining_etransfer_alpha=self.joining_etransfer_alpha,
-                eta_scale=self.eta_scale,
-            )
-        except (IndexError, ValueError) as exc:
-            # The closure can raise only on a degenerate flow split (empty
-            # supplier or collector mask), and the guard above already routes
-            # those to the continuity fallback before this call. Reaching
-            # here therefore means the two classifications disagree -- an
-            # anomaly worth seeing, not one to paper over. This used to
-            # return a lossless residual with an EMPTY Jacobian for *any*
-            # exception, which turned a plumbing error into a plausible-
-            # looking lossless junction mid-solve (issue #271). Programming
-            # errors now propagate untouched.
-            raise RuntimeError(
-                f"MPCEv2Element '{self.id}': Mynard closure failed on a "
-                f"non-degenerate state (port_mdots={list(port_mdots)}, "
-                f"suppliers={sup_mask.tolist()}, collectors={col_mask.tolist()}). "
-                f"The degenerate-split guard should have caught this first."
-            ) from exc
-
-        # ITERATION-2: use mynard.K (Matlab line 73) with common-side q_dyn.
-        # This is the physically correct normalization: K is defined such
-        # that Pt_common - Pt_other = K * 0.5 * rho_com * u_com^2.
-        # The common branch is the single supplier (diverging) or single
-        # collector (converging); mynard.K is per non-common port.
+        # ---- Whole-element (f, J) from C++ ---------------------------------
         #
-        # Sign of the K*q_dyn term in the residual:
-        #   Separating: common is supplier (higher Pt), collectors have
-        #               LOWER Pt -> Pt_col = Pt_jct - K*q_dyn -> +1 in residual
-        #   Joining:    common is collector (lower Pt), suppliers have
-        #               HIGHER Pt -> Pt_sup = Pt_jct + K*q_dyn -> -1 in residual
-        if int(np.sum(sup_mask)) == 1:
-            common_mask = sup_mask
-            non_common_idxs = np.where(col_mask)[0]
-            K_term_sign = +1.0
-        else:
-            common_mask = col_mask
-            non_common_idxs = np.where(sup_mask)[0]
-            K_term_sign = -1.0
+        # Everything above is GUARD -- the degenerate-state fallbacks and the
+        # wrong-direction soft barrier, which are solver policy rather than
+        # junction physics and stay here where they are cheap to change
+        # (#302, #303). From this point the state is a junction, and the
+        # physics is one call.
+        #
+        # What this replaced: a Python closure evaluation, a sympy-lambdified
+        # dKQ/dmdot block for the canonical separating tee, an N+1-call finite
+        # -difference fallback for every other case, and a hand-derived dR/dP
+        # column. The kernel seeds the whole element over
+        # (P_i, Pt_i, outer_mdot_i, Pt_jct) and returns the Jacobian already
+        # expressed in those unknowns, so nothing is left to assemble here.
+        #
+        # It is also MORE complete. The hand-derived column covered the common
+        # port only, but K depends on every port's velocity and every velocity
+        # on its own density; measured against central differences, the two
+        # non-common dR/dP columns were absent and wrong by 4.4e-3 and 2.3e-3
+        # (issue #271).
+        #
+        # The snapped velocities are handed over as mass flows, since the
+        # kernel takes flows and derives its own U. d(rho)/dP is rho/P: the
+        # mixture density is ideal to 1e-11 over the validation range, so this
+        # is exact rather than an approximation.
+        outer_mdot = [
+            -float(U_mynard[i]) * float(rho_port[i]) * float(A[i]) * float(self._port_signs[i])
+            for i in range(N)
+        ]
+        p_static = [float(s.P) for s in states]
+        geom = _core.MpceGeometry()
+        geom.area = [float(a) for a in A]
+        # Declared angles: the kernel does the axial-back reassignment itself.
+        geom.theta_rad = [math.radians(float(t)) for t in self.port_angles_deg]
+        geom.port_sign = [float(s) for s in self._port_signs]
+        geom.joining_etransfer_alpha = float(self.joining_etransfer_alpha)
+        geom.eta_scale = float(self.eta_scale)
 
-        K_per_port = np.zeros(N)
-        if mynard.K is not None and len(mynard.K) == len(non_common_idxs):
-            for j, port_idx in enumerate(non_common_idxs):
-                K_per_port[port_idx] = float(mynard.K[j])
-
-        # Common-side dynamic head: q_dyn at the single common port.
-        common_idx = int(np.where(common_mask)[0][0])
-        u_com = abs(float(U_mynard[common_idx]))
-        rho_com = float(rho_port[common_idx])
-        q_dyn_com = 0.5 * rho_com * u_com * u_com
-
-        # Residual: Pt_i - Pt_jct + K_i * q_dyn_com = 0
-        # Common port: K_i = 0, so Pt_common = Pt_jct (continuity).
-        # Other ports: K * q_dyn_com is the loss term per Mynard's
-        # stagnation-pressure relation (Eq 15).
-        residuals: list[float] = []
-        for i in range(N):
-            Pt_i = float(states[i].Pt)
-            R_i = Pt_i - Pt_jct + K_term_sign * K_per_port[i] * q_dyn_com
-            residuals.append(R_i)
-        residuals.append(sum(port_mdots))
-
-        # Jacobian: linear pieces explicit + analytical (sympy-derived) for
-        # the K*q_dyn term in the canonical 3-port separating case; FD
-        # fallback for everything else.
-        KQ_base = K_per_port * q_dyn_com  # per-port loss term (collectors nonzero)
-        dKQ_dmdot = np.zeros((N, N))
-
-        is_canonical_separating_T = (
-            N == 3
-            and int(np.sum(sup_mask)) == 1
-            and bool(sup_mask[0])  # port 0 is the supplier
-            and abs(self.port_angles_deg[1]) < 1e-9  # straight at 0
+        kernel = _core.mpce_v2_residuals_and_jacobian(
+            p_static,
+            [float(s.Pt) for s in states],
+            [float(r) for r in rho_port],
+            [float(rho_port[i]) / p_static[i] if p_static[i] > 0.0 else 0.0 for i in range(N)],
+            outer_mdot,
+            float(Pt_jct),
+            geom,
         )
-        if is_canonical_separating_T and self.jacobian_method == "sympy":
-            dKQ_dmdot = dKQ_dmdot_separating_T(
-                np.asarray(port_mdots, dtype=float),
-                rho_port,
-                A,
-                math.radians(float(self.port_angles_deg[2])),
-                eta_scale=self.eta_scale,
+        if not kernel.valid:
+            # The guards above own every state the kernel refuses, so reaching
+            # here means the two disagree -- an anomaly worth seeing rather
+            # than one to paper over. This used to be an `except Exception`
+            # returning a lossless residual with an EMPTY Jacobian, which
+            # turned a plumbing error into a plausible-looking junction
+            # mid-solve (issue #271).
+            raise RuntimeError(
+                f"MPCEv2Element '{self.id}': the C++ kernel refused a state the "
+                f"guards accepted (port_mdots={list(port_mdots)}, "
+                f"suppliers={sup_mask.tolist()}, collectors={col_mask.tolist()})."
             )
-        else:
-            # FD fallback: N+1 Mynard calls.
-            eps_scale = 1e-4
-            for j in range(N):
-                mdot_eps = max(abs(port_mdots[j]) * eps_scale, 1e-7)
-                mdot_pert = list(port_mdots)
-                mdot_pert[j] = port_mdots[j] + mdot_eps
-                U_pert = -np.array(mdot_pert) / (rho_port * A)
-                if (np.sign(U_pert) != np.sign(U_mynard)).any():
-                    continue
-                try:
-                    m_pert = junction_loss_coefficient(
-                        U_pert,
-                        A,
-                        theta_rad,
-                        joining_etransfer_alpha=self.joining_etransfer_alpha,
-                        eta_scale=self.eta_scale,
-                    )
-                except (IndexError, ValueError) as exc:
-                    # The sign-flip guard above already skips perturbations
-                    # that cross zero; a raise here is a state the closure
-                    # cannot classify at all. Leaving the column zero was a
-                    # silent wrong derivative (issue #271, #280).
-                    raise RuntimeError(
-                        f"MPCEv2Element '{self.id}': Mynard closure failed on the "
-                        f"FD perturbation of port {j} (perturbed mdots={mdot_pert})."
-                    ) from exc
-                if m_pert.K is None or len(m_pert.K) != len(non_common_idxs):
-                    continue
-                K_pert = np.zeros(N)
-                for k, port_idx in enumerate(non_common_idxs):
-                    K_pert[port_idx] = float(m_pert.K[k])
-                u_com_pert = abs(float(U_pert[common_idx]))
-                q_dyn_pert = 0.5 * rho_com * u_com_pert * u_com_pert
-                KQ_pert = K_pert * q_dyn_pert
-                dKQ_dmdot[:, j] = (KQ_pert - KQ_base) / mdot_eps
 
-        # Sensitivity of the loss term to the common port's STATIC pressure.
-        # This column was absent, leaving a silently zero Jacobian entry -- the
-        # same defect PR #230 fixed in ConstantKTeeElement (issue #271).
-        # Temperature is derived forward for a MomentumChamberNode rather than
-        # solved, so there is no .T unknown to differentiate against.
-        #
-        # Two paths carry the dependence, and taking only the first is wrong by
-        # a few per cent:
-        #   (a) q_dyn_com = mdot^2 / (2*rho*A^2) ~ 1/rho, and rho ~ P/T for a
-        #       near-ideal gas, so d(q_dyn)/dP = -q_dyn / P.
-        #   (b) Mynard's K is a function of the port velocities U = -mdot/(rho*A),
-        #       so it moves with rho too.
-        # For (b), U depends on P and on mdot through the same 1/rho factor:
-        #       dU/dP = -U/P     and     dU/dmdot = U/mdot
-        #   =>  dK/dP = -(mdot_com / P_com) * dK/dmdot_com,
-        # which lets the existing dKQ/dmdot column supply it. Substituting and
-        # using d(q_dyn)/dmdot_com = 2*q_dyn/mdot_com, the two paths combine to
-        #       dR_i/dP_com = sign * [ K_i*q_dyn/P - (mdot_com/P) * dKQ_i/dmdot_com ]
-        # Note the leading term ends up POSITIVE: path (b) more than cancels the
-        # naive -K*q/P. Pinned by test_mpce_v2_jacobian_rows.py.
-        P_com = float(states[common_idx].P)
-        m_com = float(port_mdots[common_idx])
-        p_var_com = f"{self.port_nodes[common_idx]}.P"
+        residuals = [float(v) for v in kernel.residual]
+        # The mass row uses the ORIGINAL flows, not the snapped ones: snapping
+        # exists to let the closure classify a dead port, and must not add its
+        # 1e-9 to the conservation statement.
+        residuals[N] = float(sum(port_mdots))
 
+        # Relabel the seeds onto the solver's unknown names. The seed order is
+        # fixed by include/mpce_junction.h and pinned by
+        # test_mpce_shim_relabelling.py.
+        seed_names = (
+            [f"{self.port_nodes[i]}.P" for i in range(N)]
+            + [f"{self.port_nodes[i]}.Pt" for i in range(N)]
+            + [f"{self._port_element_ids[i]}.m_dot" for i in range(N)]
+            + [f"{self.id}.P_jct"]
+        )
         jac: dict[int, dict[str, float]] = {}
-        for i in range(N):
-            row: dict[str, float] = {
-                f"{self.port_nodes[i]}.Pt": 1.0,
-                f"{self.id}.P_jct": -1.0,
-            }
-            if P_com > 0.0:
-                dR_dP_com = float(K_per_port[i]) * q_dyn_com / P_com - (m_com / P_com) * float(
-                    dKQ_dmdot[i, common_idx]
-                )
-                if dR_dP_com != 0.0:
-                    row[p_var_com] = row.get(p_var_com, 0.0) + K_term_sign * dR_dP_com
-            for j in range(N):
-                if abs(dKQ_dmdot[i, j]) > 0.0:
-                    mdot_var = f"{self._port_element_ids[j]}.m_dot"
-                    # Outer mdot has been sign-mapped: port_mdots[j] = sign_j * outer.
-                    # Chain rule: d(KQ_i)/d(outer_j) = dKQ_dmdot[i,j] * sign_j.
-                    # K_term_sign carries the joining/separating residual flip.
-                    row[mdot_var] = row.get(mdot_var, 0.0) + (
-                        K_term_sign * dKQ_dmdot[i, j] * self._port_signs[j]
-                    )
-            jac[i] = row
-
-        mass_row: dict[str, float] = {}
-        for i in range(N):
-            mass_var = f"{self._port_element_ids[i]}.m_dot"
-            mass_row[mass_var] = mass_row.get(mass_var, 0.0) + self._port_signs[i]
-        jac[N] = mass_row
+        for row in range(N + 1):
+            entries: dict[str, float] = {}
+            for seed, name in enumerate(seed_names):
+                value = float(kernel.jacobian[row][seed])
+                if value != 0.0:
+                    entries[name] = entries.get(name, 0.0) + value
+            jac[row] = entries
 
         return residuals, jac
 

--- a/python/tests/test_mpce_shim_relabelling.py
+++ b/python/tests/test_mpce_shim_relabelling.py
@@ -1,0 +1,262 @@
+"""The Python element as a shim over the C++ whole-element (f, J).
+
+`MPCEv2Element.residuals` no longer computes the junction physics. It applies
+the guards -- the degenerate-state fallbacks and the wrong-direction soft
+barrier, which are solver policy and stay in Python -- and then calls
+`_core.mpce_v2_residuals_and_jacobian`, whose Jacobian comes back seeded over
+`(P_i, Pt_i, outer_mdot_i, Pt_jct)` in that fixed order.
+
+All that is left is relabelling those ten columns onto the solver's unknown
+names. That mapping is the shim's whole contract and nothing else tests it: a
+slip would be a silent transposition, not an error, and the golden C++ tests
+cannot see it because they never touch the names.
+
+Issue #271, step 4.4.
+"""
+
+from __future__ import annotations
+
+import math
+import warnings
+
+import numpy as np
+import pytest
+
+import combaero as cb
+from combaero.network import NetworkSolver
+from combaero.network.components import NetworkMixtureState
+from combaero.network.mpce_v2_element import MPCEv2Element
+from validation.junction import random_robustness as rr
+
+_Y = list(cb.mole_to_mass(cb.species.dry_air()))
+
+
+def _element(flow_direction: str = "branch") -> MPCEv2Element:
+    ports = ["p0", "p1", "p2"]
+    if flow_direction == "branch":
+        element = MPCEv2Element(
+            id="jct",
+            inlet_nodes=ports[:1],
+            outlet_nodes=ports[1:],
+            inlet_angles_deg=[0.0],
+            outlet_angles_deg=[0.0, 90.0],
+            port_areas=[0.01] * 3,
+            flow_direction="branch",
+            strict=False,
+        )
+    else:
+        element = MPCEv2Element(
+            id="jct",
+            inlet_nodes=ports[:2],
+            outlet_nodes=ports[2:],
+            inlet_angles_deg=[0.0, 90.0],
+            outlet_angles_deg=[0.0],
+            port_areas=[0.01] * 3,
+            flow_direction="merge",
+            strict=False,
+        )
+    element._port_element_ids = ["e0", "e1", "e2"]
+    return element
+
+
+def _states():
+    return [
+        NetworkMixtureState(P=1.0e5, Pt=100_300.0, T=300.0, Tt=300.5, m_dot=0.0, Y=list(_Y))
+        for _ in range(3)
+    ]
+
+
+_BRANCH = [-0.10, 0.06, 0.04]
+_MERGE = [-0.06, -0.04, 0.10]
+
+
+# ---------------------------------------------------------------------------
+# The names
+# ---------------------------------------------------------------------------
+
+
+def test_every_reported_name_is_one_the_solver_knows():
+    """A name the solver does not recognise is silently dropped from the
+    sparse assembly, so a typo would cost a whole column with no error."""
+    element = _element()
+    _, jac = element.residuals(_states(), 100_300.0, list(_BRANCH))
+
+    legal = (
+        {f"{n}.P" for n in element.port_nodes}
+        | {f"{n}.Pt" for n in element.port_nodes}
+        | {f"{e}.m_dot" for e in element._port_element_ids}
+        | {f"{element.id}.P_jct"}
+    )
+    for row, entries in jac.items():
+        for name in entries:
+            assert name in legal, f"row {row} reports an unknown name {name!r}"
+
+
+def test_the_pt_and_junction_columns_land_on_the_right_names():
+    """R_i = Pt_i - Pt_jct + ..., so row i must carry +1 on ITS OWN port's Pt
+    and -1 on the junction, and nothing on any other port's Pt. Pinned by name
+    rather than by index, which is what a relabelling slip would break."""
+    element = _element()
+    _, jac = element.residuals(_states(), 100_300.0, list(_BRANCH))
+
+    for i, node in enumerate(element.port_nodes):
+        assert jac[i][f"{node}.Pt"] == pytest.approx(1.0)
+        assert jac[i][f"{element.id}.P_jct"] == pytest.approx(-1.0)
+        for other in element.port_nodes:
+            if other != node:
+                assert f"{other}.Pt" not in jac[i], f"row {i} reports {other}.Pt"
+
+
+def test_the_mass_row_is_the_signed_port_map_by_name():
+    element = _element("merge")
+    _, jac = element.residuals(_states(), 100_300.0, list(_MERGE))
+
+    mass = jac[element.N]
+    for j, eid in enumerate(element._port_element_ids):
+        assert mass[f"{eid}.m_dot"] == pytest.approx(element._port_signs[j])
+    assert not any(name.endswith(".P") or name.endswith(".Pt") for name in mass)
+
+
+def test_the_static_pressure_columns_are_reported_at_all():
+    """The whole point of the port: the Python used to leave the non-common
+    dR/dP columns empty. If the shim drops them the improvement is invisible
+    and this is the only place that would notice."""
+    element = _element()
+    _, jac = element.residuals(_states(), 100_300.0, list(_BRANCH))
+
+    reported = {name for entries in jac.values() for name in entries if name.endswith(".P")}
+    assert len(reported) >= 2, f"only {reported} carry a static-pressure derivative"
+
+
+# ---------------------------------------------------------------------------
+# The numbers behind the names
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("direction", "mdots"), [("branch", _BRANCH), ("merge", _MERGE)])
+def test_each_named_column_matches_a_finite_difference(direction, mdots):
+    """Ties the label to the number. A transposed pair of columns would keep
+    every name legal and every value plausible, and only this catches it."""
+    element = _element(direction)
+    states = _states()
+
+    def residual(perturb=None):
+        local = [
+            NetworkMixtureState(P=s.P, Pt=s.Pt, T=s.T, Tt=s.Tt, m_dot=s.m_dot, Y=list(s.Y))
+            for s in states
+        ]
+        flows = list(mdots)
+        if perturb is not None:
+            kind, index, delta = perturb
+            if kind == "P":
+                local[index] = NetworkMixtureState(
+                    P=local[index].P + delta,
+                    Pt=local[index].Pt,
+                    T=local[index].T,
+                    Tt=local[index].Tt,
+                    m_dot=local[index].m_dot,
+                    Y=list(local[index].Y),
+                )
+            elif kind == "Pt":
+                local[index] = NetworkMixtureState(
+                    P=local[index].P,
+                    Pt=local[index].Pt + delta,
+                    T=local[index].T,
+                    Tt=local[index].Tt,
+                    m_dot=local[index].m_dot,
+                    Y=list(local[index].Y),
+                )
+            else:
+                flows[index] += delta * element._port_signs[index]
+        return np.array(element.residuals(local, 100_300.0, flows)[0])
+
+    _, jac = element.residuals(states, 100_300.0, list(mdots))
+
+    columns = (
+        [("P", i, f"{element.port_nodes[i]}.P", 1.0) for i in range(3)]
+        + [("Pt", i, f"{element.port_nodes[i]}.Pt", 1.0) for i in range(3)]
+        + [("m", i, f"{element._port_element_ids[i]}.m_dot", 1e-6) for i in range(3)]
+    )
+    for kind, index, name, step in columns:
+        fd = (residual((kind, index, step)) - residual((kind, index, -step))) / (2.0 * step)
+        for row in range(element.N + 1):
+            reported = jac[row].get(name, 0.0)
+            assert abs(reported - fd[row]) <= 1e-4 * max(1.0, abs(fd[row])), (
+                f"{direction} row {row} column {name}: "
+                f"reported {reported:.6e} against FD {fd[row]:.6e}"
+            )
+
+
+def test_the_assembled_network_jacobian_matches_finite_differences():
+    """End to end, through the solver's own assembly: the relabelling has to
+    survive being placed into the global sparse matrix, which is where a name
+    the solver does not know would vanish without trace.
+
+    Before the port this measured 4.4e-3 and 2.3e-3 on the two non-common
+    static-pressure columns.
+    """
+    import random
+
+    rng = random.Random(20260906)
+    worst = 0.0
+    checked = 0
+    for _ in range(40):
+        case = rr.sample(rng)
+        if rr.has_root(case) is not True:
+            continue
+        solver = NetworkSolver(rr.build(case))
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            sol = solver.solve(timeout=20.0)
+        if not sol["__success__"]:
+            continue
+        x = np.array(sol["__x_solution__"])
+        _, jac = solver._residuals_and_jacobian(x)
+        J = jac.toarray() if hasattr(jac, "toarray") else np.asarray(jac)
+        fd = np.zeros_like(J)
+        for j in range(len(x)):
+            h = max(abs(x[j]) * 1e-6, 1e-6)
+            xp = x.copy()
+            xm = x.copy()
+            xp[j] += h
+            xm[j] -= h
+            fd[:, j] = (solver._residuals(xp) - solver._residuals(xm)) / (2.0 * h)
+        worst = max(worst, float(np.max(np.abs(J - fd) / np.maximum(np.abs(fd), 1.0))))
+        checked += 1
+        if checked >= 6:
+            break
+
+    assert checked > 0, "no converged network was available to check"
+    assert worst < 1e-4, f"worst relative Jacobian error {worst:.3e}"
+
+
+def test_math_is_still_imported_for_the_angle_conversion():
+    """The shim converts declared degrees to radians for the kernel. Trivial,
+    and exactly the kind of thing an import cleanup removes."""
+    assert math.radians(180.0) == pytest.approx(math.pi)
+    element = _element()
+    _, jac = element.residuals(_states(), 100_300.0, list(_BRANCH))
+    assert jac  # reached the kernel at all
+
+
+def test_the_mass_residual_uses_the_original_flows_not_the_snapped_ones():
+    """Snapping exists to let the closure classify a dead port; it must not
+    enter the conservation statement.
+
+    A port at exactly zero is snapped to a velocity of 1e-9 in its declared
+    direction before the kernel sees it, which is a mass flow of order
+    1e-11 kg/s. The kernel's own mass row therefore carries that, and the
+    shim overwrites it with the sum of the ORIGINAL flows. Worth 1e-11, and
+    worth saying: the alternative is a conservation residual that is not zero
+    for a state that conserves mass exactly.
+
+    Found by falsification -- deleting the override changed nothing any other
+    test could see.
+    """
+    element = _element()
+    mdots = [-0.1, 0.0, 0.1]  # sums to exactly zero; port 1 is dead
+    residuals, _ = element.residuals(_states(), 100_300.0, list(mdots))
+
+    assert residuals[element.N] == 0.0, (
+        f"mass residual {residuals[element.N]:.3e} for a state that conserves mass exactly"
+    )

--- a/python/tests/test_mpce_v2_closure_errors.py
+++ b/python/tests/test_mpce_v2_closure_errors.py
@@ -7,10 +7,19 @@ full suite, never caught a legitimate degenerate state (the guard before the
 call handles those) and did catch a plumbing error, disguising it as a
 plausible-looking lossless junction (issue #271, step 1.2).
 
-These tests pin the replacement rule: the two exceptions the closure can
-raise become a loud, named failure with the cause chained; anything else
-propagates untouched. Errors are injected by monkeypatching the closure so
-the tests do not depend on finding a real degenerate state.
+These tests pin the replacement rule: a failure becomes a loud, named one
+with the cause chained; anything else propagates untouched.
+
+The rule outlived its original site. Since the whole-element (f, J) moved to
+C++ (#271 step 4.4), the residual path no longer calls the Python closure at
+all -- it calls ``_core.mpce_v2_residuals_and_jacobian``, which reports a
+state it cannot classify as ``valid=False`` rather than by raising. The
+residual-path tests below therefore inject at the KERNEL, and the rule they
+pin is unchanged: a refusal the guards should have caught first is a named
+RuntimeError, never a lossless residual.
+
+The DIAGNOSTICS path still calls the Python closure, so those tests still
+inject there.
 """
 
 from __future__ import annotations
@@ -73,23 +82,43 @@ def _raising(exc: BaseException, after_calls: int = 0):
 # ---------------------------------------------------------------------------
 
 
-def test_programming_error_in_the_closure_propagates(monkeypatch):
+class _FakeKernelResult:
+    """Stand-in for MpceResidualJacobian with a chosen validity."""
+
+    def __init__(self, valid: bool):
+        self.valid = valid
+        self.residual = [0.0] * 4
+        self.jacobian = [[0.0] * 10 for _ in range(4)]
+        self.common_port = 0
+        self.k_term_sign = 1.0
+        self.k_per_port = [0.0] * 3
+
+
+def test_programming_error_in_the_kernel_propagates(monkeypatch):
     """The 1.2 failure mode, pinned: an AttributeError must surface as itself.
 
     The old handler turned this into a lossless residual with jac = {} and
     19 tests failed with KeyError instead of the real error.
     """
-    monkeypatch.setattr(v2, "junction_loss_coefficient", _raising(AttributeError("plumbing")))
+
+    def boom(*args, **kwargs):
+        raise AttributeError("plumbing")
+
+    monkeypatch.setattr(v2._core, "mpce_v2_residuals_and_jacobian", boom)
 
     with pytest.raises(AttributeError, match="plumbing"):
         _element().residuals(_states(), 100_300.0, _BRANCH_MDOTS)
 
 
-@pytest.mark.parametrize("exc_type", [IndexError, ValueError])
-def test_degenerate_split_error_becomes_a_named_failure(monkeypatch, exc_type):
-    """The closure's own two exceptions become a RuntimeError naming the element
-    and the state, with the original chained -- not a lossless junction."""
-    monkeypatch.setattr(v2, "junction_loss_coefficient", _raising(exc_type("mask")))
+def test_a_kernel_refusal_becomes_a_named_failure(monkeypatch):
+    """The kernel refuses a state that is not a junction in any regime. The
+    guards own every such state, so a refusal here means the two disagree --
+    which must be loud, and must name the element and the flows."""
+    monkeypatch.setattr(
+        v2._core,
+        "mpce_v2_residuals_and_jacobian",
+        lambda *a, **k: _FakeKernelResult(valid=False),
+    )
 
     with pytest.raises(RuntimeError) as info:
         _element().residuals(_states(), 100_300.0, _BRANCH_MDOTS)
@@ -97,43 +126,63 @@ def test_degenerate_split_error_becomes_a_named_failure(monkeypatch, exc_type):
     message = str(info.value)
     assert "MPCEv2Element 'jct'" in message
     assert "port_mdots" in message
-    assert isinstance(info.value.__cause__, exc_type)
 
 
-def test_residual_never_returns_an_empty_jacobian_on_error(monkeypatch):
+def test_residual_never_returns_an_empty_jacobian_on_a_refusal(monkeypatch):
     """The specific defect: a residual with jac = {} looks like a solved row."""
-    monkeypatch.setattr(v2, "junction_loss_coefficient", _raising(IndexError("mask")))
+    monkeypatch.setattr(
+        v2._core,
+        "mpce_v2_residuals_and_jacobian",
+        lambda *a, **k: _FakeKernelResult(valid=False),
+    )
 
     with pytest.raises(RuntimeError):
         _element().residuals(_states(), 100_300.0, _BRANCH_MDOTS)
-    # If we get here without a raise, the old fallback is back.
+    # Reaching here without a raise means the old fallback is back.
 
 
 # ---------------------------------------------------------------------------
-# FD-fallback path (joining flow, two suppliers)
+# What replaced the FD fallback
 # ---------------------------------------------------------------------------
 
 
-def test_fd_perturbation_error_becomes_a_named_failure(monkeypatch):
-    """First call (the residual's own) succeeds; a perturbed call raises.
+def test_no_jacobian_column_is_silently_zero(monkeypatch):
+    """The FD fallback's failure mode was a silently zero Jacobian column, and
+    two tests used to pin its error handling. The fallback is gone -- the
+    kernel differentiates every unknown -- so the intent is pinned directly
+    instead: every entry the element reports must match a finite difference of
+    its own residual, and no column that should move may be missing.
 
-    Leaving that Jacobian column zero was a silent wrong derivative.
+    Joining flow, which is the case the FD fallback used to serve.
     """
-    monkeypatch.setattr(
-        v2, "junction_loss_coefficient", _raising(IndexError("mask"), after_calls=1)
-    )
+    element = _element("merge")
+    states = _states()
 
-    with pytest.raises(RuntimeError, match="FD perturbation"):
-        _element("merge").residuals(_states(), 100_300.0, _MERGE_MDOTS)
+    def residual_vector(mdots):
+        return list(element.residuals(states, 100_300.0, list(mdots))[0])
 
+    base = residual_vector(_MERGE_MDOTS)
+    _, jac = element.residuals(states, 100_300.0, list(_MERGE_MDOTS))
 
-def test_fd_perturbation_programming_error_propagates(monkeypatch):
-    monkeypatch.setattr(
-        v2, "junction_loss_coefficient", _raising(TypeError("plumbing"), after_calls=1)
-    )
-
-    with pytest.raises(TypeError, match="plumbing"):
-        _element("merge").residuals(_states(), 100_300.0, _MERGE_MDOTS)
+    for j in range(3):
+        step = max(abs(_MERGE_MDOTS[j]) * 1e-6, 1e-9)
+        hi = list(_MERGE_MDOTS)
+        lo = list(_MERGE_MDOTS)
+        hi[j] += step
+        lo[j] -= step
+        fd = [
+            (a - b) / (2.0 * step)
+            for a, b in zip(residual_vector(hi), residual_vector(lo), strict=True)
+        ]
+        # port_mdots are junction convention; the reported column is on the
+        # OUTER element's variable, hence the sign map.
+        name = f"{element._port_element_ids[j]}.m_dot"
+        for row in range(4):
+            reported = jac[row].get(name, 0.0) * element._port_signs[j]
+            assert abs(reported - fd[row]) <= 1e-4 * max(1.0, abs(fd[row])), (
+                f"row {row}, column {name}: reported {reported:.6e} against FD {fd[row]:.6e}"
+            )
+    assert base  # the residual itself is real, not an empty list
 
 
 # ---------------------------------------------------------------------------

--- a/python/tests/test_mpce_v2_degenerate_iterates.py
+++ b/python/tests/test_mpce_v2_degenerate_iterates.py
@@ -101,6 +101,35 @@ def test_same_sign_iterate_raises_when_strict():
 # ---------------------------------------------------------------------------
 
 
+def _spy_outer_mdot(monkeypatch, element, states, pt_jct, mdots):
+    """The velocities the CLOSURE ends up seeing, observed at the kernel call.
+
+    The snapped state used to be checked by spying on the Python closure. Since
+    the whole-element (f, J) moved to C++ (#271 step 4.4) the residual path
+    hands the kernel mass flows and the kernel derives U itself, so the same
+    quantity is read back from the flows: U_i = -port_sign_i * outer_i /
+    (rho_i A_i), which is sign-equivalent to -port_sign_i * outer_i.
+    """
+    seen = {}
+    real = v2._core.mpce_v2_residuals_and_jacobian
+
+    def spy(p_static, p_total, rho, drho_dp, outer_mdot, pt, geom):
+        seen["U"] = np.array(
+            [
+                -float(geom.port_sign[i])
+                * float(outer_mdot[i])
+                / (float(rho[i]) * float(geom.area[i]))
+                for i in range(len(outer_mdot))
+            ]
+        )
+        return real(p_static, p_total, rho, drho_dp, outer_mdot, pt, geom)
+
+    monkeypatch.setattr(v2._core, "mpce_v2_residuals_and_jacobian", spy)
+    element.residuals(states, pt_jct, list(mdots))
+    assert "U" in seen, "the kernel was never reached"
+    return seen["U"]
+
+
 def test_exact_zero_outlet_is_classified_as_a_dead_collector(monkeypatch):
     """[-0.1, -0.0, 0.125]: the straight outlet at -0.0 (an initial guess).
 
@@ -108,17 +137,8 @@ def test_exact_zero_outlet_is_classified_as_a_dead_collector(monkeypatch):
     closure must now be handed a tiny flow in the port's DECLARED direction,
     so it sees one supplier and two collectors.
     """
-    seen = {}
-    real = v2.junction_loss_coefficient
+    U = _spy_outer_mdot(monkeypatch, _element(), _states(), 100_300.0, [-0.1, -0.0, 0.125])
 
-    def spy(U, *args, **kwargs):
-        seen["U"] = np.array(U, dtype=float)
-        return real(U, *args, **kwargs)
-
-    monkeypatch.setattr(v2, "junction_loss_coefficient", spy)
-    _element().residuals(_states(), 100_300.0, [-0.1, -0.0, 0.125])
-
-    U = seen["U"]
     assert U[1] < 0.0, "the dead outlet must reach the closure as a collector"
     assert (U > 0).sum() == 1 and (U < 0).sum() == 2
 
@@ -136,17 +156,9 @@ def test_exact_zero_outlet_carries_the_dead_branch_loss():
 
 
 def test_exact_zero_inlet_in_a_merge_is_a_dead_supplier(monkeypatch):
-    seen = {}
-    real = v2.junction_loss_coefficient
+    U = _spy_outer_mdot(monkeypatch, _element("merge"), _states(), 100_300.0, [-0.1, 0.0, 0.1])
 
-    def spy(U, *args, **kwargs):
-        seen["U"] = np.array(U, dtype=float)
-        return real(U, *args, **kwargs)
-
-    monkeypatch.setattr(v2, "junction_loss_coefficient", spy)
-    _element("merge").residuals(_states(), 100_300.0, [-0.1, 0.0, 0.1])
-
-    assert seen["U"][1] > 0.0, "a dead inlet must reach the closure as a supplier"
+    assert U[1] > 0.0, "a dead inlet must reach the closure as a supplier"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Step 4.4 completed — the pybind11 binding and the Python side. Follows the kernel in #308.

`MPCEv2Element.residuals` now applies the guards — the degenerate-state fallbacks and the wrong-direction soft barrier, which are solver policy rather than junction physics — and then makes **one call** to `_core.mpce_v2_residuals_and_jacobian`. Everything after that is relabelling ten seeded columns onto the solver's unknown names.

**Deleted from the runtime path:** the Python closure evaluation, the sympy-lambdified `dKQ/dmdot` block for the canonical separating tee, the N+1-call finite-difference fallback for every other topology, and the hand-derived `dR/dP` column.

`_mpce_v2_jacobian.py` stays as the offline cross-check it was always meant to be (`test_mpce_v2_jacobian.py`), not a runtime path. `jacobian_method` is **retired and documented as selecting nothing** — a knob that quietly does not work is worse than one that says so.

## More complete, not merely faster

The hand-derived column covered the common port only, but `K` depends on every port's velocity and every velocity on its own density. Measured against central differences of the **assembled network Jacobian** across 12 converged networks:

| | worst relative error |
|---|---|
| before | **4.4e-3** |
| after | **1.4e-6** |

## The gate

| | Python | C++ shim |
|---|---|---|
| scorecard converged | 2108 / 2546 | **2109** |
| scorecard scored | 2081 | **2082** |
| Bassett / Hager / Idelchik / Wang | 0.1538 / 0.0787 / 0.8880 / 0.1184 | **identical to four decimals** |
| all sources mean err | 0.4984 | **0.4982** |
| random: root exists | 92.9% | **93.7%** |
| random: within Mach 0.3 | 99.3% | 99.3% |

Same physics, slightly better convergence — what a more complete Jacobian should buy, and the reason the gate was never "identical Jacobian".

`drho/dP` is `rho/P`: measured over the validation range the mixture density is ideal to 1e-11, so this is exact rather than an approximation, and the equation of state stays at the call site.

## Tests moved, not dropped

Two files injected errors at the Python closure, which the residual path no longer calls. Their **intent** is the #271 rule that a failure must never become a plausible-looking lossless junction, and that survives intact: a kernel refusal on a state the guards accepted is a named `RuntimeError`. Those tests now inject at the kernel; the diagnostics path still calls the Python closure, so those still inject there.

The two FD-fallback error tests are replaced by one that pins their intent **directly** — no Jacobian column may be silently zero — which is stronger than what it replaced.

`test_mpce_shim_relabelling.py` is new and covers the shim's whole contract: ten columns landing on the right names, checked *by name rather than index*, each tied to a finite difference so a transposition cannot pass, plus the assembled network Jacobian end to end.

## Falsification found a real hole

Five perturbations. Four reddened immediately: swapping the P and Pt column labels, dropping `port_sign` from the flow map, zeroing `drho/dP`, and removing the kernel-refusal raise.

The fifth did not — **deleting the mass-row override changed nothing any test could see.** That override encodes a real semantic: snapping exists to let the closure classify a dead port and must not enter the conservation statement. Worth 1e-11, and worth saying, so it now has its own test.

Full Python suite green (2238 passed).

Refs #271.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RNDxZouiHoJdaLpnnPjHq
