### PR TITLE
fix(cooling): dimple friction has no Reynolds dependence; stop pretending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+- **`dimple_friction_multiplier_and_jacobian`** (C++, its pybind11 binding and
+  the `combaero._solver_tools` re-export). It reported a derivative w.r.t.
+  `Re_Dh` that was **identically zero at every Reynolds number**, because
+  `dimple_friction_multiplier` accepts `Re_Dh` and never uses it -- the
+  multiplier is a function of dimple geometry alone. It obtained that zero by
+  central finite difference, which the Solver (f, J) rule in `CLAUDE.md`
+  forbids. Nothing called it: `channel_dimpled` uses the plain multiplier, and
+  the archived note claiming otherwise was wrong. Callers wanting the value use
+  `dimple_friction_multiplier`; there is no derivative to want.
+
+### Fixed
+- **`dimple_friction_multiplier` no longer warns about a Reynolds range it does
+  not have.** It shared a validator written for `dimple_nusselt_enhancement`,
+  which really is a power law in Re, so it emitted "Re_Dh is outside validated
+  range [10000, 80000]. Extrapolating power-law correlation" -- naming the
+  Nusselt function, about an extrapolation that cannot occur. Geometry limits
+  on `d_Dh` and `h_d` are still enforced, and the Nusselt path is unchanged.
+- **A test that could not fail has been replaced.** `test_dimple_jacobians`
+  compared the analytic derivative against a central difference of the same
+  function; both were 0.0, so it held regardless of the implementation. The
+  Nusselt half was real and is kept. The friction half is now a test that the
+  multiplier does not vary with Re, which goes red if a Re dependence is added.
+
+
 ### Fixed
 - **`ChannelElement`'s Jacobian was wrong for pin-fin and impingement
   surfaces.** Those surfaces vary their friction multiplier with mass flow,

--- a/include/cooling_correlations.h
+++ b/include/cooling_correlations.h
@@ -288,14 +288,20 @@ double dimple_nusselt_enhancement(
 // Friction penalty for dimpled surfaces
 //
 // Parameters:
-//   Re_Dh : Reynolds number based on channel hydraulic diameter [-]
+//   Re_Dh : accepted for signature symmetry with dimple_nusselt_enhancement,
+//           but the implemented form DOES NOT USE IT -- the multiplier is a
+//           function of dimple geometry alone. Whether Chyu's measured f/f0
+//           carries a weak Re dependence that this form drops is an open
+//           provenance question; do not add a derivative w.r.t. Re without
+//           settling it, because it can only be zero today.
 //   d_Dh  : dimple diameter / channel height [-]
 //   h_d   : dimple depth / diameter [-]
 //
 // Returns: Friction multiplier f_dimple/f_smooth [-]
 //
 // Source: Chyu et al. (1997)
-// Valid: Re_Dh = 10000-80000, d_Dh = 0.1-0.3, h_d = 0.1-0.3
+// Valid: d_Dh = 0.1-0.3, h_d = 0.1-0.3 (enforced). No Re range is enforced
+//        here: with no Re dependence there is nothing to extrapolate.
 // Accuracy: +/-15%
 double dimple_friction_multiplier(
     double Re_Dh,
@@ -349,6 +355,7 @@ void validate_film_cooling_params(double M, double DR, double alpha_deg);
 void validate_effusion_params(double M, double DR, double porosity, double s_D, double alpha_deg);
 void validate_effusion_discharge_params(double Re_d, double P_ratio, double alpha_deg, double L_D);
 void validate_pin_fin_params(double Re_d, double L_D, double S_D, double X_D);
+void validate_dimple_geometry(double d_Dh, double h_d);
 void validate_dimple_params(double Re_Dh, double d_Dh, double h_d);
 void validate_dimple_params(double Re_Dh, double d_Dh, double h_d, double S_d);
 

--- a/include/solver_interface.h
+++ b/include/solver_interface.h
@@ -373,10 +373,6 @@ CorrelationResult<std::tuple<double, double>>
 dimple_nusselt_enhancement_and_jacobian(double Re_Dh, double d_Dh, double h_d,
                                         double S_d);
 
-// Dimple Friction Multiplier and Jacobian wrt Re_Dh
-CorrelationResult<std::tuple<double, double>>
-dimple_friction_multiplier_and_jacobian(double Re_Dh, double d_Dh, double h_d);
-
 // Rib Enhancement Factor (High-Re) and Jacobian wrt Re
 CorrelationResult<std::tuple<double, double>>
 rib_enhancement_factor_high_re_and_jacobian(double e_D, double pitch_to_height,

--- a/python/combaero/_core.cpp
+++ b/python/combaero/_core.cpp
@@ -6258,11 +6258,6 @@ PYBIND11_MODULE(_core, m) {
         py::arg("d_Dh"), py::arg("h_d"), py::arg("S_d"),
         "Calculate Dimple Nusselt enhancement and its Jacobian w.r.t Re_Dh.");
 
-  m.def("dimple_friction_multiplier_and_jacobian",
-        &solver::dimple_friction_multiplier_and_jacobian, py::arg("Re_Dh"),
-        py::arg("d_Dh"), py::arg("h_d"),
-        "Calculate Dimple Friction multiplier and its Jacobian w.r.t Re_Dh.");
-
   m.def("rib_enhancement_factor_high_re_and_jacobian",
         &solver::rib_enhancement_factor_high_re_and_jacobian, py::arg("e_D"),
         py::arg("pitch_to_height"), py::arg("alpha_deg"), py::arg("Re"),

--- a/python/combaero/_solver_tools.py
+++ b/python/combaero/_solver_tools.py
@@ -25,7 +25,6 @@ channel_residuals_and_jacobian = _core.channel_residuals_and_jacobian
 combustor_residuals_and_jacobians = _core.combustor_residuals_and_jacobians
 conical_area_change_residuals_and_jacobian = _core.conical_area_change_residuals_and_jacobian
 density_and_jacobians = _core.density_and_jacobians
-dimple_friction_multiplier_and_jacobian = _core.dimple_friction_multiplier_and_jacobian
 dimple_nusselt_enhancement_and_jacobian = _core.dimple_nusselt_enhancement_and_jacobian
 effusion_effectiveness_and_jacobian = _core.effusion_effectiveness_and_jacobian
 ejector_cd_nozzle_mass_flow_and_jacobian = _core.ejector_cd_nozzle_mass_flow_and_jacobian
@@ -79,7 +78,6 @@ __all__ = [
     "combustor_residuals_and_jacobians",
     "conical_area_change_residuals_and_jacobian",
     "density_and_jacobians",
-    "dimple_friction_multiplier_and_jacobian",
     "dimple_nusselt_enhancement_and_jacobian",
     "effusion_effectiveness_and_jacobian",
     "ejector_cd_nozzle_mass_flow_and_jacobian",

--- a/python/tests/test_solver_interface.py
+++ b/python/tests/test_solver_interface.py
@@ -423,9 +423,6 @@ def test_dimple_jacobians():
     def nu_func(Re_Dh):
         return cb._core.dimple_nusselt_enhancement_and_jacobian(Re_Dh, d_Dh, h_d, S_d).result[0]
 
-    def f_func(Re_Dh):
-        return cb._core.dimple_friction_multiplier_and_jacobian(Re_Dh, d_Dh, h_d).result[0]
-
     for Re_Dh in [10000.0, 50000.0]:
         Nu_ana, dNu_ana = cb._core.dimple_nusselt_enhancement_and_jacobian(
             Re_Dh, d_Dh, h_d, S_d
@@ -433,9 +430,28 @@ def test_dimple_jacobians():
         dNu_num = central_difference(nu_func, Re_Dh, max(1e-4, Re_Dh * 1e-6))
         np.testing.assert_allclose(dNu_ana, dNu_num, rtol=1e-5)
 
-        f_ana, df_ana = cb._core.dimple_friction_multiplier_and_jacobian(Re_Dh, d_Dh, h_d).result
-        df_num = central_difference(f_func, Re_Dh, max(1e-4, Re_Dh * 1e-6))
-        np.testing.assert_allclose(df_ana, df_num, rtol=1e-5)
+
+def test_dimple_friction_multiplier_has_no_reynolds_dependence():
+    """The friction multiplier is a function of dimple geometry alone.
+
+    This replaces half of test_dimple_jacobians, which compared the analytic
+    derivative of dimple_friction_multiplier_and_jacobian against a central
+    difference of the same function. Both sides were identically 0.0, so the
+    assertion held no matter what the implementation did -- the function
+    finite-differenced a constant. It has been removed; this pins the fact it
+    was failing to state.
+
+    If a future Re dependence is added -- see the provenance note on
+    dimple_friction_multiplier in cooling_correlations.h -- this test fails and
+    forces the derivative question to be answered deliberately.
+    """
+    d_Dh, h_d = 0.2, 0.1
+    reference = cb.dimple_friction_multiplier(10000.0, d_Dh, h_d)
+    for Re_Dh in (2.0e4, 5.0e4, 8.0e4, 2.0e5):
+        assert cb.dimple_friction_multiplier(Re_Dh, d_Dh, h_d) == reference
+
+    # Geometry, by contrast, does move it.
+    assert cb.dimple_friction_multiplier(3.0e4, 0.3, 0.3) > reference
 
 
 def test_rib_enhancement_jacobian():

--- a/src/cooling_correlations.cpp
+++ b/src/cooling_correlations.cpp
@@ -567,6 +567,15 @@ double pin_fin_friction(double Re_d, bool is_staggered) {
 // -------------------------------------------------------------
 
 // Validate dimple parameters
+void validate_dimple_geometry(double d_Dh, double h_d) {
+    if (d_Dh < 0.1 || d_Dh > 0.3) {
+        throw std::runtime_error("Dimple d_Dh must be in range [0.1, 0.3], got " + std::to_string(d_Dh));
+    }
+    if (h_d < 0.1 || h_d > 0.3) {
+        throw std::runtime_error("Dimple h_d must be in range [0.1, 0.3], got " + std::to_string(h_d));
+    }
+}
+
 void validate_dimple_params(double Re_Dh, double d_Dh, double h_d) {
     // Re_Dh: correlation is Nu_enh = C*Re^m (power law, smooth extrapolation).
     // Warn rather than throw — the function is well-behaved outside [10000, 80000].
@@ -575,12 +584,7 @@ void validate_dimple_params(double Re_Dh, double d_Dh, double h_d) {
                   << " is outside validated range [10000, 80000]."
                      " Extrapolating power-law correlation; check results.\n";
     }
-    if (d_Dh < 0.1 || d_Dh > 0.3) {
-        throw std::runtime_error("Dimple d_Dh must be in range [0.1, 0.3], got " + std::to_string(d_Dh));
-    }
-    if (h_d < 0.1 || h_d > 0.3) {
-        throw std::runtime_error("Dimple h_d must be in range [0.1, 0.3], got " + std::to_string(h_d));
-    }
+    validate_dimple_geometry(d_Dh, h_d);
 }
 
 void validate_dimple_params(double Re_Dh, double d_Dh, double h_d, double S_d) {
@@ -630,7 +634,11 @@ double dimple_friction_multiplier(
     double d_Dh,
     double h_d
 ) {
-    validate_dimple_params(Re_Dh, d_Dh, h_d);
+    // Geometry only. The Re range warning in validate_dimple_params belongs to
+    // the Nusselt correlation, which really is a power law in Re; this friction
+    // form is not, so warning about extrapolating one would be noise.
+    (void)Re_Dh;
+    validate_dimple_geometry(d_Dh, h_d);
 
     // Friction penalty for dimples (Chyu et al. 1997)
     // Much lower than ribs (1.5-2.0x vs 6-10x)

--- a/src/solver_interface.cpp
+++ b/src/solver_interface.cpp
@@ -419,16 +419,6 @@ dimple_nusselt_enhancement_and_jacobian(double Re_Dh, double d_Dh, double h_d,
 }
 
 CorrelationResult<std::tuple<double, double>>
-dimple_friction_multiplier_and_jacobian(double Re_Dh, double d_Dh, double h_d) {
-  const double eps = std::max(1e-6, Re_Dh * 1e-6);
-  double f_plus = cooling::dimple_friction_multiplier(Re_Dh + eps, d_Dh, h_d);
-  double f_minus = cooling::dimple_friction_multiplier(Re_Dh - eps, d_Dh, h_d);
-  double df_dRe = (f_plus - f_minus) / (2.0 * eps);
-  double f = cooling::dimple_friction_multiplier(Re_Dh, d_Dh, h_d);
-  return {{f, df_dRe}, CorrelationValidity::VALID, ""};
-}
-
-CorrelationResult<std::tuple<double, double>>
 rib_enhancement_factor_high_re_and_jacobian(double e_D, double pitch_to_height,
                                              double alpha_deg, double Re) {
   const double eps = std::max(1e-6, Re * 1e-6);


### PR DESCRIPTION
Closes the second finding from the channel review. Depends on nothing; #329
tracks the rest of the family.

## Summary

- **Removes `dimple_friction_multiplier_and_jacobian`** (C++, its pybind11
  binding, the `_solver_tools` re-export). It returned a derivative w.r.t.
  `Re_Dh` that is **identically zero at every Reynolds number** -- because
  `dimple_friction_multiplier` accepts `Re_Dh` and never uses it -- and it
  computed that zero by central finite difference, which the Solver (f, J) rule
  forbids. Nothing called it.
- **Stops the friction path warning about a Reynolds range it does not have.**
  It shared a validator written for `dimple_nusselt_enhancement`, so it emitted
  the wrong function's name about an extrapolation that cannot occur.
- **Replaces a test that could not fail.**

## Context & decisions

`test_dimple_jacobians` compared the analytic derivative against a central
difference *of the same function*. Both sides were `0.0`, so the assertion held
regardless of the implementation. The Nusselt half is real and kept; the
friction half now pins Re-independence.

Falsified, as the `model-provenance` skill requires:

```
probe: f_base = 1.5 * pow(Re_Dh/30000, 0.05)
  new test   FAILED  (1.4393 != 1.3903)
  old test   would still pass -- an FD against an FD of the same function
             cannot detect a change in that function
```

Nothing called the removed function: `channel_dimpled` uses the plain
multiplier. `docs/archive/REVIEW_NETWORK_GUI.md` states it is used "inside
`channel_dimpled`", which is wrong -- left as-is, because archives record what
was believed at the time rather than what is true now.

## Not changed

**Whether Re-independence is correct.** Chyu's measured `f/f0` may carry a weak
Re dependence this form drops: the linear penalties hinged on `0.15` and the
`[1.3, 2.2]` clamp look like a constructed convenience form rather than a
published equation. Settling that needs the paper and digitised data, and it is
a physics change, not a cleanup.

So `Re_Dh` stays in the signature, with the open question recorded in
`cooling_correlations.h` where the next reader meets it. Removing the parameter
would make the current form structural and cement a possible modelling error;
this way the question stays open and cheap to answer. The new test is the guard
-- add a Re dependence and it goes red, forcing the derivative question to be
answered deliberately.

Suite 2268 passed / 28 skipped / 7 xfailed; C++ 21/21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RNDxZouiHoJdaLpnnPjHq
