### PR TITLE
fix(validation): pair Bassett's K5 and K6 at one operating point (#272)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **The junction validation harness built its pressure-driven boundary targets
+  from two different operating points.** Bassett Table 1 indexes each loss
+  coefficient on the mass-flow fraction in its own leg -- `K5` on
+  `mdot_A/mdot_C` (the straight leg), `K6` on `mdot_B/mdot_C` (the lateral) --
+  so at one physical state they are `K5(1-q)` and `K6(q)`. All three network
+  adapters read both off the same abscissa, which asked the `three_pb` and
+  `mfb_two_pb` skeletons for boundary pressures corresponding to a state that
+  does not exist. The pairing now lives in one place,
+  `bassett2001.separating_pair_at`. Measured: the junction scorecard goes from
+  2109 to **2178** of 2546 converged and 2082 to **2152** points scored, with
+  the pooled mean absolute error improving from 0.4982 to **0.4809** and
+  Bassett's own from 0.1538 to **0.1416**. `mfb_two_pb` changes character --
+  it used to drift far from the operating point it was asked for (q=0.8
+  settling at 0.857) and now lands within 0.005 across the range, because the
+  drift was the solve honestly chasing a mismatched target. Two strict xfails
+  recorded as "no root exists, waiting on the K_straight gap" come off: the
+  root existed, and the corrected target at q=0.2 is 0.422 rather than 0.122.
+  Affects the validation harness only -- no shipped model or solver behaviour
+  changes.
+
 ### Changed
 - **The momentum-CV junction's residual and Jacobian are now computed in C++.**
   `MPCEv2Element` becomes a shim: it applies the guards -- the degenerate-state

--- a/python/tests/test_bassett_fig7b_case.py
+++ b/python/tests/test_bassett_fig7b_case.py
@@ -23,18 +23,39 @@ What each topology can actually prove (docs/archive/JUNCTION_OPERATING_POINT_271
   decimals. Comparing it against Bassett at the TARGET q is a comparison at
   the wrong operating point, so this file does not do that either.
 
-Measured 2026-09-05 with the production-faithful adapter (strict=False):
+**The 2026-09-05 reading of this case was wrong, and the correction is the
+reason most of it now passes.** That reading recorded no root at q = 0.2 and
+0.4, on the grounds that the model's ``K_lat - K_str`` bottoms out at 0.551
+while the targets sat at 0.122 and 0.385, and filed them as xfails waiting on
+the #272 K_straight gap.
 
-    topology     q=0.2        q=0.4        q=0.6      q=0.8
-    imposed_q    ok           ok           ok         ok
-    three_pb     no root      ok           ok         ok
-    mfb_two_pb   no root      no root      ok         ok  (at q=0.857)
+The targets were built wrongly. Bassett Table 1 indexes each coefficient on
+the mass-flow fraction in ITS OWN leg -- ``K5`` on ``mdot_A/mdot_C`` (the
+straight leg), ``K6`` on ``mdot_B/mdot_C`` (the lateral) -- so at one physical
+operating point they are ``K5(1 - q)`` and ``K6(q)``. All three network
+adapters read both off the same abscissa, which asks the boundary conditions
+for a state made of two different operating points. The correct target at
+q = 0.2 is ``K6(0.2) - K5(0.8) = 0.422``, not 0.122, and the model hits it
+exactly -- it reproduces both of Bassett's coefficients to three decimals.
+See ``bassett2001.separating_pair_at``.
 
-The q=0.2 and q=0.4 failures are NOT solver-path failures. Those boundary-value
-problems have no solution: the model's K_lat - K_str has a minimum of 0.551 for
-this geometry and the targets sit at 0.122 and 0.385. They are xfail targets
-that come off when the K_straight gap (#272) closes, not when the solver or
-the seed improves.
+Measured 2026-09-08, after the correction:
+
+    topology     q=0.2   q=0.3   q=0.4   q>=0.5
+    imposed_q    ok      ok      ok      ok
+    three_pb     ok      ok      ok      solver fails (a root EXISTS)
+    mfb_two_pb   ok      ok      ok      ok, and it lands ON the asked q
+
+``mfb_two_pb`` is the one that changed character. It used to drift far from
+the operating point it was asked for -- q = 0.8 settling at 0.857 -- and now
+reaches 0.7970. The old drift was the solve honestly chasing a target built
+from a mismatched pair.
+
+``three_pb`` above q = 0.5 is now the only failure, and it is a SOLVER
+failure, not an infeasible system: because the model reproduces Bassett's
+coefficients, the corrected target equals the model's own value at the asked
+q, so a root exists there by construction. That is a different xfail from the
+one it replaces.
 """
 
 from __future__ import annotations
@@ -82,14 +103,6 @@ _INADMISSIBLE = (
     "closes the K_straight gap."
 )
 
-_THREE_PB_WANDER = (
-    "three_pb at q=0.4 does not converge. That topology imposes every total "
-    "pressure and leaves the flow level free, so it wanders far from the "
-    "operating point it was asked for -- at q=0.6 and 0.8 it converges but "
-    "lands at q ~ 0.04-0.06. Its K column is not scored for the same reason "
-    "(#290). Tracked with the operating-point work, not with the closure."
-)
-
 
 @pytest.mark.parametrize("q", [0.2, 0.4, 0.6, 0.8])
 def test_imposed_q_converges_across_the_curve(model, q):
@@ -122,18 +135,17 @@ def test_imposed_q_reproduces_the_model_curve(model, q, expected):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize(
-    "q",
-    [
-        pytest.param(0.4, marks=pytest.mark.xfail(strict=True, reason=_THREE_PB_WANDER)),
-        0.6,
-        0.8,
-    ],
-)
+@pytest.mark.parametrize("q", [0.2, 0.3, 0.4])
 def test_three_pb_converges(model, q):
     """The case that raised under strict=True. With the soft barrier steering
     the reversed first iterate back it converges. No K assertion: in this
-    topology the extracted K is the imposed target whatever the model does."""
+    topology the extracted K is the imposed target whatever the model does.
+
+    The low-q end used to be an xfail on the grounds that no root existed --
+    see the module docstring; the target was built from a mismatched pair.
+    q = 0.4 was separately an xfail for wandering off the operating point.
+    Both come off with the corrected pairing.
+    """
     assert _run(model, "three_pb", q).converged
 
 
@@ -143,18 +155,37 @@ def test_mfb_two_pb_converges(model, q):
 
 
 def test_mfb_two_pb_root_is_the_models_own_answer(model):
-    """q=0.8 settles at q=0.857 and must reproduce the model there.
+    """The K it reports must be the model's own answer at the q it REACHED.
 
-    This was once recorded as an uncaught mirror root, from comparing K
-    against Bassett at the target q. The honest check is against the model's
-    own imposed_q curve at the q the solve actually reached.
+    Once recorded as an uncaught mirror root, from comparing K against Bassett
+    at the target q. The honest check is against the model's own imposed_q
+    curve at the achieved operating point, whatever that turns out to be --
+    written against ``q_converged`` rather than a hard-coded number, because
+    that number moved once already when the target pairing was corrected
+    (0.857 -> 0.797).
     """
     r = _run(model, "mfb_two_pb", 0.8)
     assert r.converged, r.message
+    assert r.q_converged is not None
 
-    reference = _run(model, "imposed_q", 0.8314)
+    reference = _run(model, "imposed_q", r.q_converged)
     assert reference.converged, reference.message
     assert r.K_lateral == pytest.approx(reference.K_lateral, abs=0.01)
+
+
+def test_mfb_two_pb_now_lands_on_the_operating_point_it_was_asked_for(model):
+    """The correction's most visible effect, and the reason the drift was
+    never a modelling problem.
+
+    With the target built from a mismatched pair the split was an outcome that
+    wandered -- q = 0.8 settling at 0.857. With the pair taken at one
+    operating point it settles within 0.005 of what was asked across the
+    range. If this regresses, suspect the pairing before the solver.
+    """
+    for q in (0.4, 0.5, 0.6, 0.7, 0.8, 0.9):
+        r = _run(model, "mfb_two_pb", q)
+        assert r.converged, f"q={q}: {r.message}"
+        assert r.q_converged == pytest.approx(q, abs=0.005), f"asked q={q}, reached {r.q_converged}"
 
 
 # ---------------------------------------------------------------------------
@@ -162,24 +193,35 @@ def test_mfb_two_pb_root_is_the_models_own_answer(model):
 # ---------------------------------------------------------------------------
 
 
-_TARGET = (
-    "Bassett Fig 7b at a low lateral fraction has NO root in the "
-    "pressure-driven topologies: they constrain K_lat - K_str, the model's "
-    "value of that has a minimum of 0.551 for this geometry, and the targets "
-    "are 0.122 (q=0.2) and 0.385 (q=0.4). 'Not making good progress' is the "
-    "solver reporting an infeasible system honestly, and no initial guess "
-    "changes it. This comes off when #272 closes the K_straight gap, not "
-    "when the solver improves. strict=True so it is noticed either way."
+_THREE_PB_HIGH_Q = (
+    "three_pb does not converge above q ~ 0.5, and unlike the reason this "
+    "xfail replaces, the system IS feasible: the model reproduces Bassett's "
+    "K5 and K6 to three decimals, so the corrected target equals the model's "
+    "own K_lat - K_str at the asked q and a root exists there by "
+    "construction. This topology imposes every total pressure and leaves the "
+    "flow level free, so the residual constrains only the DIFFERENCE and the "
+    "solve has a one-parameter family to wander along. A solver and seeding "
+    "problem, not a modelling one -- the opposite of what the xfail it "
+    "replaces claimed. strict=True so it is noticed either way."
 )
 
 
-@pytest.mark.xfail(strict=True, reason=_TARGET)
-def test_three_pb_low_lateral_fraction_converges(model):
-    assert _run(model, "three_pb", 0.2).converged
+@pytest.mark.parametrize("q", [0.5, 0.6, 0.8])
+@pytest.mark.xfail(strict=True, reason=_THREE_PB_HIGH_Q)
+def test_three_pb_converges_at_high_lateral_fraction(model, q):
+    assert _run(model, "three_pb", q).converged
 
 
-@pytest.mark.xfail(strict=True, reason=_TARGET)
+def test_three_pb_low_lateral_fraction_lands_on_the_asked_point(model):
+    """Was a strict xfail on the grounds that no root existed. It did exist --
+    the target was built from two different operating points."""
+    r = _run(model, "three_pb", 0.2)
+    assert r.converged, r.message
+    assert r.q_converged == pytest.approx(0.2, abs=0.005)
+
+
 def test_mfb_two_pb_low_lateral_fraction_converges(model):
+    """The other half of the same correction."""
     assert _run(model, "mfb_two_pb", 0.2).converged
 
 

--- a/python/tests/test_junction_score_at_achieved_q.py
+++ b/python/tests/test_junction_score_at_achieved_q.py
@@ -61,10 +61,17 @@ def test_three_pb_K_is_the_imposed_target_whatever_the_model_does():
     model is inadmissible in three_pb and is rejected before a K can be
     extracted. A perturbation has to stay inside the physics to demonstrate
     anything.
+
+    The operating point moved from q = 0.8 to 0.4 when the pressure-driven
+    boundary targets were corrected to pair Bassett's K5 and K6 at one state
+    rather than off the same abscissa. three_pb converges below q ~ 0.5 and
+    not above it (see test_bassett_fig7b_case), so the falsification has to be
+    demonstrated where the topology runs at all. The point being made is
+    unchanged and does not depend on which q it is made at.
     """
     honest = MPCEv2Network(strict=False)
     wrong = MPCEv2Network(strict=False, eta_scale=0.3)
-    q = 0.8
+    q = 0.4
     target = bassett2001.K6(q, _PSI, _THETA)
 
     honest_imposed = honest.evaluate_network("bassett2001", "K6", q, _PSI, _THETA)
@@ -160,18 +167,35 @@ def test_imposed_q_reaches_the_operating_point_it_was_given(model, q):
 
 
 def test_pressure_driven_solve_reports_where_it_actually_landed(model):
-    """Bassett Fig 7b mfb_two_pb q=0.8 settles at q=0.857, not 0.8.
+    """A pressure-driven solve reports the operating point it REACHED, which
+    need not be the one it was asked for.
 
-    Reported as a mirror root before this field existed, because the K was
-    compared against the paper at 0.8 while the solve sat elsewhere.
+    Originally written on ``mfb_two_pb`` at q = 0.8, which settled at 0.857 --
+    reported as a mirror root before this field existed, because the K was
+    compared against the paper at 0.8 while the solve sat elsewhere. That
+    drift is gone: it came from a boundary target built by reading Bassett's
+    K5 and K6 off the same abscissa when Table 1 indexes them on opposite
+    legs, and with the pairing corrected ``mfb_two_pb`` lands within 0.005 of
+    what it was asked for.
+
+    So the case moved to ``three_pb``, which still drifts and for a reason
+    that is not a defect: it imposes every total pressure and leaves the flow
+    level free, so the residual constrains only ``K_lat - K_str`` and any
+    point on that curve is a root. The field has to report which one.
+
+    Written against a measured drift rather than a pinned number -- the old
+    0.857/0.831 constant had already been re-derived twice.
     """
-    r = model.evaluate_network("bassett2001", "K6", 0.8, _PSI, _THETA, topology="mfb_two_pb")
+    q_asked = 0.3
+    r = model.evaluate_network("bassett2001", "K6", q_asked, _PSI, _THETA, topology="three_pb")
 
     assert r.converged, r.message
-    # 0.857 before the dividing-streamline recovery landed; the closure moved,
-    # so the operating point it settles at moved with it.
-    assert r.q_converged == pytest.approx(0.831, abs=0.005)
-    assert r.q_converged != pytest.approx(0.8, abs=0.01)
+    assert r.q_converged is not None, "a pressure-driven solve must report where it landed"
+    assert r.q_converged != pytest.approx(q_asked, abs=0.01), (
+        "this case no longer drifts, so it cannot show that the field reports "
+        f"the achieved point (asked {q_asked}, reached {r.q_converged})"
+    )
+    assert 0.0 < r.q_converged < 1.0
 
 
 def test_bassett_K11_drift_is_reported_on_the_papers_own_axis(model):

--- a/validation/junction/models/bassett2001.py
+++ b/validation/junction/models/bassett2001.py
@@ -75,6 +75,31 @@ def K6(q: float, psi: float, theta: float) -> float:
     return q * q * psi * psi + 1.0 - 2.0 * q * psi * math.cos(0.75 * theta)
 
 
+def separating_pair_at(q_lateral: float, psi: float, theta: float) -> tuple[float, float]:
+    """(K_straight, K_lateral) for flow type 3 at ONE operating point.
+
+    Table 1 indexes each coefficient on the mass-flow fraction in ITS OWN leg:
+    ``K5`` on ``q = mdot_A/mdot_C`` (the straight leg) and ``K6`` on
+    ``q = mdot_B/mdot_C`` (the lateral). At a single physical state those are
+    ``1 - q_lateral`` and ``q_lateral``, so the pair must never be read off the
+    same abscissa.
+
+    Reading both at the same ``q`` mixes two different operating points. Doing
+    exactly that is what made Bassett Fig 7b look unreachable: the pressure-
+    driven skeletons were handed a target of ``K6(0.2) - K5(0.2) = 0.122``
+    against a model whose ``K_lat - K_str`` bottoms out at 0.551, and the
+    solver reported an infeasible system -- honestly, but about a state nobody
+    meant to ask for. The correct pairing at that point is
+    ``K6(0.2) - K5(0.8) = 0.422``, which the model hits exactly, because it
+    reproduces both of Bassett's coefficients to three decimals.
+
+    Exists so the pairing lives in one place. The same slip has been fixed
+    twice before in the scoring axis (#295) and the type-4 leg labels (#301);
+    three adapters had independently repeated it here (#272).
+    """
+    return K5(1.0 - q_lateral), K6(q_lateral, psi, theta)
+
+
 # ---------------------------------------------------------------------------
 # Joining flows (Section 3.1). Table 2 raw forms + body-text angle-corrected
 # forms per Section 4.2.

--- a/validation/junction/models/mpce_v1_network.py
+++ b/validation/junction/models/mpce_v1_network.py
@@ -108,8 +108,7 @@ class MPCEv1Network:
             net = build_separating_network_skeleton(m_in=m_in, m_lateral=q * m_in)
             lateral_terminal = "mb_lat"
         else:
-            K_lat = bassett2001.K6(q, psi, theta_rad)
-            K_str = bassett2001.K5(q)
+            K_str, K_lat = bassett2001.separating_pair_at(q, psi, theta_rad)
             if topology == "three_pb":
                 net = build_separating_three_pb_skeleton(
                     K_lateral_target=K_lat, K_straight_target=K_str

--- a/validation/junction/models/mpce_v2_network.py
+++ b/validation/junction/models/mpce_v2_network.py
@@ -235,8 +235,7 @@ class MPCEv2Network:
             net = build_separating_network_skeleton(m_in=m_in, m_lateral=q * m_in)
             lateral_terminal = "mb_lat"
         else:
-            K_lat = bassett2001.K6(q, psi, theta_rad)
-            K_str = bassett2001.K5(q)
+            K_str, K_lat = bassett2001.separating_pair_at(q, psi, theta_rad)
             if topology == "three_pb":
                 net = build_separating_three_pb_skeleton(
                     K_lateral_target=K_lat, K_straight_target=K_str

--- a/validation/junction/models/tee_junction_element_network.py
+++ b/validation/junction/models/tee_junction_element_network.py
@@ -90,8 +90,7 @@ class TeeJunctionElementNetwork:
         if topology == "imposed_q":
             return self._separating_imposed_q(q, psi, theta_rad)
         # For PB-based topologies, use Bassett analytical K to set up BCs.
-        K_lat = bassett2001.K6(q, psi, theta_rad)
-        K_str = bassett2001.K5(q)
+        K_str, K_lat = bassett2001.separating_pair_at(q, psi, theta_rad)
         if topology == "three_pb":
             net = build_separating_three_pb_skeleton(
                 K_lateral_target=K_lat, K_straight_target=K_str


### PR DESCRIPTION
Bassett **Table 1** indexes each loss coefficient on the mass-flow fraction in *its own leg*: `K5` on `mdot_A/mdot_C` (the straight leg), `K6` on `mdot_B/mdot_C` (the lateral). At one physical state those are `K5(1-q)` and `K6(q)`.

All three network adapters read both off the same abscissa:

```python
K_lat = bassett2001.K6(q, psi, theta_rad)
K_str = bassett2001.K5(q)          # q here is the LATERAL fraction
```

which asked the `three_pb` and `mfb_two_pb` skeletons for boundary pressures corresponding to a state made of **two different operating points**. `imposed_q` doesn't use these targets, which is why the accuracy scoring never saw it.

The pairing now lives in one place, `bassett2001.separating_pair_at` — the same slip has now been fixed three times: the scoring axis (#295), the type-4 leg labels (#301), and here.

## What it was hiding

This is the entire basis of the "Bassett Fig 7b has no root" finding. The target at q=0.2 was computed as `K6(0.2) − K5(0.2) = 0.122` against a model whose `K_lat − K_str` bottoms out at 0.551, so the solver reported an infeasible system — honestly, but about a state nobody meant to ask for.

The correct target is `K6(0.2) − K5(0.8) = 0.422`, and the model hits it exactly, because it reproduces both of Bassett's coefficients to three decimals:

| ψ=3, q_lat | Bassett K6 | ours | Bassett K5(1−q) | ours |
|---|---|---|---|---|
| 0.2 | 0.362 | **0.362** | −0.060 | **−0.060** |
| 0.4 | 0.444 | **0.444** | −0.040 | **−0.040** |
| 0.7 | 1.918 | **1.918** | 0.140 | **0.140** |

## Measured

| | before | after |
|---|---|---|
| scorecard converged | 2109 / 2546 | **2178** |
| points scored | 2082 | **2152** |
| Bassett mean abs error | 0.1538 | **0.1416** |
| pooled mean abs error | 0.4982 | **0.4809** |

`mfb_two_pb` changes character: it used to drift far from the operating point it was asked for — q=0.8 settling at 0.857 — and now lands within 0.005 across the range. **The drift was the solve honestly chasing a mismatched target**, not a modelling problem.

## Tests re-derived, not relaxed

- **Two strict xfails** claiming no root exists come off. They converge, and at q=0.2 `three_pb` lands exactly there.
- **`three_pb` above q ≈ 0.5 becomes a new xfail with the opposite reason.** The system is feasible *by construction* — the corrected target equals the model's own value at the asked q — so the failure is solver and seeding, not modelling.
- **`test_pressure_driven_solve_reports_where_it_actually_landed`** moved from `mfb_two_pb` to `three_pb`, because `mfb` no longer drifts and so can no longer demonstrate that the field reports the *achieved* point. Now written against a measured drift rather than a pinned number, which had already been re-derived twice.
- **The `three_pb` tautology falsification** moved from q=0.8 to 0.4 for the same reason, point unchanged.

Falsified: reverting the pairing reds 10 tests across the two files. Full suite green (2262 passed).

Validation harness only — no shipped model or solver behaviour changes.

Refs #272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RNDxZouiHoJdaLpnnPjHq
