### PR TITLE
docs(junction): close out the C++ port record before the v1 retirement

### DIFF
--- a/docs/archive/JUNCTION_OPERATING_POINT_271.md
+++ b/docs/archive/JUNCTION_OPERATING_POINT_271.md
@@ -40,6 +40,30 @@ It also means the converged q is an output, not the target.
 
 ## Finding 1: the model's coefficient difference is not monotonic
 
+> **Its conclusion is SUPERSEDED (2026-09-08, PR #314).** The U-shaped `D(q)`
+> is real and so is its minimum of 0.551. The TARGETS it was compared against
+> were not: all three network adapters built the pressure-driven boundary
+> conditions by reading Bassett's `K5` and `K6` off the same abscissa, when
+> Table 1 indexes `K5` on the straight leg and `K6` on the lateral. At one
+> operating point they are `K5(1 - q)` and `K6(q)`. The corrected target at
+> q = 0.2 is 0.422, not 0.122, and the model reaches it exactly.
+>
+> So "infeasible, not mis-seeded" is wrong, and both points converge. The
+> method below -- compare the target against the range the model can produce
+> -- was sound; the input to it was not.
+>
+> The paragraph beginning "Why the minimum sits so high is the K_straight gap"
+> is void for the same reason. It compared the model's `K_straight` against
+> Bassett's `K5` on mismatched axes. On the correct axis, at psi = 3, the model
+> spans -0.0625..+0.4848 against Bassett's -0.0625..+0.4704, a maximum
+> difference of **0.014** -- not the "wrong sign and magnitude at low q" this
+> section reports.
+>
+> Kept rather than rewritten: the reasoning is worth reading, and this is the
+> third time an axis convention has produced a convincing physics story out of
+> an index error (#295, #301, #314).
+
+
 `D(q) = K_lat_model(q) - K_str_model(q)` is U-shaped. Mapped through the
 `imposed_q` topology (where q is a boundary condition, so `D` is well defined):
 
@@ -1264,16 +1288,32 @@ declared (7e). The whole-element `(f, J)` moved to C++ and, in doing so,
 supplied two Jacobian columns the Python never had.
 
 **What did not close, and is tracked elsewhere.** The `K_straight` gap is
-[issue #272]'s and is untouched by any of this. Its acceptance gate is
-now met -- the closure scores 0.0498 against the 0.2405 bar -- and the
-residual disagreement was located in the closure rather than the coupling,
-which narrows the search without ending it.
+[issue #272]'s. Its acceptance gate is met -- the closure scores 0.0498
+against the 0.2405 bar -- and the residual disagreement was located in the
+closure rather than the coupling.
+
+That gap is also **smaller than this document makes it look**. A day after
+this entry was first written, the "Bassett Fig 7b has no root" result that
+Finding 1 rests on turned out to be an artefact of boundary targets built by
+reading `K5` and `K6` off the same abscissa (PR #314). On the correct axis the
+model matches Bassett's `K5` to 0.014 and his `K6` to three decimals. What is
+left of `K_straight` is an accuracy question inside the closure, not an
+infeasibility.
 
 **A caution for anyone reading this file later.** Several claims in it were
 repeated from these notes long after the suite had moved on: the equal-area
 identity xfail came off on 2026-09-05, and the "model creates energy below
 q ~ 0.2" finding was an artefact of `eta_scale = 1.0` and never was an xfail.
 Read the suite, not the record.
+
+And a second caution, which cost more. **Three separate findings in this file
+and the design doc were built on an axis convention that was wrong**, each
+time producing a convincing physics story out of an index error -- the scoring
+axis (#295), the type-4 leg labels (#301), and the pressure-driven targets
+(#314). The tell each time was the same: a model that reproduces a paper's
+analytics to three decimals in one place while apparently failing badly in
+another. When those two things are true at once, check the index before
+building a theory.
 
 [MPCE_CPP_PORT_DESIGN.md]: ../../validation/junction/MPCE_CPP_PORT_DESIGN.md
 [JUNCTION_JACOBIAN_271.md]: JUNCTION_JACOBIAN_271.md

--- a/docs/archive/JUNCTION_OPERATING_POINT_271.md
+++ b/docs/archive/JUNCTION_OPERATING_POINT_271.md
@@ -1243,6 +1243,39 @@ scale-dependence are in [MPCE_CPP_PORT_DESIGN.md] sections 7c and 7d.
 - `python/combaero/network/solver.py` -- `_propagate_analytical_pt_prop`
   (the seed) and `verify_solution_consistent`'s call site (the detector).
 
+## Closing the record (2026-09-08)
+
+[Issue #271] is closed. This document served the operating-point
+investigation that preceded the C++ port; the port itself is recorded in
+[MPCE_CPP_PORT_DESIGN.md] section 8a, and what follows is only what a reader
+of THIS file needs in order to know where it stands.
+
+**The findings above held up, with two exceptions recorded in place.**
+Finding 12 ("the residual landscape is clean; the failures are outside the
+model") is true of the q-endpoint cases it examined and not of the plateau
+class -- see Finding 16. And Finding 16's own first reading, that the plateau
+was a mode seam and the soft-barrier penalty was cleared, was itself wrong;
+the correction is in the design doc's 7c and 7d.
+
+**What closed the arc.** The barrier's fixed point at
+`slack* = sqrt(dP / alpha)` was the plateau (7d), and the weight that sets it
+is dimensional, so it is now derived from the network's own scales rather than
+declared (7e). The whole-element `(f, J)` moved to C++ and, in doing so,
+supplied two Jacobian columns the Python never had.
+
+**What did not close, and is tracked elsewhere.** The `K_straight` gap is
+[issue #272]'s and is untouched by any of this. Its acceptance gate is
+now met -- the closure scores 0.0498 against the 0.2405 bar -- and the
+residual disagreement was located in the closure rather than the coupling,
+which narrows the search without ending it.
+
+**A caution for anyone reading this file later.** Several claims in it were
+repeated from these notes long after the suite had moved on: the equal-area
+identity xfail came off on 2026-09-05, and the "model creates energy below
+q ~ 0.2" finding was an artefact of `eta_scale = 1.0` and never was an xfail.
+Read the suite, not the record.
+
 [MPCE_CPP_PORT_DESIGN.md]: ../../validation/junction/MPCE_CPP_PORT_DESIGN.md
 [JUNCTION_JACOBIAN_271.md]: JUNCTION_JACOBIAN_271.md
 [issue #271]: https://github.com/thiemom/combaero/issues/271
+[issue #272]: https://github.com/thiemom/combaero/issues/272

--- a/validation/junction/MPCE_CPP_PORT_DESIGN.md
+++ b/validation/junction/MPCE_CPP_PORT_DESIGN.md
@@ -321,7 +321,17 @@ problems have no solution.** The model's `K_lat - K_str` has a minimum of
 reaches a root that does not exist. They stay pinned as xfail targets in
 `python/tests/test_bassett_fig7b_case.py`, now labelled infeasible rather
 than solver-path failures, and they come off when #272 closes the
-`K_straight` gap. **The `three_pb` assertions in that test were tautological
+`K_straight` gap.
+
+> **Superseded 2026-09-08 (PR #314).** The targets were built by reading
+> Bassett's `K5` and `K6` off the same abscissa; Table 1 indexes them on
+> opposite legs, so at one operating point they are `K5(1 - q)` and `K6(q)`.
+> The corrected target at q = 0.2 is 0.422, which the model reaches exactly.
+> Both points converge, and `mfb_two_pb` now lands within 0.005 of the q it
+> was asked for instead of drifting. `three_pb` above q ~ 0.5 is the only
+> remaining failure and the system there is feasible by construction, so it
+> is a solver and seeding problem -- the opposite of what this paragraph
+> concluded. **The `three_pb` assertions in that test were tautological
 and have been removed** -- see the next section.
 
 ## 4e. The pressure-driven topologies score less than they appear to (2026-09-05)
@@ -360,10 +370,16 @@ continuing collector: its K_straight was exactly `q^2` where Bassett and
 Hager both give `q^2 - 0.5q`. Restoring it made Mynard's CFD-fitted
 energy-transfer factor redundant, and the factor's default is now 0.
 
-**Second motivation, added 2026-09-05:** `K_straight`'s size at low q also
-decides whether the pressure-driven problem has a unique solution. The
-model's `K_lat - K_str` is U-shaped, which makes low-q targets infeasible
-and mid-range targets doubly-rooted. The acceptance criterion this yields is
+**Second motivation, added 2026-09-05 -- WITHDRAWN 2026-09-08 (PR #314).**
+`K_straight`'s size at low q was thought to decide whether the pressure-driven
+problem has a unique solution: the model's `K_lat - K_str` is U-shaped, which
+appeared to make low-q targets infeasible and mid-range targets doubly-rooted.
+The U shape is real; the infeasibility was an artefact of targets built from
+mismatched axes, and on the correct axis the model's `K_straight` matches
+Bassett's `K5` to 0.014 across the range at psi = 3. The multiplicity at
+mid-range is a property of the topology, not of `K_straight`. What survives
+below -- the equal-area identity as an exact acceptance criterion -- does not
+depend on this motivation. The acceptance criterion this yields is
 an exact identity, not an error metric: at `psi = 1` the source gives
 `K_lateral - K_straight = q (1.5 - 2 cos(0.75 theta)) + 0.5`, linear in q with
 slope and intercept fixed by geometry. The model violates it in both slope and

--- a/validation/junction/MPCE_CPP_PORT_DESIGN.md
+++ b/validation/junction/MPCE_CPP_PORT_DESIGN.md
@@ -533,7 +533,14 @@ must preserve; it does not buy convergence here.
 and then reverting with `git checkout` reverted the fix as well. Commit
 first, then instrument.
 
-## 7c. Step 2 follow-up: the residual plateau is a mode seam (2026-09-07)
+## 7c. Step 2 follow-up: the residual plateau, first reading (2026-09-07)
+
+> **Superseded by 7d.** This section named a mode seam and cleared the
+> soft-barrier penalty. Both were wrong, and the corrections are inline
+> below. Kept rather than rewritten because how the wrong answer was
+> reached is the useful part: a downward-only parameter sweep looked
+> like a falsification, and `alpha = 0` is not the same as the barrier
+> being off.
 
 Some non-converged solves have a well-behaved residual history that flattens
 onto a floor well above zero. A minimum that is not a root says an equation,
@@ -865,6 +872,94 @@ silently move 22 roots with nothing able to tell which branch is wanted.
 `MultiPortChamberElement` as the M -> 0 regression target; close the #272
 pressure-representation item as superseded.
 
+## 8a. The port as it landed (2026-09-08)
+
+Section 8 is the plan. This is what shipped, and where it diverged. Issue #271
+is closed on it.
+
+| step | what | PR |
+|---|---|---|
+| 4.1 | `DualN` to `include/dual_number.h`, plus `dexp` `dsin` `dcos` `datan2` `dlog` `dabs` and the two angle wraps | #305 |
+| 4.2 + 4.3 | Mynard closure on duals, `include/mynard_junction.h` | #307 |
+| 4.4a | whole-element (f, J), `include/mpce_junction.h`, seeded over `DualN<10>` | #308 |
+| 4.4b | pybind11 binding and the Python shim | #309 |
+| -- | `ConstantKTeeElement` audited, deliberately NOT ported | #312 |
+
+**What it bought.** Not speed. The Python assembled its Jacobian from a
+sympy `dKQ/dmdot` block plus a hand-derived `dR/dP` column for the common
+port alone, but `K` depends on every port's velocity and every velocity on its
+own density. Against central differences of the assembled network Jacobian the
+worst relative error fell from **4.4e-3 to 1.4e-6**. Accuracy identical to four
+decimals on every source; scorecard 2108 -> 2109 of 2546; random harness
+root-exists 92.9% -> 93.7%.
+
+### Seven divergences from the plan
+
+1. **Steps 4.2 and 4.3 merged.** The pseudosupplier block alone produces
+   nothing comparable against Python. The whole closure is a testable unit:
+   given `(U, A, theta)`, return `C` and `K`.
+2. **`theta` never becomes a dual.** The plan assumed the pseudosupplier block
+   would carry duals throughout. It does not: angles derive from declared
+   geometry and from means over it, and the flows enter only through *which*
+   entries are selected. The dual set is `Q`, `Qtot`, `flow_ratio`, the two
+   pseudosupplier angles, `phi` and everything downstream.
+3. **Six branch-on-primal decisions, not the two the plan named.** The
+   supplier/collector split, the second-quadrant flip, the direction flip, the
+   two wraps' multiples, the common-port choice and the collinearity test. All
+   are marked at their sites in the header.
+4. **The step-4 gate changed shape.** It could not be "equivalence with the
+   Python Jacobian", because the C++ one is *more complete* -- comparing
+   against the Python's would mark the C++ wrong exactly where it is right.
+   Residual VALUES are compared against the Python; the Jacobian is compared
+   against central differences of that residual. The `imposed_q` table gate
+   held as written.
+5. **The guards stayed in Python.** Not in the plan. The degenerate-state
+   fallbacks and the wrong-direction soft barrier are solver policy rather
+   than junction physics, they changed twice during the work (7d, 7e), and the
+   barrier's Jacobian is three lines. So "the Python element becomes a
+   relabelling shim" is true of the physics and not of the policy.
+6. **`_mpce_v2_jacobian.py` was kept**, as step 4's own sentence allowed: the
+   sympy derivation survives as an offline cross-check
+   (`test_mpce_v2_jacobian.py`), not a runtime path. The FD fallback is gone.
+   `jacobian_method` is retired and documented as selecting nothing.
+7. **`ConstantKTeeElement` was not ported** (#312). Its `K` is a fixed
+   per-port constant, so `q_dyn` depends on the common port alone and every
+   other column is genuinely zero rather than missing -- the opposite of the
+   situation that made the MPCEv2 port worth doing. FD-checked over all twelve
+   columns in both directions: complete already. A port would buy consistency
+   of pattern, not correctness.
+
+### Three things the port found that were not defects it went looking for
+
+- **`_wrap_to_pi`'s real range is `[-pi, pi)`, not the `(-pi, pi]` its
+  docstring claimed.** At exactly `+pi` the Python expression returns `-pi`.
+  It matters only where a lateral is exactly anti-parallel to the main duct,
+  which the dataset contains. The C++ matches the implementation; the Python
+  docstring was corrected.
+- **The element re-points the axial-back port at `pi`** before calling the
+  closure, because Mynard's vessel-direction convention needs it while the
+  declared angles are measured from the main axis. Missing this was worth
+  4293 Pa on the first golden case.
+- **The two non-common `dR/dP` columns were absent**, which is the finding in
+  "what it bought" above. It was measured while designing the seeding, not
+  suspected beforehand.
+
+### Method note, worth reading before the next port
+
+Falsification and coverage caught **different** things in every one of the four
+PRs, and neither substitutes for the other. Seven to eight perturbations per PR
+found nothing new; coverage found a real gap in three of four (an angle below
+`-pi`, the joining term with a single supplier, a `1e-9` dead band a comment
+made a claim about). The one time falsification earned its keep it did so by
+*passing* where it should have failed, which named an untested semantic in the
+mass row.
+
+Coverage on a templated numerics header also lies: `dual_number.h` reported
+100% of regions, lines and branches while five of thirteen operator overloads
+were never called, because an uninstantiated template is never emitted and so
+cannot be counted as missed. **Check instantiation counts, not percentages.**
+Both lessons are now in the `model-provenance` skill.
+
 ## 9. Decisions
 
 Taken (user, 2026-09-04):
@@ -872,6 +967,12 @@ Taken (user, 2026-09-04):
 1. **Residual form: stepwise and tested.** Port the faithful `Pt`-based form
    first with an exact equivalence gate; move to Mynard-native `C_j` as a
    separate, later, data-gated change. Never both in one step.
+
+   *Status 2026-09-08: first half DONE (sec 8a). The `C_j` move is still open
+   and unscheduled. Note that it would lift the `n <= 3` limit natively, which
+   nothing currently needs -- `MPCEv2Element` refuses `N > 3` at construction
+   and no shipped network asks for one -- so the case for it rests on matching
+   the paper's residual set, not on capability.*
 2. **Tuned corrections** (`alpha`, `eta`, damping, and any future one) prove
    themselves against validation data for our regime, and are labelled as
    tuned. CFD-derived corrections count as tuning; the CFD they came from is


### PR DESCRIPTION
Step 1 of the retirement sequence. The docs have to be complete before v1 goes, or the history that explains why it went is missing.

## Section 8 was still a plan

Steps 0 through 4 in future tense, with nothing recording what shipped. **8a** now covers the four PRs, what the port actually bought, and seven divergences from the plan:

| | divergence |
|---|---|
| 1 | 4.2 and 4.3 merged — the pseudosupplier block alone is not testable against Python |
| 2 | `theta` never becomes a dual; the dual set is smaller than assumed |
| 3 | six branch-on-primal decisions, not the two the plan named |
| 4 | **the step-4 gate changed shape** — it could not be equivalence with the Python Jacobian, because the C++ one is *more complete* |
| 5 | the guards stayed in Python, which the plan did not anticipate |
| 6 | `_mpce_v2_jacobian.py` kept as an offline cross-check, as step 4's own sentence allowed |
| 7 | `ConstantKTeeElement` measured and deliberately not ported |

And what the port bought, which was not speed: against central differences of the assembled network Jacobian, worst relative error **4.4e-3 → 1.4e-6**, because the hand-derived column covered the common port alone while `K` depends on every port's velocity.

Plus the three things it turned up without looking for them — `_wrap_to_pi`'s real range being `[-pi, pi)` rather than what its docstring claimed, the axial-back angle reassignment worth 4293 Pa on the first golden case, and the two missing `dR/dP` columns.

## Section 7c's heading still asserted what 7d overturned

It read *"the residual plateau is a mode seam"*. The body was corrected when the barrier's fixed point was found; the title was not. Marked superseded and **kept rather than rewritten**, because how the wrong answer was reached is the useful part: a downward-only parameter sweep looked like a falsification, and `alpha = 0` is not the same as the barrier being off.

## The provenance record had no closing entry

Adds one: what held, the two findings that did not (Finding 12's scope, and Finding 16's own first reading), what closed the arc, and what did not and is #272's.

It ends with a caution earned this week — several claims were repeated from those notes long after the suite had moved on, including an xfail that came off on 2026-09-05 and one that never existed as an xfail at all. **Read the suite, not the record.**

## Also

Section 9's decision 1 gains a status line: the `Pt`-based port is done, the move to Mynard-native `C_j` is still open and unscheduled, and it would lift an `n <= 3` limit that nothing currently needs.

Docs only. Next in the sequence: deprecate v1, cut v0.5.0, then rename and retire in v0.6.0.

Refs #271, #272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RNDxZouiHoJdaLpnnPjHq
