### PR TITLE
fix(ci): wait on the PyPI index representation uv actually reads

### DIFF
--- a/.github/workflows/publish-gui.yml
+++ b/.github/workflows/publish-gui.yml
@@ -105,9 +105,19 @@ jobs:
           # instead of failing.
           GUI_WHEEL=$(ls dist/combaero_gui-*.whl)
           VERSION=$(basename "$GUI_WHEEL" | cut -d- -f2)
+          #
+          # Ask for the JSON representation, because that is the one uv reads.
+          # pypi.org/simple/<pkg>/ serves two variants of the same URL --
+          # text/html and application/vnd.pypi.simple.v1+json -- and they are
+          # cached separately. On the v0.6.0 release the HTML variant listed
+          # 0.6.0 while uv, resolving against the JSON variant one second
+          # later, still saw only <=0.5.0 and failed with "No solution found".
+          # Waiting on the wrong representation is waiting on nothing.
           echo "Waiting for combaero==$VERSION on the PyPI simple index..."
           for i in $(seq 1 40); do
-            if curl -fsS "https://pypi.org/simple/combaero/" 2>/dev/null | grep -q "combaero-$VERSION"; then
+            if curl -fsS -H "Accept: application/vnd.pypi.simple.v1+json" \
+                 "https://pypi.org/simple/combaero/" 2>/dev/null \
+               | grep -q "\"$VERSION\""; then
               echo "Found combaero==$VERSION on PyPI after $((i - 1)) retries."
               exit 0
             fi
@@ -119,8 +129,11 @@ jobs:
       - name: Install wheel and smoke-test server
         run: |
           uv venv .test-venv
-          # install wheel (combaero is a dependency, pulled from PyPI)
-          uv pip install --python .test-venv dist/combaero_gui-*.whl
+          # install wheel (combaero is a dependency, pulled from PyPI).
+          # --refresh-package: belt and braces against uv reusing a cached
+          # index listing that predates the combaero release we just waited for.
+          uv pip install --python .test-venv --refresh-package combaero \
+            dist/combaero_gui-*.whl
           .test-venv/bin/combaero-gui &
           SERVER_PID=$!
           # poll instead of a fixed sleep -- a fixed 4s sleep flaked on the


### PR DESCRIPTION
## Summary

- The v0.6.0 `combaero-gui` publish failed with `No solution found ... only
  combaero<=0.5.0 is available`, one second after its own wait step reported
  finding combaero 0.6.0 on the index. The wait step polls `text/html` from
  `/simple/combaero/`; uv resolves against the
  `application/vnd.pypi.simple.v1+json` variant of the same URL, and the CDN
  caches the two separately -- so the workflow waited on a document the
  installer never reads, which is indistinguishable from not waiting.
- The poll now sends the same `Accept` header uv does. Added
  `--refresh-package combaero` to the install as a second guard, against a
  uv-side cached listing reintroducing the race from the other end.

## Context & decisions

```
13:46:05  combaero 0.6.0 uploaded
13:46:19  wait step, HTML variant   -> 0.6.0 present, exit 0
13:46:20  uv pip install, JSON variant -> only <=0.5.0, fail
```

- Same defect the step's own comment already records, one level up: the v0.4.1
  fix moved the poll off the JSON API and onto `/simple/` without noticing that
  `/simple/` is itself two separately cached documents.
- The quotes in the grep pattern are load-bearing -- they stop a future `0.6.1`
  matching `0.6.10`, and stop a version matching inside a filename. Checked
  against the live index: `0.6.0` and `0.5.0` match, `0.7.0` and `9.9.9` do not.
- The v0.6.0 tag is unaffected and should not move; this file ships in neither
  package. `combaero` 0.6.0 published fine and only the GUI verify failed, so
  re-running that job completes the release. This PR is so the next release
  does not need to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RNDxZouiHoJdaLpnnPjHq
