### PR TITLE
fix(channel): pin-fin and impingement surfaces had a wrong Jacobian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`ChannelElement`'s Jacobian was wrong for pin-fin and impingement
+  surfaces.** Those surfaces vary their friction multiplier with mass flow,
+  but the multiplier was handed to the C++ friction routine frozen, so the
+  element reported `d(dP)/d(mdot)` short by **10.5%** and `d(dP)/dT` short by
+  **13.1%** against central differences. Both now agree to 1e-10. Ribbed and
+  dimpled were exact throughout -- their multipliers carry no Reynolds
+  dependence, which is what localised the fault. Newton convergence on
+  networks using either surface should improve; the converged solution for the
+  default `friction_model="haaland"` is unchanged.
+
+### Changed
+- **A localised array's pressure drop is now the correlation's own.** The
+  pin-fin and impingement correlations return `dP` directly, and
+  `ChannelElement` takes it instead of converting it into a multiplier on pipe
+  friction. The former route divided by a friction factor restated in Python
+  and let the C++ one multiply it back in, which cancels only when both pick
+  the same correlation. The Python side always used Haaland (rough) or
+  Petukhov (smooth) regardless of the element's `friction_model`, so the drop
+  moved by **+0.48%** for `colebrook`/`serghides` and **-24.7%** for
+  `petukhov`. For the default `haaland` the drop is unchanged bit for bit.
+
+  A channel carrying one of these surfaces now takes the array drop in both
+  regimes. The array correlations are incompressible by construction, so
+  `regime="compressible"` no longer layers Fanno friction on top of a drop the
+  array already owns.
+
+### Added
+- **`ChannelResult.ddP_dvelocity`** [Pa*s/m], for chaining a channel
+  correlation's pressure sensitivity onto a caller's own mass flow.
+  `ddP_dmdot` is taken w.r.t. the mass flow through the correlation's internal
+  flow area -- the pin-array minimum section, the jet holes -- so chaining it
+  directly is wrong by the area ratio, **45x** for a 25 mm channel over a 3 mm
+  pin array. The impingement routine is driven by per-jet mass flow rather
+  than a velocity and so leaves the new field unset; `ConvectiveSurface`
+  carries the split that converts it.
+
+
 ## [0.6.0] - 2026-09-09
 
 ### Changed

--- a/docs/API_CPP.md
+++ b/docs/API_CPP.md
@@ -476,6 +476,8 @@ struct ChannelResult {
     double dh_dmdot;       // dh/dmdot [W/(m²·K·kg/s)]
     double dh_dT;          // dh/dT [W/(m²·K²)]
     double ddP_dmdot;      // d(dP)/dmdot [Pa·s/kg]
+    double ddP_dvelocity;  // d(dP)/d(velocity) [Pa·s/m] - chain from this, not
+                           // ddP_dmdot, which uses the correlation's own flow area
     double ddP_dT;         // d(dP)/dT [Pa/K]
     double dT_aw_dmdot;    // dT_aw/dmdot [K·s/kg]
     double dT_aw_dT;       // dT_aw/dT [-] (approx 1 at low Mach)

--- a/include/heat_transfer.h
+++ b/include/heat_transfer.h
@@ -542,6 +542,14 @@ struct ChannelResult {
   double dh_dmdot = 0.0;     // ∂h/∂ṁ  [W/(m²·K·kg/s)]
   double dh_dT = 0.0;        // ∂h/∂T  [W/(m²·K²)]
   double ddP_dmdot = 0.0;    // ∂(dP)/∂ṁ [Pa·s/kg]
+  // d(dP)/d(velocity) [Pa*s/m]. Prefer this over ddP_dmdot when chaining
+  // from a caller's own mass flow: ddP_dmdot is taken w.r.t. the mass flow
+  // through THIS correlation's internal flow area (the pin-array minimum
+  // section, the jet holes), which is not the caller's element area. A
+  // caller that chains ddP_dmdot directly is wrong by the area ratio --
+  // 45x for a 25 mm channel over a 3 mm pin array. Velocity is the
+  // quantity the caller actually passes in, so it needs no such factor.
+  double ddP_dvelocity = 0.0;
   double ddP_dT = 0.0;       // ∂(dP)/∂T [Pa/K]
   double dT_aw_dmdot = 0.0;  // ∂T_aw/∂ṁ [K·s/kg]
   double dT_aw_dT = 0.0;     // ∂T_aw/∂T [-] (≈1 at low Mach)

--- a/include/units_data.h
+++ b/include/units_data.h
@@ -731,6 +731,7 @@ inline constexpr Entry function_units[] = {
     {"ChannelResult::dh_dmdot", "-", "W/(m^2*K*kg/s)"},
     {"ChannelResult::dh_dT", "-", "W/(m^2*K^2)"},
     {"ChannelResult::ddP_dmdot", "-", "Pa*s/kg"},
+    {"ChannelResult::ddP_dvelocity", "-", "Pa*s/m"},
     {"ChannelResult::ddP_dT", "-", "Pa/K"},
     {"ChannelResult::dT_aw_dmdot", "-", "K*s/kg"},
     {"ChannelResult::dT_aw_dT", "-", "- (dimensionless)"},

--- a/python/combaero/_core.cpp
+++ b/python/combaero/_core.cpp
@@ -5914,6 +5914,10 @@ PYBIND11_MODULE(_core, m) {
                     "Jacobian: dh/dT [W/(m^2*K^2)]")
       .def_readonly("ddP_dmdot", &ChannelResult::ddP_dmdot,
                     "Jacobian: d(dP)/dmdot [Pa*s/kg]")
+      .def_readonly("ddP_dvelocity", &ChannelResult::ddP_dvelocity,
+                    "Jacobian: d(dP)/d(velocity) [Pa*s/m]. Chain from this, not "
+                    "ddP_dmdot, when converting to a caller's own mass flow: "
+                    "ddP_dmdot uses the correlation's internal flow area.")
       .def_readonly("ddP_dT", &ChannelResult::ddP_dT,
                     "Jacobian: d(dP)/dT [Pa/K]")
       .def_readonly("dT_aw_dmdot", &ChannelResult::dT_aw_dmdot,

--- a/python/combaero/network/components.py
+++ b/python/combaero/network/components.py
@@ -249,14 +249,7 @@ class ConvectiveSurface:
             rho, _ = _safe_rho(cb.density(T, P, X))
             mdot_total = rho * velocity * (math.pi / 4 * diameter**2)
 
-            x = self.model.x_D * self.model.d_jet
-            y = self.model.y_D * self.model.d_jet
-            A_per_jet = x * y
-            if A_per_jet > 0 and self.model.A_target > 0:
-                N_jets = self.model.A_target / A_per_jet
-                mdot_jet = mdot_total / max(1.0, N_jets)
-            else:
-                mdot_jet = mdot_total  # fallback
+            mdot_jet = mdot_total / self._jet_split()
 
             result = cb.channel_impingement(
                 T,
@@ -277,6 +270,34 @@ class ConvectiveSurface:
             raise TypeError(f"Unknown channel model type: {type(self.model)}")
 
         return result
+
+    def _jet_split(self) -> float:
+        """Jets sharing the element mass flow (>= 1). Impingement only."""
+        x = self.model.x_D * self.model.d_jet
+        y = self.model.y_D * self.model.d_jet
+        A_per_jet = x * y
+        if A_per_jet > 0 and self.model.A_target > 0:
+            return max(1.0, self.model.A_target / A_per_jet)
+        return 1.0
+
+    def ddP_dmdot_element(self, result, rho: float, area: float) -> float:
+        """Chain the correlation dP sensitivity onto the ELEMENT mass flow.
+
+        Each correlation is driven by a different quantity -- the pin-fin
+        routine by channel velocity, the impingement routine by per-jet mass
+        flow -- so the conversion lives beside the code that built those
+        inputs. ``ChannelResult.ddP_dmdot`` is never the element's: it is
+        taken w.r.t. the correlation's own internal flow area.
+        """
+        if isinstance(self.model, PinFinModel):
+            if rho <= 0.0 or area <= 0.0:
+                return 0.0
+            return result.ddP_dvelocity / (rho * area)
+        if isinstance(self.model, ImpingementModel):
+            # The surface builds mdot_total from the element's own area, so
+            # mdot_total is the element mass flow and only the split remains.
+            return result.ddP_dmdot / self._jet_split()
+        return 0.0
 
 
 # ============================================================================
@@ -2454,6 +2475,8 @@ class ChannelElement(NetworkElement):
         m_dot = state_in.m_dot
 
         f_mult = self.surface.f_multiplier if self.surface else 1.0
+        # Set by the pin-fin / impingement branch below, which returns early.
+        array_result = None
 
         if self.surface and not isinstance(self.surface.model, SmoothModel):
             cs = cb.complete_state(state_in.T, state_in.Pt, state_in.X)
@@ -2483,14 +2506,50 @@ class ChannelElement(NetworkElement):
                         Re, self.surface.model.d_Dh, self.surface.model.h_d
                     )
                 elif isinstance(self.surface.model, (PinFinModel, ImpingementModel)):
-                    # Explicit geometry drop from localized array physics
-                    h_res = self.htc_and_T(state_in)
-                    if h_res is not None:
-                        dP_target = h_res.dP
-                        dynamic_head = 0.5 * rho * v**2
-                        if dynamic_head > 0:
-                            f_total = dP_target / ((self.length / dh) * dynamic_head)
-                            f_mult *= f_total / f_base
+                    # Localized arrays own their drop outright: the pin-array
+                    # and jet correlations return dP directly, so the element
+                    # takes it rather than converting it into a multiplier on
+                    # pipe friction. The former route divided by a locally
+                    # restated f_base and let the C++ friction factor multiply
+                    # it back in, which cancels exactly only when both pick the
+                    # same correlation. With friction_model="petukhov" the
+                    # round-trip moved the drop by -24.7%.
+                    array_result = self.htc_and_T(state_in)
+
+        if array_result is not None:
+            # dP is the correlation's own, so its analytic derivatives are the
+            # element's. Chain through VELOCITY, not ddP_dmdot: that field is
+            # taken w.r.t. the mass flow through the array's internal minimum
+            # section, which for a 25 mm channel over a 3 mm pin array differs
+            # from the element's by 45x (see ChannelResult in heat_transfer.h).
+            f_surf = self.surface.f_multiplier if self.surface else 1.0
+            rho_ref, _ = _safe_rho(state_in.density())
+            area = self.area if self.area else 0.0
+            d_dP_d_mdot = f_surf * self.surface.ddP_dmdot_element(array_result, rho_ref, area)
+            # Friction opposes the flow, so the drop follows the sign of m_dot
+            # while its magnitude depends on |m_dot| -- which leaves the
+            # derivative sign-independent.
+            dP_array = math.copysign(f_surf * array_result.dP, m_dot)
+            d_dP_dT = math.copysign(f_surf * array_result.ddP_dT, m_dot)
+
+            res = [state_in.Pt - state_out.Pt - dP_array]
+            jac = {
+                0: {
+                    f"{self.id}.m_dot": -d_dP_d_mdot,
+                    f"{self.from_node}.Pt": 1.0,
+                    f"{self.from_node}.T": -d_dP_dT,
+                    f"{self.to_node}.Pt": -1.0,
+                }
+            }
+            # Known gap: the array correlations expose no dP sensitivity to
+            # static pressure or composition, so those columns are absent
+            # rather than approximated from a pipe-friction stand-in.
+            #
+            # This path is taken in both regimes. The array correlations are
+            # incompressible by construction, and layering Fanno friction on
+            # top of a drop the array already owns was never meaningful, so
+            # regime="compressible" gets the same array drop.
+            return res, jac
 
         if self.regime == "compressible":
             # Use compressible Fanno flow with friction

--- a/python/tests/test_channel_element_jacobian_fd.py
+++ b/python/tests/test_channel_element_jacobian_fd.py
@@ -1,0 +1,184 @@
+"""Element-level Jacobian of ChannelElement against central differences.
+
+The existing test_channel_jacobians.py checks that the C++ correlations
+populate their derivative fields (``assert result.dh_dmdot != 0.0``). That is
+not the same question as whether the ELEMENT's residual Jacobian is right, and
+the gap hid a real defect: for pin-fin and impingement surfaces the surface
+multiplier varies with mass flow, but was handed to the C++ friction routine
+as a frozen constant, so d(dP)/d(mdot) was short by 10.5% and d(dP)/dT by
+13.1%. Ribbed and dimpled were exact throughout -- their multipliers carry no
+Reynolds dependence -- which is what localised the fault.
+"""
+
+import pytest
+
+import combaero as cb
+from combaero.network.components import (
+    ChannelElement,
+    ConvectiveSurface,
+    DimpledModel,
+    ImpingementModel,
+    NetworkMixtureState,
+    PinFinModel,
+    RibbedModel,
+    SmoothModel,
+)
+
+Y_AIR = cb.mole_to_mass(cb.species.dry_air())
+
+# Kept inside every correlation's validated range so a range warning never
+# masks a derivative error.
+BASE = {"m_dot": 0.35, "T_up": 600.0, "P_up": 2.0e5, "Pt_up": 2.1e5, "P_dn": 1.95e5}
+
+SURFACES = {
+    "smooth": lambda: ConvectiveSurface(area=0.1, model=SmoothModel()),
+    "ribbed": lambda: ConvectiveSurface(
+        area=0.1, model=RibbedModel(e_D=0.05, pitch_to_height=10.0)
+    ),
+    "dimpled": lambda: ConvectiveSurface(area=0.1, model=DimpledModel(d_Dh=0.2, h_d=0.2, S_d=1.5)),
+    "pin_fin": lambda: ConvectiveSurface(
+        area=0.1,
+        model=PinFinModel(pin_diameter=0.003, channel_height=0.006, S_D=2.5, X_D=2.5),
+    ),
+    "impingement": lambda: ConvectiveSurface(
+        area=0.1,
+        model=ImpingementModel(d_jet=0.002, z_D=3.0, x_D=5.0, y_D=5.0, A_target=0.05, Cd_jet=0.8),
+    ),
+}
+
+
+def _channel(surface_key: str) -> ChannelElement:
+    return ChannelElement(
+        id="ch",
+        from_node="A",
+        to_node="B",
+        length=0.6,
+        diameter=0.025,
+        roughness=1e-5,
+        surface=SURFACES[surface_key](),
+    )
+
+
+def _states(m_dot: float, T_up: float, P_up: float, Pt_up: float, P_dn: float):
+    s_in = NetworkMixtureState(T=T_up, P=P_up, Pt=Pt_up, Tt=610.0, m_dot=m_dot, Y=Y_AIR)
+    s_out = NetworkMixtureState(T=595.0, P=P_dn, Pt=P_dn, Tt=605.0, m_dot=m_dot, Y=Y_AIR)
+    return s_in, s_out
+
+
+def _residual(elem: ChannelElement, **kw) -> float:
+    res, _ = elem.residuals(*_states(**kw))
+    return res[0]
+
+
+def _central_difference(elem: ChannelElement, var: str, step: float) -> float:
+    plus, minus = dict(BASE), dict(BASE)
+    plus[var] += step
+    minus[var] -= step
+    return (_residual(elem, **plus) - _residual(elem, **minus)) / (2.0 * step)
+
+
+# (perturbed variable, jacobian column, FD step)
+COLUMNS = [
+    ("m_dot", "ch.m_dot", 1e-6),
+    ("T_up", "A.T", 1e-3),
+    ("Pt_up", "A.Pt", 1.0),
+    ("P_dn", "B.Pt", 1.0),
+]
+
+
+@pytest.mark.parametrize("surface_key", sorted(SURFACES))
+@pytest.mark.parametrize(("var", "column", "step"), COLUMNS)
+def test_every_jacobian_column_matches_a_finite_difference(
+    surface_key: str, var: str, column: str, step: float
+) -> None:
+    """Each analytic entry reproduces a central difference of the residual."""
+    elem = _channel(surface_key)
+    _, jac = elem.residuals(*_states(**BASE))
+    analytic = jac[0].get(column, 0.0)
+    numeric = _central_difference(elem, var, step)
+    scale = max(abs(numeric), abs(analytic), 1e-12)
+    assert abs(analytic - numeric) / scale < 1e-6, (
+        f"{surface_key}/{column}: analytic {analytic:.6e} vs FD {numeric:.6e}"
+    )
+
+
+@pytest.mark.parametrize("surface_key", ["pin_fin", "impingement"])
+def test_array_drop_is_the_correlation_drop(surface_key: str) -> None:
+    """A localised array's element drop IS its correlation's dP.
+
+    Pins the formulation: the array correlations return a pressure drop
+    outright, so the element takes it rather than converting it into a
+    multiplier on pipe friction. Routing it through a locally restated f_base
+    cancelled exactly only when C++ picked the same correlation -- with
+    friction_model="petukhov" it moved the drop by -24.7%.
+    """
+    for friction_model in ("haaland", "colebrook", "serghides", "petukhov"):
+        elem = _channel(surface_key)
+        elem.friction_model = friction_model
+        s_in, s_out = _states(**BASE)
+        res, _ = elem.residuals(s_in, s_out)
+        dP_element = s_in.Pt - s_out.Pt - res[0]
+        expected = elem.surface.f_multiplier * elem.htc_and_T(s_in).dP
+        assert dP_element == pytest.approx(expected, rel=1e-12), friction_model
+
+
+def test_ddP_dmdot_is_not_the_element_mass_flow() -> None:
+    """ChannelResult.ddP_dmdot uses the ARRAY's flow area, not the element's.
+
+    Chaining it directly is wrong by the area ratio, which is why the element
+    chains ddP_dvelocity instead. This test exists so the trap is stated
+    somewhere a reader will find it: the two differ by 45x for this geometry.
+    """
+    elem = _channel("pin_fin")
+    s_in, _ = _states(**BASE)
+    result = elem.htc_and_T(s_in)
+
+    rho = s_in.density()
+    correct = result.ddP_dvelocity / (rho * elem.area)
+    naive = result.ddP_dmdot
+
+    # A_cross = channel_height * pin_diameter * (S_D - 1) / S_D, from
+    # heat_transfer.cpp -- the pin array's minimum section.
+    a_cross = 0.006 * 0.003 * (2.5 - 1.0) / 2.5
+    assert naive / correct == pytest.approx(elem.area / a_cross, rel=1e-6)
+    assert naive / correct > 40.0, "the trap should be large enough to notice"
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "The pin-fin and impingement correlations expose no dP sensitivity to "
+        "static pressure. dP scales as 1/rho, so the true column is dP/P -- "
+        "about 0.058 here, a first-order term. Left absent rather than "
+        "approximated from a pipe-friction stand-in."
+    ),
+)
+def test_array_jacobian_carries_a_static_pressure_column() -> None:
+    elem = _channel("pin_fin")
+    _, jac = elem.residuals(*_states(**BASE))
+    numeric = _central_difference(elem, "P_up", 1.0)
+    assert numeric != 0.0, "the residual really does depend on P_up"
+    assert jac[0].get("A.P", 0.0) == pytest.approx(numeric, rel=1e-6)
+
+
+def test_reverse_flow_drop_opposes_the_flow() -> None:
+    """Friction acts against the flow, so the drop follows sign(m_dot)."""
+    elem = _channel("pin_fin")
+    forward = dict(BASE)
+    reverse = dict(BASE, m_dot=-BASE["m_dot"])
+
+    s_in_f, s_out_f = _states(**forward)
+    s_in_r, s_out_r = _states(**reverse)
+    dP_f = s_in_f.Pt - s_out_f.Pt - elem.residuals(s_in_f, s_out_f)[0][0]
+    dP_r = s_in_r.Pt - s_out_r.Pt - elem.residuals(s_in_r, s_out_r)[0][0]
+
+    assert dP_f > 0.0
+    assert dP_r == pytest.approx(-dP_f, rel=1e-12)
+    # Magnitude depends on |m_dot|, so the derivative does not flip sign.
+    assert elem.residuals(s_in_f, s_out_f)[1][0]["ch.m_dot"] == pytest.approx(
+        elem.residuals(s_in_r, s_out_r)[1][0]["ch.m_dot"], rel=1e-12
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/src/heat_transfer.cpp
+++ b/src/heat_transfer.cpp
@@ -1005,6 +1005,8 @@ channel_smooth(double T, double P, const std::vector<double> &X,
     double dP_factor = (length / diameter) / (2.0 * rho * A_cross * A_cross);
     result.ddP_dmdot = df_dRe * dRe_dmdot * dP_factor * mdot * mdot
                      + f * (length / diameter) * mdot / (rho * A_cross * A_cross);
+    // mdot = rho * velocity * A_cross at fixed rho, so d(mdot)/d(velocity) = rho * A_cross
+    result.ddP_dvelocity = result.ddP_dmdot * rho * A_cross;
 
     // d(dP)/dT: includes df/dT and drho/dT terms
     // dP = f * (L/D) * mdot^2 / (2*rho*A^2), so d(dP)/dT has df/dT and d(1/rho)/dT = -drho/dT/rho^2
@@ -1082,6 +1084,7 @@ ChannelResult channel_ribbed(double T, double P, const std::vector<double> &X,
   result.dh_dmdot = enh * base.dh_dmdot;
   result.dh_dT = enh * base.dh_dT;
   result.ddP_dmdot = fmul * base.ddP_dmdot;
+  result.ddP_dvelocity = fmul * base.ddP_dvelocity;
   result.ddP_dT = fmul * base.ddP_dT;
   result.dT_aw_dmdot = base.dT_aw_dmdot;
   result.dT_aw_dT = base.dT_aw_dT;
@@ -1138,6 +1141,7 @@ ChannelResult channel_dimpled(double T, double P, const std::vector<double> &X,
     result.dh_dmdot = enh * base.dh_dmdot + base.h * denh_dRe * dRe_dmdot;
     result.dh_dT = enh * base.dh_dT + base.h * denh_dRe * dRe_dT;
     result.ddP_dmdot = fmul * base.ddP_dmdot; // fmul is Re-independent in this model
+  result.ddP_dvelocity = fmul * base.ddP_dvelocity;
     result.ddP_dT = fmul * base.ddP_dT;
     result.dT_aw_dmdot = base.dT_aw_dmdot;
     result.dT_aw_dT = base.dT_aw_dT;
@@ -1250,6 +1254,9 @@ ChannelResult channel_pin_fin(double T, double P, const std::vector<double> &X,
     result.ddP_dmdot = static_cast<double>(N_rows) *
                        (df_dRe * dRe_dmdot * rho * v_max * v_max / 2.0 +
                         f_pin * v_max_factor * v_max_factor * mdot / (rho * A_cross * A_cross));
+    // A_cross here is the pin-array minimum section, not the caller's channel
+    // area, which is why ddP_dmdot cannot be chained by a caller directly.
+    result.ddP_dvelocity = result.ddP_dmdot * rho * A_cross;
 
     // ddP/dT: includes df/dT and drho/dT terms
     // dP = N * f * mdot^2 / (2 * rho * A_min^2)
@@ -1368,6 +1375,9 @@ ChannelResult channel_impingement(double T, double P,
 
     // ddP/dmdot: dP = f * rho * (mdot/(rho*A_jet))^2 / 2 = f * mdot^2 / (2*rho*A_jet^2)
     result.ddP_dmdot = f * mdot_jet / (std::max(rho, 1e-6) * A_jet * A_jet);
+    // ddP_dvelocity is deliberately left unset here: this routine is driven
+    // by per-jet mass flow, not by a velocity, so no such derivative exists.
+    // A caller chains ddP_dmdot through its own mdot_jet split instead.
     // Fix: remove spurious /rho in ddP/dT
     result.ddP_dT = -f * v_jet * v_jet / 2.0 * drho_dT;
 


### PR DESCRIPTION
## Summary

- Pin-fin and impingement surfaces vary their friction multiplier with mass
  flow, but it was handed to the C++ friction routine frozen, so
  `ChannelElement`'s derivatives were short by **10.5%** (`d(dP)/d(mdot)`) and
  **13.1%** (`d(dP)/dT`). Both now agree with central differences to 1e-10.
- The element now takes a localised array's drop from the correlation directly
  instead of converting it into a multiplier on pipe friction. That round-trip
  cancelled only when Python and C++ picked the same friction correlation, and
  Python ignored the element's `friction_model`.
- Adds `ChannelResult.ddP_dvelocity`, because `ddP_dmdot` is not taken w.r.t.
  the caller's mass flow.

## Measurement

Element residual Jacobian vs central differences, every surface model:

| surface | `d(dP)/d(mdot)` before | after |
|---|---|---|
| smooth | 2.0e-11 | 2.0e-11 |
| ribbed | 2.9e-11 | 2.9e-11 |
| dimpled | 3.8e-11 | 3.8e-11 |
| **pin_fin** | **1.05e-01** | **3.4e-11** |
| **pin_fin** `d(dP)/dT` | **1.31e-01** | **9.7e-11** |

Ribbed and dimpled are the control: their multipliers carry no Reynolds
dependence, so a frozen constant is genuinely correct there. That they never
moved is what localised the fault to the velocity-dependent branch.

Residual impact of dropping the round-trip, measured across a mass-flow sweep:

```
haaland (default)      unchanged, ratio 1.000000 at every point
colebrook / serghides  +0.48%
petukhov              -24.7%
```

## Context & decisions

`ChannelResult.ddP_dmdot` is differentiated w.r.t. the mass flow through the
**correlation's** internal flow area -- the pin-array minimum section, the jet
holes -- not the element's. Chaining it directly is wrong by the area ratio:
**45x** for a 25 mm channel over a 3 mm pin array. I nearly did exactly that.

`ddP_dvelocity` makes the chain reference-frame-free, and the conversion lives
in `ConvectiveSurface`, beside the code that builds those inputs. The
impingement routine takes per-jet mass flow rather than a velocity, so it
leaves the new field unset and its jet split does the conversion.

The chain factor came from `A_cross` in `heat_transfer.cpp`, not from fitting:
it predicts `5.805040e+04` against a central difference of `5.805040e+04`.

A channel with one of these surfaces now takes the array drop in **both**
regimes. The correlations are incompressible by construction, and layering
Fanno friction on a drop the array already owns was never meaningful.

## Not changed

The static-pressure column for array surfaces. `dP` scales as `1/rho`, so the
true entry is `dP/P` -- about 0.058 here, first order and not negligible. The
correlations expose no such derivative, and approximating it from a
pipe-friction stand-in is how the original defect got in. Recorded as a
**strict xfail** carrying the number, so it fails loudly once someone supplies
it.

Also untouched: the review turned up more in this element -- a `Re_Dh`
parameter that `dimple_friction_multiplier` accepts and never uses (making its
exported `_and_jacobian` return an identically-zero derivative, by finite
difference, against the Solver (f,J) rule), two different density guards in
one class, and an Re floor applied in `diagnostics` but not `residuals`. Those
are separate changes.

Full suite 2267 passed / 28 skipped / 7 xfailed; C++ 21/21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RNDxZouiHoJdaLpnnPjHq
