### PR TITLE
chore(skills): track write-pr, fix its casing and guidance

### DIFF
--- a/.claude/skills/write-pr/SKILL.md
+++ b/.claude/skills/write-pr/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: write-pr
+description: Use when writing or editing a pull request title or body.
+---
+
+### Title Rules
+- Conventional Commits, under 72 chars, scope in parens. The type list is open:
+  `feat`, `fix`, `refactor`, `perf`, `chore`, `docs`, `test`, `ci`, plus the
+  API-lifecycle pair this repo uses -- `remove(junction):`, `rename(junction):`.
+
+### Tone & General Rules
+- Be direct and high-signal. No conversational fluff, boilerplate templates, or
+  statements like "All tests pass".
+- Write for the final squash commit -- ignore WIP commits and review
+  iterations. Branch protection means the PR body IS the permanent record.
+- Size the body to blast radius, not to commit type. A one-line `docs:` change
+  to the release process earns more explanation than a large `feat:` nothing
+  depends on yet. Anything touching release, publish, or packaging machinery is
+  never "just a chore".
+- End with the required attribution footer.
+
+### Standard PR Body Structure
+1. **Summary:** 1-3 bullet points on *what* changed and *why*.
+2. **Context & decisions:** edge cases, non-obvious implementation details, and
+   dead ends worth not repeating.
+3. **Not changed:** what you deliberately left alone, and why -- a tag not
+   moved, a name not renamed, a deprecation kept. Omit when there is nothing.
+4. **Artifacts (include only when relevant):**
+   - **Measurement / evidence:** the numbers that justify the change --
+     validation scorecard, MAE, analytic-vs-FD agreement, a falsification
+     result, coverage instantiation counts. A physics, solver or correlation
+     change without one is unfinished; see the `model-provenance` skill.
+   - **Architecture / flow:** minimal Mermaid diagram for new state machines or
+     inter-service flows.
+   - **UI / visual:** table with `Before` and `After` screenshot columns.
+   - **Performance:** table comparing target-branch baseline against this branch.
+   - **API / contract:** short snippet showing breaking changes or public
+     signature updates.
+
+### What not to claim
+- State what you measured. State separately what you did NOT verify, and why.
+  An untested path named in the PR is cheap; one discovered during a release is
+  not.
+- A negative result, reported, is a good outcome. Never widen a tolerance, drop
+  a case, or tune against the score to make a PR look clean.
+
+### High-Risk / Architecture Changes (Exception)
+Expand into an RFC-style write-up -- problem statement, alternatives considered,
+failure modes, rollout and rollback -- when the change removes or renames public
+API, alters a physics closure or a residual form, changes release or packaging
+behaviour, or carries high regression risk.

--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,7 @@ TODO.md
 !.claude/skills/
 .claude/skills/*
 !.claude/skills/model-provenance/
+!.claude/skills/write-pr/
 
 # Benchmark run outputs (auto-generated, not for tracking)
 benchmarks/runs/


### PR DESCRIPTION
## Summary

- Tracks the `write-pr` skill, which was gitignored -- `model-provenance` was
  the only shared one. Adds the `!` rule alongside it.
- Renames `skill.MD` to `SKILL.md`. It loaded on macOS only because the
  filesystem is case-insensitive; on a case-sensitive checkout, discovery finds
  nothing and the skill silently does not exist. Same class as the
  macOS-implicit-includes rule in `CLAUDE.md`, and it only starts to bite now
  that the file is shared.
- Corrects guidance that this week's PRs falsified.

## Context & decisions

Each guidance change came from a PR the skill would have handled wrong:

- **Type list read as closed** and omitted `remove` and `rename` -- both on
  `main` from the v1 retirement (#322) and the junction rename (#323). Marked
  open; `test` and `ci` added.
- **No home for evidence.** The four artifact types were architecture, UI,
  performance and API, so a scorecard MAE or an analytic-vs-FD agreement could
  only be squeezed into "brief note". That pulls directly against
  `model-provenance`, where a claim without a number is an unmeasured
  assumption. Added a Measurement/evidence type.
- **Body size keyed off commit type**, capping `chore` and `docs` at two
  bullets. That would have gutted the two PRs this week that most needed
  explaining: #324, a `chore(release)` moving the PyPI pin behind the v0.3.1
  hotfix, and #325, a one-line `docs` change accounting for three releases of
  unsigned tags. Now keyed off blast radius, with release and packaging
  machinery called out.
- **Added "Not changed".** Load-bearing repeatedly -- four names deliberately
  not renamed in #323, a tag that must not move in #326.
- **Added "what not to claim".** The v0.6.0 GUI verify failed on infrastructure
  and never exercised the renamed package, which the PR would have been read as
  covering.
- **RFC triggers named concretely** instead of "core invariants" and "data
  migrations" -- the latter does not occur in a repo with no database.

## Not changed

`show-me` stays untracked. It is equally local-only today, but sharing it was
not asked for and it carries repo-specific architecture notes that would want a
review pass first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RNDxZouiHoJdaLpnnPjHq
