### PR TITLE
chore(biome): sync biome.json + pre-commit pin to 2.5.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ test_uv_env/
 
 # Local validation data and reference papers
 docs/bassett/
+
+# pnpm content-addressable store, created when pnpm runs outside gui/frontend
+.pnpm-store/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,5 +63,5 @@ repos:
     rev: v0.6.1
     hooks:
       - id: biome-check
-        additional_dependencies: ["@biomejs/biome@2.5.10"]
+        additional_dependencies: ["@biomejs/biome@2.5.12"]
         files: ^gui/frontend/

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.5.10/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.12/schema.json",
 	"files": {
 		"ignoreUnknown": true,
 		"includes": ["gui/frontend/src/**"]


### PR DESCRIPTION
Follows #297, which bumped `gui/frontend/package.json` to `@biomejs/biome` 2.5.12 and — being a manifest-and-lockfile update — left the other two places the version lives untouched:

| file | before | now |
|---|---|---|
| `gui/frontend/package.json` | 2.5.12 | 2.5.12 (dependabot) |
| `biome.json` `$schema` | **2.5.10** | 2.5.12 |
| `.pre-commit-config.yaml` pin | **2.5.10** | 2.5.12 |

**The desync is quiet, which is why it's worth a commit of its own.** `scripts/check-gui-style.sh` runs `pnpm exec biome`, so CI was already checking with 2.5.12 while the local pre-commit hook formatted with 2.5.10. The two only diverge when a rule changes between versions — and that is exactly the state `b9b3299` was written to repair at 2.5.10, so it has bitten once already.

Kept separate from the dependabot PR so the sync stays visible in history for the next bump. CLAUDE.md's frontend version-sync checklist names all three files.

**Verified**: `pnpm exec biome --version` reports 2.5.12, and `./scripts/check-gui-style.sh` checks 47 files with no fixes applied — so 2.5.12 changes no formatting here.

**Also gitignores `.pnpm-store/`.** Running `pnpm install` from the repo root rather than `gui/frontend` drops a 119 MB content-addressable store there, which `git add -A` then sweeps up. The added-large-files hook caught it while this commit was being made, which is the only reason it isn't in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RNDxZouiHoJdaLpnnPjHq
