### PR TITLE
chore(release): cut 0.6.0 and move the GUI pin in lockstep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-09-09
+
 ### Changed
 - **The momentum-CV junction drops its version suffix.** `MPCEv2Element` is now
   `MultiPortChamberElement`, taking the name freed by the removal below. The
@@ -61,7 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `combaero~=0.5` to keep running a network built on it.
 
 
-## [0.5.0] - 2026-09-08
+## [0.5.0] - 2026-09-09
 
 ### Added
 - **`NetworkSolver.solve` now reports why a solve ended, separately from
@@ -1754,7 +1756,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - State property units mismatch in example runner
 - Solver stability under degenerate initial conditions
 
-[Unreleased]: https://github.com/thiemom/combaero/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/thiemom/combaero/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/thiemom/combaero/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/thiemom/combaero/compare/v0.4.2...v0.5.0
 [0.4.2]: https://github.com/thiemom/combaero/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/thiemom/combaero/compare/v0.4.0...v0.4.1

--- a/gui/pyproject.toml
+++ b/gui/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "uvicorn",
     "pydantic",
     "pandas",
-    "combaero~=0.5",
+    "combaero~=0.6",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Prepares the 0.6.0 release. **The tag is not pushed here** -- that triggers both
publish workflows and is a separate, deliberate step.

## What is in 0.6.0

Two entries, both from #271's close-out:

- **Changed** -- the momentum-CV junction drops its version suffix.
  `MPCEv2Element` is now `MultiPortChamberElement`; the abstract base is
  `MultiPortChamberBase`. Both concrete classes are now exported from
  `combaero.network`, which they were not before.
- **Removed** -- the base class's own junction model and the C++ stack behind
  it, deprecated in 0.5.0 and removed here as announced.

## CHANGELOG

`[Unreleased]` becomes `[0.6.0] - 2026-09-09`, compare links added,
`[Unreleased]` re-pointed at `v0.6.0...HEAD`. No regrouping needed this cycle:
Changed then Removed is already Keep a Changelog's canonical order.

Also corrected: 0.5.0's date read `2026-09-08`, the day its cut was prepared,
but the tag was pushed on the 9th (`v0.5.0` is dated 2026-09-09 09:45 +0200).
The date records the release. **The tag is not moved.**

## GUI pin

`gui/pyproject.toml` `combaero~=0.5` -> `~=0.6`. The hard rule with the v0.3.1
hotfix behind it, and it binds harder than usual this cycle: 0.6.0 renames
classes the GUI backend imports at startup, so a stale 0.5.x resolved from PyPI
would fail on import rather than degrade.

Checked and **not** changed: the two CHANGELOG lines advising `combaero~=0.5`
are migration advice for anyone still on the removed model, so they point at 0.5
deliberately; `publish-gui.yml`'s `combaero>=0.4` is inside a comment explaining
why the version-wait exists, and the logic derives the version from the built
wheel's filename.

## Why 0.6.0 rather than 0.5.1

Removed public API and renamed public classes and modules. Breaking for anyone
importing the old names.

Diff is two files, six lines. No code changes, so no gate to re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RNDxZouiHoJdaLpnnPjHq
