### PR TITLE
deprecate(junction): MultiPortChamberElement's own model, removal in 0.6.0 (#271)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Deprecated
+- **`MultiPortChamberElement`'s own junction model, for removal in 0.6.0.**
+  Its `residuals`, `diagnostics` and `verify_solution_consistent` now emit a
+  `DeprecationWarning` once per element. Use `MPCEv2Element`: on the same
+  Bassett separating cells it scores a mean absolute error of 0.0564 against
+  this model's 0.5260 and converges on 94 of 105 points against 77, and it
+  computes its residual and Jacobian in C++. This model is also energetically
+  inconsistent for joining flow and sign-symmetric, so it admits mirror roots.
+  Nothing in the package or the GUI instantiates it.
+
+  **Only the model is deprecated.** The class also owns the topology and port
+  machinery that `MPCEv2Element` and `ConstantKTeeElement` inherit unchanged --
+  13 of its 17 public members -- and that is staying. The warning is guarded on
+  the exact type rather than on `isinstance`, because
+  `MPCEv2Element.diagnostics` delegates here through `super()` and would
+  otherwise warn every user of the element that replaces this one.
+
+  0.5.0 is the last release carrying it, so a network built on it can be run by
+  pinning `combaero~=0.5`.
+
 ### Fixed
 - **The junction validation harness built its pressure-driven boundary targets
   from two different operating points.** Bassett Table 1 indexes each loss

--- a/python/combaero/network/components.py
+++ b/python/combaero/network/components.py
@@ -3232,6 +3232,45 @@ class TeeJunctionElement(NetworkElement):
 # ---------------------------------------------------------------------------
 
 
+#: v0.5.0 is the last release carrying MultiPortChamberElement's own model.
+_V1_JUNCTION_REMOVAL = "0.6.0"
+
+
+def _warn_v1_junction_model(element: object, method: str) -> None:
+    """Warn once per element that this junction MODEL is going away.
+
+    Only the model is deprecated -- ``residuals``, ``diagnostics`` and
+    ``verify_solution_consistent`` on :class:`MultiPortChamberElement` itself.
+    The class also owns the topology and port machinery that
+    ``MPCEv2Element`` and ``ConstantKTeeElement`` inherit unchanged, 13 of its
+    17 public members, and none of that is going anywhere. So the check is
+    ``type(element) is MultiPortChamberElement`` and not ``isinstance``:
+    ``MPCEv2Element.diagnostics`` calls ``super().diagnostics()``, and warning
+    there would fire on every user of the element that REPLACES this one.
+
+    Why it is going: the model scores 0.5260 against Bassett's separating
+    curves where MPCEv2Element scores 0.0564 on the same cells, converges on
+    77 of 105 against 94, is energetically inconsistent for joining flow, and
+    is sign-symmetric so it admits mirror roots. Nothing in the package or the
+    GUI instantiates it. See issue #271.
+    """
+    if type(element) is not MultiPortChamberElement:
+        return
+    if getattr(element, "_v1_model_deprecation_warned", False):
+        return
+    element._v1_model_deprecation_warned = True  # type: ignore[attr-defined]
+    warnings.warn(
+        f"MultiPortChamberElement.{method} is deprecated and will be removed "
+        f"in combaero {_V1_JUNCTION_REMOVAL}. Use MPCEv2Element, which is "
+        f"roughly nine times more accurate on Bassett's separating curves, "
+        f"converges more often, and computes its residual and Jacobian in "
+        f"C++. The topology machinery this class also provides is NOT "
+        f"deprecated -- MPCEv2Element inherits it. See issue #271.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+
+
 class MultiPortChamberElement(NetworkElement):
     """
     Momentum-CV junction element (N >= 2 ports).
@@ -3391,6 +3430,13 @@ class MultiPortChamberElement(NetworkElement):
         """Post-solve energy-consistency check: no collector port may end
         up with a higher total pressure than the best supplier port.
 
+        DEPRECATED, removal in 0.6.0. Note that this per-branch bound is the
+        form MPCEv2Element deliberately does NOT use: a passive junction may
+        raise one branch's total pressure at another's expense, which is real
+        physics and is why Bassett's K5 and Hager's xi_t go negative in
+        dividing flow. The replacement asserts the aggregate
+        ``sum_in |m| Pt >= sum_out |m| Pt`` instead.
+
         The v1 impulse rows are even in the port flows (u_i^2), so the
         sign-flipped image of any root is also an exact root -- and the
         image of a physical root is energetically impossible (flow
@@ -3412,6 +3458,7 @@ class MultiPortChamberElement(NetworkElement):
         reject the v1 model's own legitimate solutions (observed on the
         certified-audit merge fixtures).
         """
+        _warn_v1_junction_model(self, "verify_solution_consistent")
         flows: list[float] = []
         pts: list[float] = []
         for i in range(self.N):
@@ -3586,6 +3633,8 @@ class MultiPortChamberElement(NetworkElement):
     ) -> tuple[list[float], dict[int, dict[str, float]]]:
         """Evaluate residuals + Jacobian. Called from the solver special-case.
 
+        DEPRECATED, removal in 0.6.0 -- see ``_warn_v1_junction_model``.
+
         Args:
             states: per-port NetworkMixtureState (carries P, T, Y at each port).
             P_jct: junction's internal static pressure unknown value.
@@ -3599,6 +3648,7 @@ class MultiPortChamberElement(NetworkElement):
             Jacobian uses the connecting elements' m_dot unknown names with the
             port-orientation sign baked in.
         """
+        _warn_v1_junction_model(self, "residuals")
         P = [s.P for s in states]
         T = [s.T for s in states]
         Y = [list(s.Y) for s in states]
@@ -3662,6 +3712,13 @@ class MultiPortChamberElement(NetworkElement):
         P_jct: float,
         port_mdots: list[float] | None = None,
     ) -> dict[str, float]:
+        """DEPRECATED, removal in 0.6.0 -- see ``_warn_v1_junction_model``.
+
+        Note that ``MPCEv2Element.diagnostics`` delegates here via ``super()``,
+        which is why the warning is guarded on the exact type rather than on
+        ``isinstance``.
+        """
+        _warn_v1_junction_model(self, "diagnostics")
         diag: dict[str, float] = {"P_jct": float(P_jct), "n_ports": float(self.N)}
         for i in range(self.N):
             diag[f"port_{i}_P"] = float(states[i].P)

--- a/python/tests/test_v1_junction_deprecation.py
+++ b/python/tests/test_v1_junction_deprecation.py
@@ -1,0 +1,170 @@
+"""`MultiPortChamberElement`'s own model is deprecated; its machinery is not.
+
+v0.5.0 is the last release carrying it. The retirement is decided on
+measurement, not preference: on the same Bassett separating cells the v1 model
+scores 0.5260 against `MPCEv2Element`'s 0.0564 and converges on 77 of 105
+points against 94. It is also energetically inconsistent for joining flow and
+sign-symmetric, so it admits mirror roots. Nothing in the package or the GUI
+instantiates it (issue #271).
+
+The distinction these tests exist to protect is that **only the model goes**.
+The class also owns the topology and port machinery that `MPCEv2Element` and
+`ConstantKTeeElement` inherit unchanged -- 13 of its 17 public members -- and
+that is not deprecated. `MPCEv2Element.diagnostics` in particular delegates
+here through `super()`, so a warning guarded on `isinstance` would fire on
+every user of the element that REPLACES this one. It is guarded on the exact
+type instead.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+import combaero as cb
+from combaero.network.components import (
+    BorderCarnotLossElement,
+    MultiPortChamberElement,
+    NetworkMixtureState,
+)
+from combaero.network.mpce_v2_element import ConstantKTeeElement, MPCEv2Element
+
+_Y = list(cb.mole_to_mass(cb.species.dry_air()))
+
+
+def _states():
+    return [
+        NetworkMixtureState(P=1.0e5, Pt=100_300.0, T=300.0, Tt=300.5, m_dot=0.0, Y=list(_Y))
+        for _ in range(3)
+    ]
+
+
+def _v1() -> MultiPortChamberElement:
+    element = MultiPortChamberElement(
+        id="jct",
+        inlet_nodes=["p0"],
+        outlet_nodes=["p1", "p2"],
+        inlet_angles_deg=[0.0],
+        outlet_angles_deg=[0.0, 90.0],
+        port_areas=[0.01] * 3,
+    )
+    element._port_element_ids = ["e0", "e1", "e2"]
+    return element
+
+
+def _v2(cls=MPCEv2Element):
+    kwargs = {
+        "id": "jct",
+        "inlet_nodes": ["p0"],
+        "outlet_nodes": ["p1", "p2"],
+        "inlet_angles_deg": [0.0],
+        "outlet_angles_deg": [0.0, 90.0],
+        "port_areas": [0.01] * 3,
+        "flow_direction": "branch",
+        "strict": False,
+    }
+    if cls is ConstantKTeeElement:
+        kwargs["K_ports"] = {1: 0.35, 2: 1.20}
+    element = cls(**kwargs)
+    element._port_element_ids = ["e0", "e1", "e2"]
+    return element
+
+
+_MDOTS = [-0.10, 0.06, 0.04]
+
+
+# ---------------------------------------------------------------------------
+# The model warns
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("method", ["residuals", "diagnostics", "verify_solution_consistent"])
+def test_each_v1_model_method_warns(method):
+    element = _v1()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        if method == "residuals":
+            element.residuals(_states(), 1.0e5, list(_MDOTS))
+        elif method == "diagnostics":
+            element.diagnostics(_states(), 1.0e5, list(_MDOTS))
+        else:
+            element.verify_solution_consistent({})
+
+    deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert deprecations, f"{method} did not warn"
+    text = str(deprecations[0].message)
+    assert method in text
+    assert "0.6.0" in text, "the warning must say WHEN it goes"
+    assert "MPCEv2Element" in text, "the warning must say what to use instead"
+
+
+def test_it_warns_once_per_element_not_once_per_call():
+    """`residuals` is called thousands of times in a Newton loop. A warning
+    per call would be unusable, so it is guarded per instance."""
+    element = _v1()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        for _ in range(20):
+            element.residuals(_states(), 1.0e5, list(_MDOTS))
+
+    deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert len(deprecations) == 1, f"{len(deprecations)} warnings from 20 calls"
+
+
+def test_a_second_element_warns_again():
+    """Per instance, not per process: a second network must still be told."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _v1().residuals(_states(), 1.0e5, list(_MDOTS))
+        _v1().residuals(_states(), 1.0e5, list(_MDOTS))
+
+    deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert len(deprecations) == 2
+
+
+# ---------------------------------------------------------------------------
+# The machinery does not
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("cls", [MPCEv2Element, ConstantKTeeElement])
+def test_the_replacement_elements_do_not_warn(cls):
+    """The load-bearing case. `MPCEv2Element.diagnostics` calls
+    `super().diagnostics()`, so a warning guarded on `isinstance` would fire
+    on every user of the element that replaces this one."""
+    element = _v2(cls)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        element.residuals(_states(), 100_300.0, list(_MDOTS))
+        element.diagnostics(_states(), 100_300.0, list(_MDOTS))
+        element.verify_solution_consistent({})
+
+    deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert not deprecations, f"{cls.__name__} warned: {[str(w.message) for w in deprecations]}"
+
+
+def test_the_subclass_really_does_reach_v1_diagnostics():
+    """Otherwise the test above passes for the wrong reason -- it would prove
+    nothing if the delegation had quietly gone away."""
+    import inspect
+
+    assert "super()" in inspect.getsource(MPCEv2Element.diagnostics)
+
+
+def test_constructing_v1_does_not_warn():
+    """Only USING the model warns. Constructing one is how the machinery gets
+    exercised, and a warning at construction would fire for subclasses too."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _v1()
+        _v2()
+
+    assert not [w for w in caught if issubclass(w.category, DeprecationWarning)]
+
+
+def test_the_companion_loss_element_is_not_deprecated():
+    """`BorderCarnotLossElement` pairs with v1 in the Tier-1 design but is a
+    separate element and is not going anywhere with it."""
+    assert BorderCarnotLossElement is not None
+    assert not hasattr(BorderCarnotLossElement, "_v1_model_deprecation_warned")


### PR DESCRIPTION
Step 2 of the retirement sequence. **0.5.0 will be the last release carrying this model**, so a network built on it can be run by pinning `combaero~=0.5`, and the 0.6.0 removal is announced by the software rather than only by a changelog.

## Why, measured

| | v1 model | `MPCEv2Element` |
|---|---|---|
| Bassett separating MAE (same cells) | **0.5260** | 0.0564 |
| converged | 77 / 105 | 94 / 105 |

It is also energetically inconsistent for joining flow and sign-symmetric, so it admits mirror roots. Nothing in `python/combaero` or the GUI instantiates it — one validation adapter and five test files do.

## Only the model is deprecated

`residuals`, `diagnostics` and `verify_solution_consistent`. The class also owns the topology and port machinery that `MPCEv2Element` and `ConstantKTeeElement` inherit unchanged — **13 of its 17 public members** — and that is staying.

That distinction is load-bearing in the implementation, not just the prose:

```python
if type(element) is not MultiPortChamberElement:
    return   # a subclass using inherited machinery
```

`MPCEv2Element.diagnostics` delegates here through `super()`, so a warning guarded on `isinstance` would fire on **every user of the element that replaces this one**. There's a test asserting the delegation still exists, so the guard test can't pass for the wrong reason.

The warning also fires **once per instance**, because `residuals` is called thousands of times in a Newton loop and a warning per call would be unusable. Per instance rather than per process, so a second network is still told.

## Falsified

- switching the guard to `isinstance` → 2 tests red
- dropping the once-per-instance guard → 1 test red

Full suite green (2272 passed), and no existing test warns.

## One thing recorded on the way out

`verify_solution_consistent`'s docstring now says what its replacement does differently. The per-branch bound here — *no collector above the best supplier* — is the form `MPCEv2Element` deliberately does **not** use, because a passive junction may raise one branch's total pressure at another's expense. That is real physics, and it is why Bassett's `K5` and Hager's `ξ_t` go negative in dividing flow. The replacement asserts the aggregate `sum_in |m|Pt >= sum_out |m|Pt` instead.

Next: cut v0.5.0 (changelog, `gui/pyproject.toml` pin 0.4 → 0.5, tag), then rename and retire in 0.6.0.

Refs #271, #272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RNDxZouiHoJdaLpnnPjHq
