### PR TITLE
fix(docs): the units generator was silently dropping 35 entries

### DIFF
--- a/docs/UNITS.md
+++ b/docs/UNITS.md
@@ -99,22 +99,24 @@ All functions use consistent units to avoid conversion errors.
 
 #### Mixture Properties (Mass/Other Basis)
 
-| Function                           | Input Units                                         | Output Unit           |
-|------------------------------------|-----------------------------------------------------|-----------------------|
-| `density`                          | T: K, P: Pa, X: mol/mol                             | kg/m^3                |
-| `molar_volume`                     | T: K, P: Pa                                         | m^3/mol               |
-| `specific_gas_constant`            | X: mol/mol                                          | J/(kg*K)              |
-| `isentropic_expansion_coefficient` | T: K, X: mol/mol                                    | - (gamma)             |
-| `speed_of_sound`                   | T: K, X: mol/mol                                    | m/s                   |
-| `cp_mass`                          | T: K, X: mol/mol                                    | J/(kg*K)              |
-| `cv_mass`                          | T: K, X: mol/mol                                    | J/(kg*K)              |
-| `h_mass`                           | T: K, X: mol/mol                                    | J/kg                  |
-| `s_mass`                           | T: K, X: mol/mol, P: Pa, P_ref: Pa                  | J/(kg*K)              |
-| `u_mass`                           | T: K, X: mol/mol                                    | J/kg                  |
-| `air_properties`                   | T: K, P: Pa, humidity: - (0-1)                      | AirProperties struct  |
-| `thermo_state`                     | T: K, P: Pa, X: mol/mol, P_ref: Pa (default 101325) | ThermoState struct    |
-| `transport_state`                  | T: K, P: Pa, X: mol/mol                             | TransportState struct |
-| `complete_state`                   | T: K, P: Pa, X: mol/mol, P_ref: Pa (default 101325) | CompleteState struct  |
+| Function                           | Input Units                                                                                                              | Output Unit            |
+|------------------------------------|--------------------------------------------------------------------------------------------------------------------------|------------------------|
+| `density`                          | T: K, P: Pa, X: mol/mol                                                                                                  | kg/m^3                 |
+| `molar_volume`                     | T: K, P: Pa                                                                                                              | m^3/mol                |
+| `specific_gas_constant`            | X: mol/mol                                                                                                               | J/(kg*K)               |
+| `isentropic_expansion_coefficient` | T: K, X: mol/mol                                                                                                         | - (gamma)              |
+| `speed_of_sound`                   | T: K, X: mol/mol                                                                                                         | m/s                    |
+| `cp_mass`                          | T: K, X: mol/mol                                                                                                         | J/(kg*K)               |
+| `cv_mass`                          | T: K, X: mol/mol                                                                                                         | J/(kg*K)               |
+| `h_mass`                           | T: K, X: mol/mol                                                                                                         | J/kg                   |
+| `s_mass`                           | T: K, X: mol/mol, P: Pa, P_ref: Pa                                                                                       | J/(kg*K)               |
+| `u_mass`                           | T: K, X: mol/mol                                                                                                         | J/kg                   |
+| `air_properties`                   | T: K, P: Pa, humidity: - (0-1)                                                                                           | AirProperties struct   |
+| `thermo_state`                     | T: K, P: Pa, X: mol/mol, P_ref: Pa (default 101325)                                                                      | ThermoState struct     |
+| `transport_state`                  | T: K, P: Pa, X: mol/mol                                                                                                  | TransportState struct  |
+| `complete_state`                   | T: K, P: Pa, X: mol/mol, P_ref: Pa (default 101325)                                                                      | CompleteState struct   |
+| `combustion_state`                 | X_fuel: mol/mol, X_ox: mol/mol, phi: -, T_reactants: K, P: Pa, fuel_name: str (default ''), smooth: bool (default False) | CombustionState struct |
+| `combustion_state_from_streams`    | fuel_stream: Stream, ox_stream: Stream, fuel_name: str (default ''), smooth: bool (default False)                        | CombustionState struct |
 
 #### Inverse Solvers
 
@@ -164,10 +166,11 @@ All functions use consistent units to avoid conversion errors.
 
 #### Fanno Flow
 
-| Function           | Input Units                                                | Output Unit   |
-|--------------------|------------------------------------------------------------|---------------|
-| `fanno_channel`    | T_in: K, P_in: Pa, u_in: m/s, L: m, D: m, f: -, X: mol/mol | FannoSolution |
-| `fanno_max_length` | T_in: K, P_in: Pa, u_in: m/s, D: m, f: -, X: mol/mol       | m             |
+| Function              | Input Units                                                                                                         | Output Unit   |
+|-----------------------|---------------------------------------------------------------------------------------------------------------------|---------------|
+| `fanno_channel`       | T_in: K, P_in: Pa, u_in: m/s, L: m, D: m, f: -, X: mol/mol                                                          | FannoSolution |
+| `fanno_channel_rough` | T_in: K, P_in: Pa, u_in: m/s, L: m, D: m, roughness: m, X: mol/mol, correlation: str, f_multiplier: - (default 1.0) | FannoSolution |
+| `fanno_max_length`    | T_in: K, P_in: Pa, u_in: m/s, D: m, f: -, X: mol/mol                                                                | m             |
 
 #### Thrust
 
@@ -181,10 +184,12 @@ All functions use consistent units to avoid conversion errors.
 
 #### Thermo-Aware High-Level Functions
 
-| Function              | Input Units                                        | Output Unit                |
-|-----------------------|----------------------------------------------------|----------------------------|
-| `channel_flow`        | T: K, P: Pa, X: mol/mol, u: m/s, L: m, D: m, f: -  | IncompressibleFlowSolution |
-| `orifice_flow_thermo` | T: K, P: Pa, X: mol/mol, P_back: Pa, A: m^2, Cd: - | IncompressibleFlowSolution |
+| Function                | Input Units                                                                 | Output Unit                |
+|-------------------------|-----------------------------------------------------------------------------|----------------------------|
+| `channel_flow`          | T: K, P: Pa, X: mol/mol, u: m/s, L: m, D: m, f: -                           | IncompressibleFlowSolution |
+| `channel_flow_rough`    | T: K, P: Pa, X: mol/mol, u: m/s, L: m, D: m, roughness: m, correlation: str | IncompressibleFlowSolution |
+| `orifice_flow_thermo`   | T: K, P: Pa, X: mol/mol, P_back: Pa, A: m^2, Cd: -                          | IncompressibleFlowSolution |
+| `channel_pressure_drop` | T: K, P: Pa, X: mol/mol, v: m/s, D: m, L: m, roughness: m, correlation: str | tuple(Pa, -, -)            |
 
 #### Bernoulli & Orifice
 
@@ -423,31 +428,33 @@ All functions use consistent units to avoid conversion errors.
 
 ### cooling_correlations.h - Advanced Cooling Correlations
 
-| Function                          | Input Units                                                        | Output Unit |
-|-----------------------------------|--------------------------------------------------------------------|-------------|
-| `rib_enhancement_factor`          | e_D: -, pitch_to_height: -, alpha_deg: deg                         | -           |
-| `rib_enhancement_factor_high_re`  | e_D: -, pitch_to_height: -, alpha_deg: deg, Re: -                  | -           |
-| `rib_friction_multiplier`         | e_D: -, pitch_to_height: -                                         | -           |
-| `rib_friction_multiplier_high_re` | e_D: -, pitch_to_height: -                                         | -           |
-| `thermal_performance_factor`      | Nu_ratio: -, f_ratio: -                                            | -           |
-| `impingement_nusselt`             | Re_jet: -, Pr: -, z_D: -, x_D: - (default 0), y_D: - (default 0)   | -           |
-| `film_cooling_effectiveness`      | x_D: -, M: -, DR: -, alpha_deg: deg                                | -           |
-| `film_cooling_effectiveness_avg`  | x_D: -, M: -, DR: -, alpha_deg: deg, s_D: - (default 3.0)          | -           |
-| `film_cooling_multirow_sellers`   | row_positions_xD: list[-], eval_xD: -, M: -, DR: -, alpha_deg: deg | -           |
-| `effusion_effectiveness`          | x_D: -, M: -, DR: -, porosity: -, s_D: -, alpha_deg: deg           | -           |
-| `dimple_nusselt_enhancement`      | Re_Dh: -, d_Dh: -, h_d: -, S_d: -                                  | -           |
-| `dimple_friction_multiplier`      | Re_Dh: -, d_Dh: -, h_d: -                                          | -           |
-| `effusion_discharge_coefficient`  | Re_d: -, P_ratio: -, alpha_deg: deg, L_D: - (default 4.0)          | -           |
+| Function                          | Input Units                                                               | Output Unit |
+|-----------------------------------|---------------------------------------------------------------------------|-------------|
+| `rib_enhancement_factor`          | e_D: -, pitch_to_height: -, alpha_deg: deg                                | -           |
+| `rib_enhancement_factor_high_re`  | e_D: -, pitch_to_height: -, alpha_deg: deg, Re: -                         | -           |
+| `rib_friction_multiplier`         | e_D: -, pitch_to_height: -                                                | -           |
+| `rib_friction_multiplier_high_re` | e_D: -, pitch_to_height: -                                                | -           |
+| `thermal_performance_factor`      | Nu_ratio: -, f_ratio: -                                                   | -           |
+| `impingement_nusselt`             | Re_jet: -, Pr: -, z_D: -, x_D: - (default 0), y_D: - (default 0)          | -           |
+| `film_cooling_effectiveness`      | x_D: -, M: -, DR: -, alpha_deg: deg                                       | -           |
+| `film_cooling_effectiveness_avg`  | x_D: -, M: -, DR: -, alpha_deg: deg, s_D: - (default 3.0)                 | -           |
+| `film_cooling_multirow_sellers`   | row_positions_xD: list[-], eval_xD: -, M: -, DR: -, alpha_deg: deg        | -           |
+| `effusion_effectiveness`          | x_D: -, M: -, DR: -, porosity: -, s_D: -, alpha_deg: deg                  | -           |
+| `pin_fin_nusselt`                 | Re_d: -, Pr: -, L_D: -, S_D: -, X_D: -, is_staggered: bool (default True) | -           |
+| `dimple_nusselt_enhancement`      | Re_Dh: -, d_Dh: -, h_d: -, S_d: -                                         | -           |
+| `dimple_friction_multiplier`      | Re_Dh: -, d_Dh: -, h_d: -                                                 | -           |
+| `effusion_discharge_coefficient`  | Re_d: -, P_ratio: -, alpha_deg: deg, L_D: - (default 4.0)                 | -           |
 
 ### acoustics.h - Acoustic Properties
 
-| Function                    | Input Units                          | Output Unit |
-|-----------------------------|--------------------------------------|-------------|
-| `wavelength`                | f: Hz, c: m/s                        | m           |
-| `frequency_from_wavelength` | lambda: m, c: m/s                    | Hz          |
-| `acoustic_impedance`        | rho: kg/m^3, c: m/s                  | Pa*s/m      |
-| `sound_pressure_level`      | p_rms: Pa, p_ref: Pa (default 20e-6) | dB          |
-| `particle_velocity`         | p: Pa, rho: kg/m^3, c: m/s           | m/s         |
+| Function                    | Input Units                                                                      | Output Unit               |
+|-----------------------------|----------------------------------------------------------------------------------|---------------------------|
+| `acoustic_properties`       | f: Hz, rho: kg/m^3, c: m/s, p_rms: Pa (default 20e-6), p_ref: Pa (default 20e-6) | AcousticProperties struct |
+| `wavelength`                | f: Hz, c: m/s                                                                    | m                         |
+| `frequency_from_wavelength` | lambda: m, c: m/s                                                                | Hz                        |
+| `acoustic_impedance`        | rho: kg/m^3, c: m/s                                                              | Pa*s/m                    |
+| `sound_pressure_level`      | p_rms: Pa, p_ref: Pa (default 20e-6)                                             | dB                        |
+| `particle_velocity`         | p: Pa, rho: kg/m^3, c: m/s                                                       | m/s                       |
 
 ### orifice.h - Orifice Flow Utilities
 
@@ -461,9 +468,12 @@ All functions use consistent units to avoid conversion errors.
 
 ### solver_interface.h - Compressible Flow Elements
 
-| Function                                 | Input Units                                                      | Output Unit                                 |
-|------------------------------------------|------------------------------------------------------------------|---------------------------------------------|
-| `orifice_compressible_mdot_and_jacobian` | T0: K, P0: Pa, P_back: Pa, X: mol/mol, Cd: -, area: m^2, beta: - | tuple(kg/s, kg/(s*Pa), kg/(s*Pa), kg/(s*K)) |
+| Function                                      | Input Units                                                                                                                                        | Output Unit                                 |
+|-----------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------|
+| `orifice_compressible_mdot_and_jacobian`      | T0: K, P0: Pa, P_back: Pa, X: mol/mol, Cd: -, area: m^2, beta: -                                                                                   | tuple(kg/s, kg/(s*Pa), kg/(s*Pa), kg/(s*K)) |
+| `orifice_compressible_residuals_and_jacobian` | m_dot: kg/s, P_total_up: Pa, T_up: K, Y_up: kg/kg, P_static_down: Pa, Cd: -, area: m^2, beta: -                                                    | OrificeResult                               |
+| `channel_compressible_mdot_and_jacobian`      | T_in: K, P_in: Pa, u_in: m/s, X: mol/mol, L: m, D: m, roughness: m, friction_model: str, f_multiplier: - (default 1.0)                             | tuple(Pa, -, Pa/K, Pa/(m/s))                |
+| `channel_compressible_residuals_and_jacobian` | m_dot: kg/s, P_total_up: Pa, T_up: K, Y_up: kg/kg, P_static_down: Pa, L: m, D: m, roughness: m, friction_model: str, f_multiplier: - (default 1.0) | ChannelResult                               |
 
 ### geometry.h - Geometric Utilities
 
@@ -477,6 +487,46 @@ All functions use consistent units to avoid conversion errors.
 | `hydraulic_diameter`         | A: m^2, P_wetted: m    | m            |
 | `hydraulic_diameter_rect`    | a: m, b: m             | m            |
 | `hydraulic_diameter_annulus` | D_outer: m, D_inner: m | m            |
+
+### area_change.h - Area Change Elements
+
+| Function              | Input Units                                                                             | Output Unit                                                                                  |
+|-----------------------|-----------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
+| `sharp_area_change`   | m_dot: kg/s, rho: kg/m^3, mu: Pa*s, F0: m^2, F1: m^2, Mach: -, m_scale: kg/s, D_h: m    | AreaChangeResult (dP: Pa, dS_dm: Pa*s/kg, dS_drho: Pa*m^3/kg, dS_dmu: -, mach_clamped: bool) |
+| `conical_area_change` | m_dot: kg/s, rho: kg/m^3, mu: Pa*s, F0: m^2, F1: m^2, length: m, Mach: -, m_scale: kg/s | AreaChangeResult (dP: Pa, dS_dm: Pa*s/kg, dS_drho: Pa*m^3/kg, dS_dmu: -, mach_clamped: bool) |
+
+### tee_junction.h + solver_interface.h - Tee Junction Elements
+
+| Function                               | Input Units                                                                                                                                                              | Output Unit                                                                                                                                                                                             |
+|----------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `merging_tee_residuals_and_jacobian`   | m_dot_com: kg/s, m_dot_branch: kg/s, dP0_straight: Pa, dP0_branch: Pa, P_static_com: Pa, T_com: K, Y_com: kg/kg, theta: rad, psi: -, F_C: m^2, blend_k: - (default 30.0) | TeeJunctionResult (R_straight: Pa, R_branch: Pa, dR/dm_dot: Pa*s/kg, dR/dP: -, dR/dT: Pa/K, dR/dY: Pa, K_straight: -, K_branch: -, q: -, blend_w: -, topology_valid: bool, status: CorrelationValidity) |
+| `branching_tee_residuals_and_jacobian` | m_dot_com: kg/s, m_dot_branch: kg/s, dP0_straight: Pa, dP0_branch: Pa, P_static_com: Pa, T_com: K, Y_com: kg/kg, theta: rad, psi: -, F_C: m^2, blend_k: - (default 30.0) | TeeJunctionResult (R_straight: Pa, R_branch: Pa, dR/dm_dot: Pa*s/kg, dR/dP: -, dR/dT: Pa/K, dR/dY: Pa, K_straight: -, K_branch: -, q: -, blend_w: -, topology_valid: bool, status: CorrelationValidity) |
+| `tee_K1`                               | q: -, psi: -, theta: rad                                                                                                                                                 | - (K)                                                                                                                                                                                                   |
+| `tee_K2`                               | q: -                                                                                                                                                                     | - (K)                                                                                                                                                                                                   |
+| `tee_K3`                               | q: -, psi: -, theta: rad                                                                                                                                                 | - (K)                                                                                                                                                                                                   |
+| `tee_K4`                               | q: -, psi: -, theta: rad                                                                                                                                                 | - (K)                                                                                                                                                                                                   |
+| `tee_K5`                               | q: -                                                                                                                                                                     | - (K)                                                                                                                                                                                                   |
+| `tee_K6`                               | q: -, psi: -, theta: rad                                                                                                                                                 | - (K)                                                                                                                                                                                                   |
+| `tee_K7`                               | q: -, psi: -, theta: rad                                                                                                                                                 | - (K)                                                                                                                                                                                                   |
+| `tee_K8`                               | q: -, psi: -, theta: rad                                                                                                                                                 | - (K)                                                                                                                                                                                                   |
+| `tee_K9`                               | q: -, psi: -, theta: rad                                                                                                                                                 | - (K)                                                                                                                                                                                                   |
+| `tee_K10`                              | q: -, psi: -, theta: rad                                                                                                                                                 | - (K)                                                                                                                                                                                                   |
+| `tee_K11`                              | q: -, psi: -, theta: rad                                                                                                                                                 | - (K)                                                                                                                                                                                                   |
+| `tee_K12`                              | q: -, psi: -, theta: rad                                                                                                                                                 | - (K)                                                                                                                                                                                                   |
+
+### multi_port_chamber.h + solver_interface.h - Momentum-CV junction
+
+| Function                                    | Input Units                                                                                                           | Output Unit                                                                                                                                               |
+|---------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `multi_port_chamber_residuals_and_jacobian` | P_jct: Pa, P: list[Pa], mdot: list[kg/s] (positive = out of junction), T: list[K], Y: list[list[kg/kg]], A: list[m^2] | MultiPortChamberResult (impulse_residuals: list[Pa], port_jac: list[PortImpulseJacobian (dR_dP: -, dR_dmdot: Pa*s/kg, dR_dT: Pa/K)], mass_residual: kg/s) |
+| `border_carnot_loss_residual_and_jacobian`  | mdot: kg/s, Pt_in: Pa, Pt_out: Pa, P_in: Pa, T_in: K, Y_in: kg/kg, area: m^2, delta_geom: rad                         | BorderCarnotLossResult (residual: Pa, d_res_dPt_in: -, d_res_dPt_out: -, d_res_dP_in: -, d_res_dT_in: Pa/K, d_res_dmdot: Pa*s/kg)                         |
+| `border_carnot_L`                           | delta_geom: rad                                                                                                       | - (L = 4*(1-cos((3/4)*delta))^2)                                                                                                                          |
+
+### mpce_junction.h - Momentum-CV junction, whole-element (f, J)
+
+| Function                         | Input Units                                                                                                                                                                                                                                                                                                                       | Output Unit                                                                                                                                                                                                                              |
+|----------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `mpce_v2_residuals_and_jacobian` | p_static: list[Pa], p_total: list[Pa], rho: list[kg/m^3], drho_dp: list[kg/(m^3*Pa)], outer_mdot: list[kg/s] (the CONNECTING element's flow; geom.port_sign maps it to junction convention), pt_jct: Pa, geom: MpceGeometry (area: list[m^2], theta_rad: list[rad], port_sign: list[-], joining_etransfer_alpha: -, eta_scale: -) | MpceResidualJacobian (residual: list[Pa] with a final kg/s mass row, jacobian: list[list[d(row)/d(seed)]] over seeds [p_static x3, p_total x3, outer_mdot x3, pt_jct], valid: bool, common_port: -, k_term_sign: -, k_per_port: list[-]) |
 
 ### vatistas.h - Vatistas n-Vortex Model
 
@@ -500,68 +550,82 @@ All functions use consistent units to avoid conversion errors.
 
 ### heat_transfer.h - Heat Transfer Correlations
 
-| Function                       | Input Units                                                      | Output Unit               |
-|--------------------------------|------------------------------------------------------------------|---------------------------|
-| `nusselt_dittus_boelter`       | Re: -, Pr: -, heating: bool                                      | - (Nu)                    |
-| `nusselt_gnielinski`           | Re: -, Pr: -, f: - (optional)                                    | - (Nu)                    |
-| `nusselt_sieder_tate`          | Re: -, Pr: -, mu_ratio: -                                        | - (Nu)                    |
-| `nusselt_petukhov`             | Re: -, Pr: -, f: - (optional)                                    | - (Nu)                    |
-| `htc_from_nusselt`             | Nu: -, k: W/(m*K), L: m                                          | W/(m^2*K)                 |
-| `nusselt_circular_channel`     | State, V: m/s, D: m                                              | - (Nu)                    |
-| `htc_circular_channel`         | State, V: m/s, D: m                                              | W/(m^2*K)                 |
-| `lmtd`                         | dT1: K, dT2: K                                                   | K                         |
-| `lmtd_counterflow`             | T_hot_in: K, T_hot_out: K, T_cold_in: K, T_cold_out: K           | K                         |
-| `lmtd_parallelflow`            | T_hot_in: K, T_hot_out: K, T_cold_in: K, T_cold_out: K           | K                         |
-| `overall_htc`                  | h_values: W/(m^2*K), t_over_k: m^2*K/W                           | W/(m^2*K)                 |
-| `overall_htc_wall`             | h_inner, h_outer: W/(m^2*K), t_over_k_layers: m^2*K/W            | W/(m^2*K)                 |
-| `overall_htc_wall`             | h_inner, h_outer: W/(m^2*K), t_wall: m, k_wall: W/(m*K)          | W/(m^2*K)                 |
-| `thermal_resistance`           | h: W/(m^2*K), A: m^2                                             | K/W                       |
-| `thermal_resistance_wall`      | t: m, k: W/(m*K), A: m^2                                         | K/W                       |
-| `heat_rate`                    | U: W/(m^2*K), A: m^2, dT: K                                      | W                         |
-| `heat_flux`                    | U: W/(m^2*K), dT: K                                              | W/m^2                     |
-| `heat_transfer_area`           | Q: W, U: W/(m^2*K), dT: K                                        | m^2                       |
-| `heat_transfer_dT`             | Q: W, U: W/(m^2*K), A: m^2                                       | K                         |
-| `wall_temperature_profile`     | T_hot: K, T_cold: K, h_hot, h_cold: W/(m^2*K), t_over_k: m^2*K/W | K (vector)                |
-| `ntu`                          | U: W/(m^2*K), A: m^2, C_min: W/K                                 | -                         |
-| `capacity_ratio`               | C_min: W/K, C_max: W/K                                           | -                         |
-| `effectiveness_counterflow`    | NTU: -, C_r: -                                                   | -                         |
-| `effectiveness_parallelflow`   | NTU: -, C_r: -                                                   | -                         |
-| `heat_rate_from_effectiveness` | epsilon: -, C_min: W/K, T_hot_in: K, T_cold_in: K                | W                         |
-| `adiabatic_wall_temperature`   | T_hot: K, T_coolant: K, eta: -                                   | K                         |
-| `dT_edge_dT_hot`               | edge_idx, h_hot, h_cold: W/(m^2*K), t_over_k: m^2*K/W            | - (dT_edge/dT_hot)        |
-| `dT_edge_dT_cold`              | edge_idx, h_hot, h_cold: W/(m^2*K), t_over_k: m^2*K/W            | - (dT_edge/dT_cold)       |
-| `dT_edge_dT_bulk`              | edge_idx, h_hot, h_cold: W/(m^2*K), t_over_k: m^2*K/W            | - (dT/dT_hot, dT/dT_cold) |
-| `dT_edge_dq`                   | edge_idx, h_hot: W/(m^2*K), t_over_k: m^2*K/W                    | K*m^2/W (dT_edge/dq)      |
+| Function                       | Input Units                                                                                                     | Output Unit               |
+|--------------------------------|-----------------------------------------------------------------------------------------------------------------|---------------------------|
+| `nusselt_dittus_boelter`       | Re: -, Pr: -, heating: bool                                                                                     | - (Nu)                    |
+| `nusselt_gnielinski`           | Re: -, Pr: -, f: - (optional)                                                                                   | - (Nu)                    |
+| `nusselt_sieder_tate`          | Re: -, Pr: -, mu_ratio: -                                                                                       | - (Nu)                    |
+| `nusselt_petukhov`             | Re: -, Pr: -, f: - (optional)                                                                                   | - (Nu)                    |
+| `htc_from_nusselt`             | Nu: -, k: W/(m*K), L: m                                                                                         | W/(m^2*K)                 |
+| `nusselt_circular_channel`     | State, V: m/s, D: m                                                                                             | - (Nu)                    |
+| `htc_circular_channel`         | State, V: m/s, D: m                                                                                             | W/(m^2*K)                 |
+| `htc_circular_channel`         | T: K, P: Pa, X: mol/mol, velocity: m/s, diameter: m, correlation: str, heating: bool, mu_ratio: -, roughness: m | tuple(W/(m^2*K), -, -)    |
+| `lmtd`                         | dT1: K, dT2: K                                                                                                  | K                         |
+| `lmtd_counterflow`             | T_hot_in: K, T_hot_out: K, T_cold_in: K, T_cold_out: K                                                          | K                         |
+| `lmtd_parallelflow`            | T_hot_in: K, T_hot_out: K, T_cold_in: K, T_cold_out: K                                                          | K                         |
+| `overall_htc`                  | h_values: W/(m^2*K), t_over_k: m^2*K/W                                                                          | W/(m^2*K)                 |
+| `overall_htc_wall`             | h_inner, h_outer: W/(m^2*K), t_over_k_layers: m^2*K/W                                                           | W/(m^2*K)                 |
+| `overall_htc_wall`             | h_inner, h_outer: W/(m^2*K), t_wall: m, k_wall: W/(m*K)                                                         | W/(m^2*K)                 |
+| `thermal_resistance`           | h: W/(m^2*K), A: m^2                                                                                            | K/W                       |
+| `thermal_resistance_wall`      | t: m, k: W/(m*K), A: m^2                                                                                        | K/W                       |
+| `heat_rate`                    | U: W/(m^2*K), A: m^2, dT: K                                                                                     | W                         |
+| `heat_flux`                    | U: W/(m^2*K), dT: K                                                                                             | W/m^2                     |
+| `heat_transfer_area`           | Q: W, U: W/(m^2*K), dT: K                                                                                       | m^2                       |
+| `heat_transfer_dT`             | Q: W, U: W/(m^2*K), A: m^2                                                                                      | K                         |
+| `wall_temperature_profile`     | T_hot: K, T_cold: K, h_hot, h_cold: W/(m^2*K), t_over_k: m^2*K/W                                                | K (vector)                |
+| `ntu`                          | U: W/(m^2*K), A: m^2, C_min: W/K                                                                                | -                         |
+| `capacity_ratio`               | C_min: W/K, C_max: W/K                                                                                          | -                         |
+| `effectiveness_counterflow`    | NTU: -, C_r: -                                                                                                  | -                         |
+| `effectiveness_parallelflow`   | NTU: -, C_r: -                                                                                                  | -                         |
+| `heat_rate_from_effectiveness` | epsilon: -, C_min: W/K, T_hot_in: K, T_cold_in: K                                                               | W                         |
+| `adiabatic_wall_temperature`   | T_hot: K, T_coolant: K, eta: -                                                                                  | K                         |
+| `cooled_wall_heat_flux`        | T_hot: K, T_coolant: K, h_hot: W/(m^2*K), h_coolant: W/(m^2*K), eta: -, t_wall: m, k_wall: W/(m*K)              | W/m^2                     |
+| `heat_flux_from_T_at_edge`     | T_measured: K, edge_idx, T_hot: K, T_cold: K, h_hot, h_cold: W/(m^2*K), t_over_k: m^2*K/W                       | W/m^2                     |
+| `heat_flux_from_T_at_depth`    | T_measured: K, depth: m, T_hot: K, T_cold: K, h_hot, h_cold: W/(m^2*K), thicknesses: m, conductivities: W/(m*K) | W/m^2                     |
+| `bulk_T_from_edge_T_and_q`     | T_measured: K, edge_idx, q: W/m^2, h_hot, h_cold: W/(m^2*K), t_over_k: m^2*K/W, solve_for: str                  | K                         |
+| `dT_edge_dT_hot`               | edge_idx, h_hot, h_cold: W/(m^2*K), t_over_k: m^2*K/W                                                           | - (dT_edge/dT_hot)        |
+| `dT_edge_dT_cold`              | edge_idx, h_hot, h_cold: W/(m^2*K), t_over_k: m^2*K/W                                                           | - (dT_edge/dT_cold)       |
+| `dT_edge_dT_bulk`              | edge_idx, h_hot, h_cold: W/(m^2*K), t_over_k: m^2*K/W                                                           | - (dT/dT_hot, dT/dT_cold) |
+| `dT_edge_dq`                   | edge_idx, h_hot: W/(m^2*K), t_over_k: m^2*K/W                                                                   | K*m^2/W (dT_edge/dq)      |
 
 ### acoustics.h - Acoustic Mode Analysis
 
-| Function                         | Input Units                                                              | Output Unit               |
-|----------------------------------|--------------------------------------------------------------------------|---------------------------|
-| `tube_axial_modes`               | Tube (L: m, D: m), c: m/s, upstream: BC, downstream: BC, n_max           | Hz (vector)               |
-| `annulus_azimuthal_modes`        | Annulus, c: m/s, m_max                                                   | Hz (vector)               |
-| `annulus_modes`                  | Annulus, c: m/s, upstream: BC, downstream: BC, n_max, m_max              | Hz (vector)               |
-| `modes_in_range`                 | modes, f_min: Hz, f_max: Hz                                              | Hz (vector)               |
-| `closest_mode`                   | modes, f_target: Hz                                                      | AcousticMode              |
-| `min_mode_separation`            | modes                                                                    | Hz                        |
-| `axial_mode_upstream`            | f0: Hz, M: -                                                             | Hz                        |
-| `axial_mode_downstream`          | f0: Hz, M: -                                                             | Hz                        |
-| `axial_mode_split`               | f0: Hz, M: -                                                             | (Hz, Hz)                  |
-| `helmholtz_frequency`            | V: m^3, A_neck: m^2, L_neck: m, c: m/s, end_correction: -                | Hz                        |
-| `strouhal`                       | f: Hz, L: m, u: m/s                                                      | - (St)                    |
-| `frequency_from_strouhal`        | St: -, L: m, u: m/s                                                      | Hz                        |
-| `quarter_wave_frequency`         | L: m, c: m/s                                                             | Hz                        |
-| `absorption_from_impedance_norm` | z_norm: complex [-]                                                      | - (alpha)                 |
-| `is_whistling_risk`              | freq: Hz, u_bias: m/s, d_orifice: m                                      | bool                      |
-| `annular_duct_modes_analytical`  | geom: AnnularDuctGeometry, c: m/s, f_max: Hz, bc_ends: BoundaryCondition | AnnularMode vector        |
-| `to_acoustic_geometry`           | flow_geom: CanAnnularFlowGeometry, n_cans: -, L_can: m, D_can: m         | CanAnnularGeometry struct |
-| `half_wave_frequency`            | L: m, c: m/s                                                             | Hz                        |
-| `stokes_layer`                   | nu: m^2/s, f: Hz                                                         | m                         |
-| `thermal_layer`                  | alpha: m^2/s, f: Hz                                                      | m                         |
-| `effective_viscothermal_layer`   | delta_nu: m, delta_kappa: m, gamma: -                                    | m                         |
-| `helmholtz_Q`                    | V: m^3, A_neck: m^2, L_neck: m, nu: m^2/s, alpha: m^2/s, gamma: -, f: Hz | - (Q)                     |
-| `tube_Q`                         | L: m, D: m, nu: m^2/s, alpha: m^2/s, gamma: -, f: Hz                     | - (Q)                     |
-| `damping_ratio`                  | Q: -                                                                     | - (zeta)                  |
-| `bandwidth`                      | f0: Hz, Q: -                                                             | Hz                        |
+| Function                             | Input Units                                                                                                                                                                                          | Output Unit               |
+|--------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------|
+| `tube_axial_modes`                   | Tube (L: m, D: m), c: m/s, upstream: BC, downstream: BC, n_max                                                                                                                                       | Hz (vector)               |
+| `annulus_axial_modes`                | Annulus (L: m, D_inner: m, D_outer: m), c: m/s, upstream: BC, downstream: BC, n_max                                                                                                                  | Hz (vector)               |
+| `annulus_azimuthal_modes`            | Annulus, c: m/s, m_max                                                                                                                                                                               | Hz (vector)               |
+| `annulus_modes`                      | Annulus, c: m/s, upstream: BC, downstream: BC, n_max, m_max                                                                                                                                          | Hz (vector)               |
+| `modes_in_range`                     | modes, f_min: Hz, f_max: Hz                                                                                                                                                                          | Hz (vector)               |
+| `closest_mode`                       | modes, f_target: Hz                                                                                                                                                                                  | AcousticMode              |
+| `min_mode_separation`                | modes                                                                                                                                                                                                | Hz                        |
+| `axial_mode_upstream`                | f0: Hz, M: -                                                                                                                                                                                         | Hz                        |
+| `axial_mode_downstream`              | f0: Hz, M: -                                                                                                                                                                                         | Hz                        |
+| `axial_mode_split`                   | f0: Hz, M: -                                                                                                                                                                                         | (Hz, Hz)                  |
+| `helmholtz_frequency`                | V: m^3, A_neck: m^2, L_neck: m, c: m/s, end_correction: -                                                                                                                                            | Hz                        |
+| `strouhal`                           | f: Hz, L: m, u: m/s                                                                                                                                                                                  | - (St)                    |
+| `frequency_from_strouhal`            | St: -, L: m, u: m/s                                                                                                                                                                                  | Hz                        |
+| `quarter_wave_frequency`             | L: m, c: m/s                                                                                                                                                                                         | Hz                        |
+| `orifice_impedance_with_flow`        | freq: Hz, u_bias: m/s, u_grazing: m/s, d_orifice: m, l_orifice: m, porosity: -, Cd: -, rho: kg/m^3, c: m/s                                                                                           | complex [-]               |
+| `quarter_wave_resonator_tmm`         | freq: Hz, L_tube: m, A_duct: m^2, A_tube: m^2, d_orifice: m, l_orifice: m, porosity: -, Cd: -, u_bias: m/s, u_grazing: m/s, rho: kg/m^3, c: m/s                                                      | TransferMatrix            |
+| `absorption_from_impedance_norm`     | z_norm: complex [-]                                                                                                                                                                                  | - (alpha)                 |
+| `liner_sdof_impedance_norm`          | freq: Hz, orifice: LinerOrificeGeometry, cavity: LinerCavity, flow: LinerFlowState, medium: AcousticMedium                                                                                           | complex [-]               |
+| `liner_sdof_absorption`              | freq: Hz, orifice: LinerOrificeGeometry, cavity: LinerCavity, flow: LinerFlowState, medium: AcousticMedium                                                                                           | - (alpha)                 |
+| `sweep_liner_sdof_absorption`        | freqs: Hz (vector), orifice: LinerOrificeGeometry, cavity: LinerCavity, flow: LinerFlowState, medium: AcousticMedium                                                                                 | - (alpha vector)          |
+| `liner_2dof_serial_impedance_norm`   | freq: Hz, face_orifice: LinerOrificeGeometry, septum_orifice: LinerOrificeGeometry, depth_1: m, depth_2: m, face_flow: LinerFlowState, septum_flow: LinerFlowState, medium: AcousticMedium           | complex [-]               |
+| `liner_2dof_serial_absorption`       | freq: Hz, face_orifice: LinerOrificeGeometry, septum_orifice: LinerOrificeGeometry, depth_1: m, depth_2: m, face_flow: LinerFlowState, septum_flow: LinerFlowState, medium: AcousticMedium           | - (alpha)                 |
+| `sweep_liner_2dof_serial_absorption` | freqs: Hz (vector), face_orifice: LinerOrificeGeometry, septum_orifice: LinerOrificeGeometry, depth_1: m, depth_2: m, face_flow: LinerFlowState, septum_flow: LinerFlowState, medium: AcousticMedium | - (alpha vector)          |
+| `is_whistling_risk`                  | freq: Hz, u_bias: m/s, d_orifice: m                                                                                                                                                                  | bool                      |
+| `annular_duct_modes_analytical`      | geom: AnnularDuctGeometry, c: m/s, f_max: Hz, bc_ends: BoundaryCondition                                                                                                                             | AnnularMode vector        |
+| `to_acoustic_geometry`               | flow_geom: CanAnnularFlowGeometry, n_cans: -, L_can: m, D_can: m                                                                                                                                     | CanAnnularGeometry struct |
+| `half_wave_frequency`                | L: m, c: m/s                                                                                                                                                                                         | Hz                        |
+| `stokes_layer`                       | nu: m^2/s, f: Hz                                                                                                                                                                                     | m                         |
+| `thermal_layer`                      | alpha: m^2/s, f: Hz                                                                                                                                                                                  | m                         |
+| `effective_viscothermal_layer`       | delta_nu: m, delta_kappa: m, gamma: -                                                                                                                                                                | m                         |
+| `helmholtz_Q`                        | V: m^3, A_neck: m^2, L_neck: m, nu: m^2/s, alpha: m^2/s, gamma: -, f: Hz                                                                                                                             | - (Q)                     |
+| `tube_Q`                             | L: m, D: m, nu: m^2/s, alpha: m^2/s, gamma: -, f: Hz                                                                                                                                                 | - (Q)                     |
+| `damping_ratio`                      | Q: -                                                                                                                                                                                                 | - (zeta)                  |
+| `bandwidth`                          | f0: Hz, Q: -                                                                                                                                                                                         | Hz                        |
 
 ### geometry.h - Residence Time
 
@@ -626,6 +690,16 @@ All functions use consistent units to avoid conversion errors.
 | `ChannelResult::dq_dmdot`    | -           | W*s/(m^2*kg)            |
 | `ChannelResult::dq_dT`       | -           | W/(m^2*K)               |
 | `ChannelResult::dq_dT_hot`   | -           | W/(m^2*K)               |
+
+### heat_transfer.h - Channel flow functions (HTC + pressure drop)
+
+| Function              | Input Units                                                                                                          | Output Unit   |
+|-----------------------|----------------------------------------------------------------------------------------------------------------------|---------------|
+| `channel_smooth`      | T: K, P: Pa, X: mol/mol, velocity: m/s, diameter: m, length: m, T_wall: K                                            | ChannelResult |
+| `channel_ribbed`      | T: K, P: Pa, X: mol/mol, velocity: m/s, diameter: m, length: m, e_D: -, pitch_to_height: -, alpha_deg: deg, T_hot: K | ChannelResult |
+| `channel_dimpled`     | T: K, P: Pa, X: mol/mol, velocity: m/s, diameter: m, length: m, d_Dh: -, h_d: -, S_d: -, T_hot: K                    | ChannelResult |
+| `channel_pin_fin`     | T: K, P: Pa, X: mol/mol, velocity: m/s, channel_height: m, pin_diameter: m, S_D: -, X_D: -, N_rows: -, T_hot: K      | ChannelResult |
+| `channel_impingement` | T: K, P: Pa, X: mol/mol, mdot_jet: kg/s, d_jet: m, z_D: -, x_D: -, y_D: -, A_target: m^2, T_hot: K                   | ChannelResult |
 
 ### cooling_correlations.h - Pin fin friction (new scalar)
 

--- a/include/units_data.h
+++ b/include/units_data.h
@@ -336,6 +336,20 @@ inline constexpr Entry function_units[] = {
     {"border_carnot_L", "delta_geom: rad", "- (L = 4*(1-cos((3/4)*delta))^2)"},
 
     // -------------------------------------------------------------------------
+    // mpce_junction.h - Momentum-CV junction, whole-element (f, J)
+    // -------------------------------------------------------------------------
+    {"mpce_v2_residuals_and_jacobian",
+     "p_static: list[Pa], p_total: list[Pa], rho: list[kg/m^3], "
+     "drho_dp: list[kg/(m^3*Pa)], outer_mdot: list[kg/s] (the CONNECTING "
+     "element's flow; geom.port_sign maps it to junction convention), "
+     "pt_jct: Pa, geom: MpceGeometry (area: list[m^2], theta_rad: list[rad], "
+     "port_sign: list[-], joining_etransfer_alpha: -, eta_scale: -)",
+     "MpceResidualJacobian (residual: list[Pa] with a final kg/s mass row, "
+     "jacobian: list[list[d(row)/d(seed)]] over seeds "
+     "[p_static x3, p_total x3, outer_mdot x3, pt_jct], valid: bool, "
+     "common_port: -, k_term_sign: -, k_per_port: list[-])"},
+
+    // -------------------------------------------------------------------------
     // friction.h - Friction Factor Correlations
     // -------------------------------------------------------------------------
     {"friction_haaland", "Re: -, e_D: -", "- (f)"},

--- a/scripts/generate_units_md.py
+++ b/scripts/generate_units_md.py
@@ -34,7 +34,25 @@ def parse_units_data(path: Path) -> list[UnitEntry]:
     section_pattern = re.compile(r"//\s*[-]+\s*\n\s*//\s*(.+?)\s*\n\s*//\s*[-]+")
 
     # Match entries like: {"name", "input", "output"},
-    entry_pattern = re.compile(r'\{"([^"]+)",\s*"([^"]*)",\s*"([^"]*)"\}')
+    #
+    # Each of the three fields may be written as SEVERAL adjacent string
+    # literals, which C++ concatenates:
+    #
+    #     {"name",
+    #      "a: Pa, "
+    #      "b: kg/s",
+    #      "Result (x: Pa)"},
+    #
+    # The original pattern required exactly one literal per field and so
+    # matched none of those, silently dropping 35 of the entries in
+    # units_data.h from docs/UNITS.md -- the whole solver-interface family
+    # (merging_tee, branching_tee, multi_port_chamber, border_carnot_loss,
+    # the compressible orifice and channel), the acoustics liner family and
+    # the cooling channel family among them. Nothing failed; the generated
+    # document was simply short, which is the worst way for a generator to be
+    # wrong.
+    _field = r'((?:\s*"[^"]*")+)'
+    entry_pattern = re.compile(r"\{" + _field + r"\s*," + _field + r"\s*," + _field + r"\s*\}")
 
     # Find all sections and their positions
     sections: list[tuple[int, str]] = []
@@ -44,7 +62,10 @@ def parse_units_data(path: Path) -> list[UnitEntry]:
     # Find all entries
     for match in entry_pattern.finditer(content):
         pos = match.start()
-        name, input_units, output_units = match.groups()
+        # Join each field's adjacent literals, exactly as C++ would.
+        name, input_units, output_units = (
+            "".join(re.findall(r'"([^"]*)"', group)) for group in match.groups()
+        )
 
         # Determine which section this entry belongs to
         section = ""


### PR DESCRIPTION
Pre-release check of `docs/UNITS.md` against `include/units_data.h`. Regenerating it changed **182 lines** — which, for an auto-generated file nobody had edited, is the wrong kind of surprise.

## The generator required exactly one string literal per field

```python
entry_pattern = re.compile(r'\{"([^"]+)",\s*"([^"]*)",\s*"([^"]*)"\}')
```

Most entries in `units_data.h` write their input and output fields as *several adjacent literals*, which C++ concatenates and this regex does not match. Those entries were dropped with **no error and no warning** — the document was simply short.

**35 of them**, including the entire solver-interface family (`merging_tee`, `branching_tee`, `multi_port_chamber`, `border_carnot_loss`, the compressible orifice and channel), the acoustics liner family, and the cooling channel family.

Fixed by matching one-or-more adjacent literals per field and joining them the way the compiler would. Verified: `merging_tee_residuals_and_jacobian`, `multi_port_chamber_residuals_and_jacobian`, `liner_sdof_absorption` and `channel_ribbed` were all absent from `UNITS.md` and are all present now, with no mangled or empty rows.

## Also adds the missing `mpce_v2_residuals_and_jacobian` entry

That one is mine. It was bound in `_core.cpp` and documented in `docs/API_CPP.md` in #308/#309, but never given a `units_data.h` entry — which the repo's API-sync rule requires.

Worth noting **why nothing caught it**: `test_units_sync.py` checks exported *Python* symbols, not `_core` bindings. So on the C++ side that rule is enforced by review rather than by CI. Not fixing that here — it's a separate decision about whether the sync test should reach across the pybind boundary — but it's the reason a hard rule went unmet for two PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RNDxZouiHoJdaLpnnPjHq
