### PR TITLE
docs(skill): separate falsification from coverage, and name reward hacking

### DIFF
--- a/.claude/skills/model-provenance/SKILL.md
+++ b/.claude/skills/model-provenance/SKILL.md
@@ -30,12 +30,58 @@ regression test, where it came from and why — before it's trusted.
    limiting cases) get exact tolerances; tuning-dependent behavior (damping,
    pseudo-transient continuation parameters) gets a labeled band. Falsify
    each new regression test once — revert the fix, confirm red for the right
-   reason, restore.
+   reason, restore. Then measure coverage separately; see below for why one
+   does not substitute for the other.
 5. On completion, close the change into a short provenance record: the
    formulation chosen and the alternatives considered, the literature basis
    (source plus the specific case or correlation), the invariant it must
    preserve, dead ends tried, and a pointer to the test that pins it. WHY
    only — never restate the code.
+
+## Falsification and coverage are different checks
+
+**Falsification checks that the tests bind to the code you wrote; coverage
+checks whether you wrote tests for the code you actually have.** Run both.
+Neither finds what the other does.
+
+Falsification perturbs the implementation and asserts a test goes red. It
+catches a test that passes for the wrong reason — a tautology, a vacuous
+assertion, a fixture where every quantity is imposed. Its most useful outcome
+is the perturbation that does **not** go red: that names a behaviour nothing
+tests. Porting `MPCEv2Element` to C++, deleting the line that keeps the
+snapping out of the mass-conservation row changed no test result. The line was
+right and the gap was real, so the semantic got its own test.
+
+Coverage asks a different question, and templates make it lie. `dual_number.h`
+reported 100% of regions, lines and branches while five of its thirteen
+operator overloads — including `operator+(D, D)` — were never called. An
+uninstantiated template is never emitted, so it cannot be counted as missed.
+**Check instantiation counts, not percentages.** Across four port PRs, coverage
+found a real gap in three of them (an angle below `-pi`, the joining term with
+a single supplier, a `1e-9` dead band a comment made a claim about) and seven
+to eight falsifications per PR found none of the three.
+
+Record which branches are genuinely unreachable and why, so the next reader
+does not hunt for them.
+
+## Reward hacking is failure, not a shortcut
+
+A number that improved because the model got better is a result. A number that
+improved because the measurement was bent is a defect that looks like a
+result, and it is worse than no change at all.
+
+- **Never tune a constant against the score it is judged by.** Empirical terms
+  prove themselves on the digitised data and are labelled as tuned. A CFD
+  correction is tuning; it does not reproduce the source CFD.
+- **Prefer a saturation plateau to a peak.** If the metric is monotone in a
+  parameter and flat above some value, there is no peak to fit and the choice
+  is safe. If it peaks, ask what the peak is made of before taking it.
+- **Falsify the metric, not only the change** — perturb the model and confirm
+  the score moves. A cell whose every quantity is imposed scores nothing.
+- **Never falsify by removing one half of a matched pair**, and never widen a
+  tolerance or delete a case to make a suite green.
+- Improving one case while the aggregate stands still is not an improvement;
+  say so and revert. A negative result, reported, is a good outcome.
 
 ## Rules
 
@@ -51,6 +97,9 @@ regression test, where it came from and why — before it's trusted.
 
 Every new element or correlation has a spike verified against its source
 before integration. Every analytical derivative has an independent
-cross-check. Every accepted agent change has an answered provenance
-question. Every closed model has a short record you could read in six
-months without this conversation.
+cross-check. Every new test has been falsified once, and coverage has been
+measured separately with instantiation counts checked. Every accepted agent
+change has an answered provenance question. Every number that moved can be
+traced to a change in the model rather than to a change in the measurement.
+Every closed model has a short record you could read in six months without
+this conversation.


### PR DESCRIPTION
Two additions to the `model-provenance` skill, both earned during the MPCEv2 C++ port (#305, #307, #308, #309).

## Falsification and coverage are different checks

The skill asked for falsification and said nothing about coverage. That gap showed up four times in a row.

> **Falsification checks that the tests bind to the code you wrote; coverage checks whether you wrote tests for the code you actually have.**

Across the four port PRs, seven to eight perturbations each found nothing new. Coverage found a real gap in **three of four**: an input angle below `-pi`, the joining term with a single supplier, and a `1e-9` dead band that a comment made a claim about.

And the one time falsification earned its keep, it did so by **passing** where it should have failed — deleting the line that keeps snapping out of the mass-conservation row changed no test result, which named an untested semantic. That is worth stating explicitly: the most useful falsification outcome is the perturbation that does *not* go red.

The section also records the trap that makes a coverage number untrustworthy on templated numerics. `dual_number.h` reported **100% of regions, lines and branches** while five of its thirteen operator overloads — including `operator+(D, D)` — were never called. An uninstantiated template is never emitted, so it cannot be counted as missed. **Check instantiation counts, not percentages.**

## Reward hacking is failure, not a shortcut

These rules were live in this repo but scattered across memory, issue comments and PR descriptions, and were not in the skill at all:

- Never tune a constant against the score it is judged by.
- Prefer a saturation plateau to a peak — if the metric is monotone and flat above some value there is no peak to fit.
- Falsify the metric, not only the change; a cell whose every quantity is imposed scores nothing.
- Never falsify by removing one half of a matched pair, and never widen a tolerance to make a suite green.
- Improving one case while the aggregate stands still is not an improvement. Say so and revert.

The framing: a number that improved because the measurement was bent is worse than no change at all, because it looks like a result.

## Done criteria

Updated to require both checks, instantiation counts included, and to require that every number which moved traces to a change in the model rather than to a change in the measurement.

---

Note for reviewers: the `end-of-file-fixer` pre-commit hook cannot open files under `.claude/skills` in this environment (`PermissionError: Operation not permitted`) — a sandbox path restriction, not a content problem. The file ends with a single newline. No hook was bypassed; the commit ran with the sandbox disabled for that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RNDxZouiHoJdaLpnnPjHq
